### PR TITLE
Effectie v1.8.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val CrossScalaVersions: Seq[String] = Seq(
 ).distinct
 val IncludeTest: String = "compile->compile;test->test"
 
-lazy val hedgehogVersion = "f6139169375836149f2e3bfeef85c350c92bd01f"
+lazy val hedgehogVersion = "0.6.1"
 lazy val hedgehogRepo: MavenRepository =
   "bintray-scala-hedgehog" at "https://dl.bintray.com/hedgehogqa/scala-hedgehog"
 

--- a/changelogs/1.8.1.md
+++ b/changelogs/1.8.1.md
@@ -1,0 +1,4 @@
+## [1.8.1](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone14%22) - 2020-12-25 🎄
+
+## Done
+* Support Scala `3.0.0-M3` (#174)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -3,7 +3,7 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
 object ProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "1.8.0"
+  val ProjectVersion: String = "1.8.1"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# Effectie v1.8.1
## [1.8.1](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone14%22) - 2020-12-25 🎄

## Done
* Support Scala `3.0.0-M3` (#174)
