### PR TITLE
Updated: docs to have the supported Scala versions automatically when docs/mdoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -329,7 +329,14 @@ lazy val docs = (project in file("generated-docs"))
         scalaVersion.value, isDotty.value, libraryDependencies.value
       )
     , mdocVariables := Map(
-        "VERSION" -> (ThisBuild / version).value
+        "VERSION" -> (ThisBuild / version).value,
+        "SUPPORTED_SCALA_VERSIONS" -> {
+            val versions = CrossScalaVersions.map(v => s"`$v`")
+            if (versions.length > 1)
+              s"${versions.init.mkString(", ")} and ${versions.last}"
+            else
+              versions.mkString
+          }
       )
 
     , docusaurDir := (ThisBuild / baseDirectory).value / "website"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ slug: "/"
 | effectie-cats-effect | [![Download](https://api.bintray.com/packages/kevinlee/maven/effectie-cats-effect/images/download.svg)](https://bintray.com/kevinlee/maven/effectie-cats-effect/_latestVersion) | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kevinlee/effectie-cats-effect_2.13/badge.svg)](https://search.maven.org/artifact/io.kevinlee/effectie-cats-effect_2.13) |
 | effectie-scalaz-effect | [![Download](https://api.bintray.com/packages/kevinlee/maven/effectie-scalaz-effect/images/download.svg)](https://bintray.com/kevinlee/maven/effectie-scalaz-effect/_latestVersion) | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kevinlee/effectie-scalaz-effect_2.13/badge.svg)](https://search.maven.org/artifact/io.kevinlee/effectie-scalaz-effect_2.13) |
 
-* Supported Scala Versions: `2.11`, `2.12`, `2.13` and `3.0.0-M1`
+* Supported Scala Versions: @SUPPORTED_SCALA_VERSIONS@
 
 A set of type-classes and utils for functional effect libraries (i.e. Scalaz and Cats Effect).
 


### PR DESCRIPTION
Updated: docs to have the supported Scala versions automatically when `docs/mdoc`