### PR TITLE
Name changes in EitherTSupport and EitherTSupport object

### DIFF
--- a/cats-effect/src/main/scala/effectie/cats/EitherTSupport.scala
+++ b/cats-effect/src/main/scala/effectie/cats/EitherTSupport.scala
@@ -5,13 +5,21 @@ import cats.data.EitherT
 
 trait EitherTSupport {
 
-  def eitherTF[F[_] : EffectConstructor, A, B](ab: => Either[A, B]): EitherT[F, A, B] =
+  def eitherTEffect[F[_] : EffectConstructor, A, B](ab: => Either[A, B]): EitherT[F, A, B] =
     EitherT(EffectConstructor[F].effectOf(ab))
 
-  def eitherTEffect[F[_] : EffectConstructor : Functor, A, B](b: => B): EitherT[F, A, B] =
+  def eitherTPureEffect[F[_] : EffectConstructor, A, B](ab: Either[A, B]): EitherT[F, A, B] =
+    EitherT(EffectConstructor[F].pureEffect(ab))
+
+  def eitherTLiftEffect[F[_] : EffectConstructor : Functor, A, B](b: => B): EitherT[F, A, B] =
     EitherT.liftF[F, A, B](EffectConstructor[F].effectOf(b))
 
-  def eitherTLiftF[F[_] : EffectConstructor : Functor, A, B](fb: => F[B]): EitherT[F, A, B] =
+  def eitherTLiftPureEffect[F[_] : EffectConstructor : Functor, A, B](b: B): EitherT[F, A, B] =
+    EitherT.liftF[F, A, B](EffectConstructor[F].pureEffect(b))
+
+  def eitherTLiftF[F[_] : EffectConstructor : Functor, A, B](fb: F[B]): EitherT[F, A, B] =
     EitherT.liftF[F, A, B](fb)
 
 }
+
+object EitherTSupport extends  EitherTSupport


### PR DESCRIPTION
Close #16
# Name changes in EitherTSupport and EitherTSupport object
* Changed: name changes in `EitherTSupport` to make it more sense
* Added: `EitherTSupport` `object` for convenience