### PR TITLE
Close #90 - CanCatch.catchNonFatal may not work due to non-lazy evaluation of F[A]

### DIFF
--- a/cats-effect/src/main/scala/effectie/cats/Catching.scala
+++ b/cats-effect/src/main/scala/effectie/cats/Catching.scala
@@ -19,15 +19,15 @@ trait Catching {
 object Catching extends Catching {
 
   private[Catching] final class CurriedCanCatch1[F[_], A] {
-    def apply[B](fb: F[B]): CurriedCanCatch2[F, A, B] =
-      new CurriedCanCatch2[F, A, B](fb)
+    def apply[B](fb: => F[B]): CurriedCanCatch2[F, A, B] =
+      new CurriedCanCatch2[F, A, B](() => fb)
   }
 
   private[Catching] final class CurriedCanCatch2[F[_], A, B](
-    private val fb: F[B]
+    private val fb: () => F[B]
   ) extends AnyVal {
     def apply(f: Throwable => A)(implicit CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatal(fb)(f)
+      CanCatch[F].catchNonFatal(fb())(f)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))

--- a/core/src/main/scala-2.12_2.13/effectie/compat/FutureCompat.scala
+++ b/core/src/main/scala-2.12_2.13/effectie/compat/FutureCompat.scala
@@ -11,7 +11,7 @@ object FutureCompat {
 
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
   def transform[A, B](
-    future: Future[A]
+    future: => Future[A]
   )(
     f: Try[A] => Try[B]
   )(implicit executor: ExecutionContext): Future[B] =

--- a/core/src/main/scala/effectie/CanCatch.scala
+++ b/core/src/main/scala/effectie/CanCatch.scala
@@ -2,7 +2,7 @@ package effectie
 
 trait CanCatch[F[_]] {
   type Xor[A, B]
-  def catchNonFatal[A, B](fb: F[B])(f: Throwable => A): F[Xor[A, B]]
+  def catchNonFatal[A, B](fb: => F[B])(f: Throwable => A): F[Xor[A, B]]
 }
 
 object CanCatch {

--- a/scalaz-effect/src/main/scala/effectie/scalaz/CanCatch.scala
+++ b/scalaz-effect/src/main/scala/effectie/scalaz/CanCatch.scala
@@ -23,7 +23,7 @@ object CanCatch {
 
   implicit val canCatchIo: CanCatch[IO] = new CanCatch[IO] {
     @SuppressWarnings(Array("org.wartremover.warts.Throw"))
-    override def catchNonFatal[A, B](fb: IO[B])(f: Throwable => A): IO[A \/ B] =
+    override def catchNonFatal[A, B](fb: => IO[B])(f: Throwable => A): IO[A \/ B] =
       EitherT(fb.attempt)
         .leftMap {
           case NonFatal(ex) =>
@@ -40,7 +40,7 @@ object CanCatch {
 
   final class CanCatchFuture(val EC0: ExecutionContext)
     extends CanCatch[Future] {
-    override def catchNonFatal[A, B](fb: Future[B])(f: Throwable => A): Future[A \/ B] =
+    override def catchNonFatal[A, B](fb: => Future[B])(f: Throwable => A): Future[A \/ B] =
       FutureCompat.transform(fb) {
         case SuccessS(b) =>
           Try(b.right[A])
@@ -51,7 +51,7 @@ object CanCatch {
   }
 
   implicit val canCatchId: CanCatch[Id] = new CanCatch[Id] {
-    override def catchNonFatal[A, B](fb: Id[B])(f: Throwable => A): Id[A \/ B] =
+    override def catchNonFatal[A, B](fb: => Id[B])(f: Throwable => A): Id[A \/ B] =
       Try(fb) match {
         case SuccessS(b) =>
           b.right[A]

--- a/scalaz-effect/src/main/scala/effectie/scalaz/Catching.scala
+++ b/scalaz-effect/src/main/scala/effectie/scalaz/Catching.scala
@@ -21,15 +21,15 @@ trait Catching {
 object Catching extends Catching {
 
   private[Catching] final class CurriedCanCatch1[F[_], A] {
-    def apply[B](fb: F[B]): CurriedCanCatch2[F, A, B] =
-      new CurriedCanCatch2[F, A, B](fb)
+    def apply[B](fb: => F[B]): CurriedCanCatch2[F, A, B] =
+      new CurriedCanCatch2[F, A, B](() => fb)
   }
 
   private[Catching] final class CurriedCanCatch2[F[_], A, B](
-    private val fb: F[B]
+    private val fb: () => F[B]
   ) extends AnyVal {
     def apply(f: Throwable => A)(implicit CC: CanCatch[F]): F[A \/ B] =
-      CanCatch[F].catchNonFatal(fb)(f)
+      CanCatch[F].catchNonFatal(fb())(f)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))


### PR DESCRIPTION
Close #90 - `CanCatch.catchNonFatal` may not work due to non-lazy evaluation of `F[A]`
`CanCatch.catchNonFatal` now has a by-name parameter.