### PR TITLE
Effectie v1.2.0

### DIFF
--- a/changelogs/1.2.0.md
+++ b/changelogs/1.2.0.md
@@ -1,0 +1,6 @@
+## [1.2.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone7%22) - 2020-08-03
+
+## Done
+* Improve type inference of `eitherTRight`, `eitherTRightPure`, `eitherTLeft` and `eitherTLeftPure` in `EitherTSupport` (#104)
+* Move `ExecutorServiceOps` from `test` to `main` (#106)
+* Add a way to log to `ExecutorServiceOps.shutdownAndAwaitTermination` (#108)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -3,7 +3,7 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
 object ProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "1.1.0"
+  val ProjectVersion: String = "1.2.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# Effectie v1.2.0
## [1.2.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone7%22) - 2020-08-03

## Done
* Improve type inference of `eitherTRight`, `eitherTRightPure`, `eitherTLeft` and `eitherTLeftPure` in `EitherTSupport` (#104)
* Move `ExecutorServiceOps` from `test` to `main` (#106)
* Add a way to log to `ExecutorServiceOps.shutdownAndAwaitTermination` (#108)
