### PR TITLE
Changed: auto-publishing the doc site is now manual - No need to keep the publish-docs branch

### DIFF
--- a/.github/workflows/manual-publish-github-pages.yml
+++ b/.github/workflows/manual-publish-github-pages.yml
@@ -1,9 +1,7 @@
 name: Publish GitHub Pages
 
 on:
-  push:
-    branches:
-      - publish-docs
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Changed: auto-publishing the doc site is now manual - No need to keep the `publish-docs` branch