### PR TITLE
Effectie v1.0.0

### DIFF
--- a/changelogs/1.0.0.md
+++ b/changelogs/1.0.0.md
@@ -1,0 +1,12 @@
+## [1.0.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone5%22) - 2020-06-13
+
+This version contains some backward-incompatible changes in API (`EitherTSupport` and `OptionTSupport`).
+
+## Added
+* Add <code>~~Attempt~~</code> (#60)
+* Change `Attempt` to `CanCatch` (#64)
+* Add `Catching` (#62)
+
+## Changed
+* Improve `EitherTSupport` (#68)
+* Improve `OptionTSupport` (#70)

--- a/docs/docs/docs/index.md
+++ b/docs/docs/docs/index.md
@@ -14,7 +14,7 @@ Why Effectie? Please read ["Why?"](#why) section.
 In `build.sbt`,
 
 ```scala
-libraryDependencies += "io.kevinlee" %% "effectie-cats-effect" % "0.4.0"
+libraryDependencies += "io.kevinlee" %% "effectie-cats-effect" % "1.0.0"
 ```
 then import
 
@@ -35,7 +35,7 @@ For more details, check out [Effectie for Cats Effect](cats-effect).
 In `build.sbt`,
 
 ```scala
-libraryDependencies += "io.kevinlee" %% "effectie-scalaz-effect" % "0.4.0"
+libraryDependencies += "io.kevinlee" %% "effectie-scalaz-effect" % "1.0.0"
 ```
 then import
 

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -3,7 +3,7 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
 object ProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.4.0"
+  val ProjectVersion: String = "1.0.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# Effectie v1.0.0

## [1.0.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone5%22) - 2020-06-13

This version contains some backward-incompatible changes in API (`EitherTSupport` and `OptionTSupport`).

## Added
* Add <code>~~Attempt~~</code> (#60)
* Change `Attempt` to `CanCatch` (#64)
* Add `Catching` (#62)

## Changed
* Improve `EitherTSupport` (#68)
* Improve `OptionTSupport` (#70)
