### PR TITLE
Close #108 - Add a way to log to ExecutorServiceOps.shutdownAndAwaitTermination

### DIFF
--- a/cats-effect/src/test/scala/effectie/cats/CanCatchSpec.scala
+++ b/cats-effect/src/test/scala/effectie/cats/CanCatchSpec.scala
@@ -245,7 +245,7 @@ object CanCatchSpec extends Properties {
           throw ex
       } finally {
         try {
-          ExecutorServiceOps.shutdownAndAwaitTermination(executorService, waitFor)
+          ExecutorServiceOps.shutdownAndAwaitTerminationWithLogger(executorService, waitFor)(println(_))
         } catch {
           case NonFatal(ex) =>
             @SuppressWarnings(Array("org.wartremover.warts.ToString"))

--- a/cats-effect/src/test/scala/effectie/cats/CatchingSpec.scala
+++ b/cats-effect/src/test/scala/effectie/cats/CatchingSpec.scala
@@ -353,7 +353,7 @@ object CatchingSpec extends Properties {
           throw ex
       } finally {
         try {
-          ExecutorServiceOps.shutdownAndAwaitTermination(executorService, waitFor)
+          ExecutorServiceOps.shutdownAndAwaitTerminationWithLogger(executorService, waitFor)(println(_))
         } catch {
           case NonFatal(ex) =>
             @SuppressWarnings(Array("org.wartremover.warts.ToString"))

--- a/core/src/main/scala/effectie/concurrent/ExecutorServiceOps.scala
+++ b/core/src/main/scala/effectie/concurrent/ExecutorServiceOps.scala
@@ -10,24 +10,61 @@ import scala.concurrent.duration.FiniteDuration
  */
 trait ExecutorServiceOps {
 
-  def shutdownAndAwaitTermination(executorService: ExecutorService, waitFor: FiniteDuration): Unit = {
+  private def noLogger(s: => String): Unit = ()
+
+  def shutdownAndAwaitTermination(
+    executorService: ExecutorService,
+    waitFor: FiniteDuration
+  ): Unit = {
+    shutdownAndAwaitTerminationWithLogger(executorService, waitFor)(noLogger)
+  }
+
+
+  @SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
+  def shutdownAndAwaitTerminationWithLogger(
+    executorService: ExecutorService,
+    waitFor: FiniteDuration
+  )(
+    logger: (=> String) => Unit
+  ): Unit = {
+    logger("About to start executorService.shutdown()")
     executorService.shutdown()
 
     try {
-      if (!executorService.awaitTermination(waitFor.toSeconds, TimeUnit.SECONDS)) {
+      logger(
+        "executorService.shutdown() has been called " +
+        s"and await termination for ${waitFor.toMillis} ms (${waitFor.toSeconds} s)"
+      )
+      if (!executorService.awaitTermination(waitFor.toMillis, TimeUnit.MILLISECONDS)) {
+        logger(s"calling executorService.shutdownNow()")
         val _ = executorService.shutdownNow()
 
-        if (!executorService.awaitTermination(waitFor.toSeconds, TimeUnit.SECONDS)) {
-          println("ExecutorService did not terminate")
+        logger(
+            "executorService.shutdownNow() has been called " +
+            s"and await termination for ${waitFor.toMillis} ms (${waitFor.toSeconds} s)"
+        )
+        if (!executorService.awaitTermination(waitFor.toMillis, TimeUnit.MILLISECONDS)) {
+          logger(
+            "ExecutorService did not terminate " +
+            s"after awaiting for ${waitFor.toMillis} ms (${waitFor.toSeconds} s)."
+          )
         } else {
+          logger("ExecutorService has been terminated.")
           ()
         }
       } else {
+        logger("ExecutorService has been terminated.")
         ()
       }
     } catch {
       case ie: InterruptedException =>
+        logger("InterruptedException has been caught while terminating ExecutorService.")
+        logger("Calling executorService.shutdownNow()")
         val _ = executorService.shutdownNow()
+        logger(
+          "executorService.shutdownNow() has been called" +
+          " and calling Thread.currentThread.interrupt()"
+        )
         Thread.currentThread.interrupt()
     }
   }

--- a/scalaz-effect/src/test/scala/effectie/scalaz/CanCatchSpec.scala
+++ b/scalaz-effect/src/test/scala/effectie/scalaz/CanCatchSpec.scala
@@ -242,7 +242,7 @@ object CanCatchSpec extends Properties {
           throw ex
       } finally {
         try {
-          ExecutorServiceOps.shutdownAndAwaitTermination(executorService, waitFor)
+          ExecutorServiceOps.shutdownAndAwaitTerminationWithLogger(executorService, waitFor)(println(_))
         } catch {
           case NonFatal(ex) =>
             @SuppressWarnings(Array("org.wartremover.warts.ToString"))

--- a/scalaz-effect/src/test/scala/effectie/scalaz/CatchingSpec.scala
+++ b/scalaz-effect/src/test/scala/effectie/scalaz/CatchingSpec.scala
@@ -351,7 +351,7 @@ object CatchingSpec extends Properties {
           throw ex
       } finally {
         try {
-          ExecutorServiceOps.shutdownAndAwaitTermination(executorService, waitFor)
+          ExecutorServiceOps.shutdownAndAwaitTerminationWithLogger(executorService, waitFor)(println(_))
         } catch {
           case NonFatal(ex) =>
             @SuppressWarnings(Array("org.wartremover.warts.ToString"))


### PR DESCRIPTION
Close #108 - Add a way to log to `ExecutorServiceOps.shutdownAndAwaitTermination`