### PR TITLE
Changed: effect => effectOf to avoid naming conflict with cats.effect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ import microsites.ConfigYml
 
 val ProjectScalaVersion: String = "2.13.1"
 val CrossScalaVersions: Seq[String] = Seq("2.11.12", "2.12.11", ProjectScalaVersion)
+val IncludeTest: String = "compile->compile;test->test"
 
 lazy val hedgehogVersion = "97854199ef795a5dfba15478fd9abe66035ddea2"
 lazy val hedgehogRepo: MavenRepository =
@@ -187,7 +188,7 @@ lazy val catsEffect = (project in file("cats-effect"))
     })
     /* } Coveralls */
   )
-  .dependsOn(core % "compile->compile;test->test")
+  .dependsOn(core % IncludeTest)
 
 lazy val docDir = file("docs")
 lazy val docs = (project in docDir)

--- a/cats-effect/src/main/scala/effectie/cats/ConsoleEffect.scala
+++ b/cats-effect/src/main/scala/effectie/cats/ConsoleEffect.scala
@@ -12,13 +12,13 @@ object ConsoleEffect {
 
   final class ConsoleEffectF[F[_] : EffectConstructor : Monad] extends ConsoleEffect[F] {
     override def readLn: F[String] =
-      EffectConstructor[F].effect(scala.io.StdIn.readLine)
+      EffectConstructor[F].effectOf(scala.io.StdIn.readLine)
 
     override def putStrLn(value: String): F[Unit] =
-      EffectConstructor[F].effect(Console.out.println(value))
+      EffectConstructor[F].effectOf(Console.out.println(value))
 
     override def putErrStrLn(value: String): F[Unit] =
-      EffectConstructor[F].effect(Console.err.println(value))
+      EffectConstructor[F].effectOf(Console.err.println(value))
 
     @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
     override def readYesNo(prompt: String): F[YesNo] = for {
@@ -26,9 +26,9 @@ object ConsoleEffect {
       answer <- readLn
       yesOrN <-  answer match {
         case "y" | "Y" =>
-          EffectConstructor[F].effect(YesNo.yes)
+          EffectConstructor[F].effectOf(YesNo.yes)
         case "n" | "N" =>
-          EffectConstructor[F].effect(YesNo.no)
+          EffectConstructor[F].effectOf(YesNo.no)
         case _ =>
           readYesNo(prompt)
       }

--- a/cats-effect/src/main/scala/effectie/cats/EffectConstructor.scala
+++ b/cats-effect/src/main/scala/effectie/cats/EffectConstructor.scala
@@ -9,7 +9,7 @@ object EffectConstructor {
 
   implicit val ioEffectConstructor: EffectConstructor[IO] = new EffectConstructor[IO] {
 
-    override def effect[A](a: => A): IO[A] = IO(a)
+    override def effectOf[A](a: => A): IO[A] = IO(a)
 
     override def pureEffect[A](a: A): IO[A] = IO.pure(a)
 

--- a/cats-effect/src/main/scala/effectie/cats/EitherTSupport.scala
+++ b/cats-effect/src/main/scala/effectie/cats/EitherTSupport.scala
@@ -6,10 +6,10 @@ import cats.data.EitherT
 trait EitherTSupport {
 
   def eitherTF[F[_] : EffectConstructor, A, B](ab: => Either[A, B]): EitherT[F, A, B] =
-    EitherT(EffectConstructor[F].effect(ab))
+    EitherT(EffectConstructor[F].effectOf(ab))
 
   def eitherTEffect[F[_] : EffectConstructor : Functor, A, B](b: => B): EitherT[F, A, B] =
-    EitherT.liftF[F, A, B](EffectConstructor[F].effect(b))
+    EitherT.liftF[F, A, B](EffectConstructor[F].effectOf(b))
 
   def eitherTLiftF[F[_] : EffectConstructor : Functor, A, B](fb: => F[B]): EitherT[F, A, B] =
     EitherT.liftF[F, A, B](fb)

--- a/core/src/main/scala/effectie/EffectConstructor.scala
+++ b/core/src/main/scala/effectie/EffectConstructor.scala
@@ -1,7 +1,7 @@
 package effectie
 
 trait EffectConstructor[F[_]] {
-  def effect[A](a: => A): F[A]
+  def effectOf[A](a: => A): F[A]
   def pureEffect[A](a: A): F[A]
   def unit: F[Unit]
 }

--- a/core/src/main/scala/effectie/Effectful.scala
+++ b/core/src/main/scala/effectie/Effectful.scala
@@ -2,7 +2,7 @@ package effectie
 
 trait Effectful {
 
-  def effect[F[_] : EffectConstructor, A](a: => A): F[A] = EffectConstructor[F].effect(a)
+  def effectOf[F[_] : EffectConstructor, A](a: => A): F[A] = EffectConstructor[F].effectOf(a)
 
   def pureEffect[F[_] : EffectConstructor, A](a: A): F[A] = EffectConstructor[F].pureEffect(a)
 


### PR DESCRIPTION
Changed: `effect` => `effectOf` to avoid naming conflict with cats.effect
* `EffectConstructor.effect` => `EffectConstructor.effectOf`
* `Effectful.effect` => `Effectful.effectOf`