### PR TITLE
Close #106 - Move ExecutorServiceOps from test to main

### DIFF
--- a/cats-effect/src/test/scala/effectie/cats/CanCatchSpec.scala
+++ b/cats-effect/src/test/scala/effectie/cats/CanCatchSpec.scala
@@ -6,7 +6,8 @@ import cats.effect._
 import cats.implicits._
 
 import effectie.Effectful._
-import effectie.{ExecutorServiceOps, SomeControlThrowable}
+import effectie.SomeControlThrowable
+import effectie.concurrent.ExecutorServiceOps
 
 import hedgehog._
 import hedgehog.runner._

--- a/cats-effect/src/test/scala/effectie/cats/CatchingSpec.scala
+++ b/cats-effect/src/test/scala/effectie/cats/CatchingSpec.scala
@@ -8,7 +8,8 @@ import cats.effect._
 import cats.implicits._
 
 import effectie.Effectful.effectOf
-import effectie.{ExecutorServiceOps, SomeControlThrowable}
+import effectie.SomeControlThrowable
+import effectie.concurrent.ExecutorServiceOps
 
 import hedgehog._
 import hedgehog.runner._

--- a/core/src/main/scala/effectie/concurrent/ExecutorServiceOps.scala
+++ b/core/src/main/scala/effectie/concurrent/ExecutorServiceOps.scala
@@ -1,4 +1,4 @@
-package effectie
+package effectie.concurrent
 
 import java.util.concurrent.{ExecutorService, TimeUnit}
 

--- a/scalaz-effect/src/test/scala/effectie/scalaz/CanCatchSpec.scala
+++ b/scalaz-effect/src/test/scala/effectie/scalaz/CanCatchSpec.scala
@@ -5,7 +5,8 @@ import Scalaz._
 import scalaz.effect._
 
 import effectie.Effectful._
-import effectie.{ExecutorServiceOps, SomeControlThrowable}
+import effectie.SomeControlThrowable
+import effectie.concurrent.ExecutorServiceOps
 
 import hedgehog._
 import hedgehog.runner._

--- a/scalaz-effect/src/test/scala/effectie/scalaz/CatchingSpec.scala
+++ b/scalaz-effect/src/test/scala/effectie/scalaz/CatchingSpec.scala
@@ -6,7 +6,8 @@ import scalaz.effect._
 
 import effectie.Effectful._
 import effectie.scalaz.Catching._
-import effectie.{ExecutorServiceOps, SomeControlThrowable}
+import effectie.SomeControlThrowable
+import effectie.concurrent.ExecutorServiceOps
 
 import hedgehog._
 import hedgehog.runner._


### PR DESCRIPTION
Close #106 - Move `ExecutorServiceOps` from `test` to `main`