### PR TITLE
Close #40 - Change the names of effect constructor methods in OptionTSupport to effectOf

### DIFF
--- a/cats-effect/src/main/scala/effectie/cats/OptionTSupport.scala
+++ b/cats-effect/src/main/scala/effectie/cats/OptionTSupport.scala
@@ -6,13 +6,13 @@ import cats.implicits._
 
 trait OptionTSupport {
 
-  def optionTEffect[F[_] : EffectConstructor, A](a: => Option[A]): OptionT[F, A] =
+  def optionTEffectOf[F[_] : EffectConstructor, A](a: => Option[A]): OptionT[F, A] =
     OptionT(EffectConstructor[F].effectOf(a))
 
   def optionTEffectOfPure[F[_] : EffectConstructor, A](a: Option[A]): OptionT[F, A] =
     OptionT(EffectConstructor[F].effectOfPure(a))
 
-  def optionTLiftEffect[F[_] : EffectConstructor : Functor, A](a: => A): OptionT[F, A] =
+  def optionTLiftEffectOf[F[_] : EffectConstructor : Functor, A](a: => A): OptionT[F, A] =
     OptionT.liftF[F, A](EffectConstructor[F].effectOf(a))
 
   def optionTLiftEffectOfPure[F[_] : EffectConstructor, A](a: A): OptionT[F, A] =

--- a/scalaz-effect/src/main/scala/effectie/scalaz/OptionTSupport.scala
+++ b/scalaz-effect/src/main/scala/effectie/scalaz/OptionTSupport.scala
@@ -5,13 +5,13 @@ import Scalaz._
 
 trait OptionTSupport {
 
-  def optionTEffect[F[_] : EffectConstructor, A](a: => Option[A]): OptionT[F, A] =
+  def optionTEffectOf[F[_] : EffectConstructor, A](a: => Option[A]): OptionT[F, A] =
     OptionT(EffectConstructor[F].effectOf(a))
 
   def optionTEffectOfPure[F[_] : EffectConstructor, A](a: Option[A]): OptionT[F, A] =
     OptionT(EffectConstructor[F].effectOfPure(a))
 
-  def optionTLiftEffect[F[_] : EffectConstructor : Functor, A](a: => A): OptionT[F, A] =
+  def optionTLiftEffectOf[F[_] : EffectConstructor : Functor, A](a: => A): OptionT[F, A] =
     OptionT(EffectConstructor[F].effectOf(a).map(_.some))
 
   def optionTLiftEffectOfPure[F[_] : EffectConstructor, A](a: A): OptionT[F, A] =


### PR DESCRIPTION
Close #40 - Change the names of `effect` constructor methods in `OptionTSupport` to `effectOf`