### PR TITLE
Effectie v1.1.0

### DIFF
--- a/changelogs/1.1.0.md
+++ b/changelogs/1.1.0.md
@@ -1,0 +1,13 @@
+## [1.1.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone6%22) - 2020-08-01
+
+## Done
+* Add `catchNonFatalEither` and `catchNonFatalEitherT` to `CanCatch` (#91)
+* Add `catchNonFatalEither` and `catchNonFatalEitherT` to `Catching` (#94)
+* Improve type inference in `Effectful`, `OptionTSupport` and `EitherTSupport` (#96)
+
+## Fixed
+* `CanCatch.catchNonFatal` may not work due to non-lazy evaluation of `F[A]` (#90)
+
+## Changed in Dev
+* Replace `master` branch with `main` branch (#78)
+* Replace `sbt-microsites` with `Docusaurus 2` (#79)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -3,7 +3,7 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
 object ProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "1.0.0"
+  val ProjectVersion: String = "1.1.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# Effectie v1.1.0
## [1.1.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone6%22) - 2020-08-01

## Done
* Add `catchNonFatalEither` and `catchNonFatalEitherT` to `CanCatch` (#91)
* Add `catchNonFatalEither` and `catchNonFatalEitherT` to `Catching` (#94)
* Improve type inference in `Effectful`, `OptionTSupport` and `EitherTSupport` (#96)

## Fixed
* `CanCatch.catchNonFatal` may not work due to non-lazy evaluation of `F[A]` (#90)

## Changed in Dev
* Replace `master` branch with `main` branch (#78)
* Replace `sbt-microsites` with `Docusaurus 2` (#79)
