### PR TITLE
Task #16 - Removed: unnecessary typeclass requirement in EitherTSupport and OptionTSupport

### DIFF
--- a/cats-effect/src/main/scala/effectie/cats/EitherTSupport.scala
+++ b/cats-effect/src/main/scala/effectie/cats/EitherTSupport.scala
@@ -2,6 +2,7 @@ package effectie.cats
 
 import cats.Functor
 import cats.data.EitherT
+import cats.implicits._
 
 trait EitherTSupport {
 
@@ -14,8 +15,8 @@ trait EitherTSupport {
   def eitherTLiftEffect[F[_] : EffectConstructor : Functor, A, B](b: => B): EitherT[F, A, B] =
     EitherT.liftF[F, A, B](EffectConstructor[F].effectOf(b))
 
-  def eitherTLiftPureEffect[F[_] : EffectConstructor : Functor, A, B](b: B): EitherT[F, A, B] =
-    EitherT.liftF[F, A, B](EffectConstructor[F].pureEffect(b))
+  def eitherTLiftPureEffect[F[_] : EffectConstructor, A, B](b: B): EitherT[F, A, B] =
+    EitherT(EffectConstructor[F].pureEffect(b.asRight[A]))
 
   def eitherTLiftF[F[_] : EffectConstructor : Functor, A, B](fb: F[B]): EitherT[F, A, B] =
     EitherT.liftF[F, A, B](fb)

--- a/cats-effect/src/main/scala/effectie/cats/OptionTSupport.scala
+++ b/cats-effect/src/main/scala/effectie/cats/OptionTSupport.scala
@@ -2,6 +2,7 @@ package effectie.cats
 
 import cats.Functor
 import cats.data.OptionT
+import cats.implicits._
 
 trait OptionTSupport {
 
@@ -14,8 +15,8 @@ trait OptionTSupport {
   def optionTLiftEffect[F[_] : EffectConstructor : Functor, A](a: => A): OptionT[F, A] =
     OptionT.liftF[F, A](EffectConstructor[F].effectOf(a))
 
-  def optionTLiftPureEffect[F[_] : EffectConstructor : Functor, A](a: A): OptionT[F, A] =
-    OptionT.liftF[F, A](EffectConstructor[F].pureEffect(a))
+  def optionTLiftPureEffect[F[_] : EffectConstructor, A](a: A): OptionT[F, A] =
+    OptionT(EffectConstructor[F].pureEffect(a.some))
 
   def optionTLiftF[F[_] : EffectConstructor : Functor, A](fa: F[A]): OptionT[F, A] =
     OptionT.liftF[F, A](fa)


### PR DESCRIPTION
Task #16 - Removed: unnecessary typeclass requirement in `EitherTSupport` and `OptionTSupport`