### PR TITLE
Effectie v1.12.0

### DIFF
--- a/changelogs/1.12.0.md
+++ b/changelogs/1.12.0.md
@@ -1,0 +1,40 @@
+## [1.12.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone18) - 2021-07-23
+
+## Done
+* Add a shorter alternative name to `EffectConstructor` (#220)
+* Rename `Eft` `Fx` (#234)
+* Add `EitherT` extension methods (#230)
+  ```scala
+  val fab: F[Either[A, B]] = ???
+  fab.eitherT // EitherT[F, A, B]
+  
+  val ab: Either[A, B] = ???
+  ab.eitherT[F] // Either[F, A, B]
+  
+  val fb: F[B] = ???
+  fb.rightT[A] // EitherT[F, A, B]
+  
+  val b = ???
+  b.rightTF[F, A] // EitherT[F, A, B]
+  
+  val fa: F[A] = ???
+  fa.leftT[B] // EitherT[F, A, B]
+  
+  val a: A = ???
+  a.leftTF[F, B] // EitherT[F, A, B]
+  ```
+* Add `OptionT` extension methods (#231)
+  ```scala
+  val foa: F[Option[A]] = ???
+  foa.optionT // OptionT[F, A]
+  
+  val oa: Option[A] = ???
+  oa.optionT[F] // Option[F, A]
+  
+  val fa: F[A] = ???
+  fa.someT OptionT[F, A] // OptionT[F, A]
+  
+  val a = ???
+  a.someTF[F] // OptionT[F, A]
+  ```
+* `YesNo` in Scala 3 should derive `CanEqual` (#237)


### PR DESCRIPTION
# Effectie v1.12.0
## [1.12.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone18) - 2021-07-23

## Done
* Add a shorter alternative name to `EffectConstructor` (#220)
* Rename `Eft` `Fx` (#234)
* Add `EitherT` extension methods (#230)
  ```scala
  val fab: F[Either[A, B]] = ???
  fab.eitherT // EitherT[F, A, B]
  
  val ab: Either[A, B] = ???
  ab.eitherT[F] // Either[F, A, B]
  
  val fb: F[B] = ???
  fb.rightT[A] // EitherT[F, A, B]
  
  val b = ???
  b.rightTF[F, A] // EitherT[F, A, B]
  
  val fa: F[A] = ???
  fa.leftT[B] // EitherT[F, A, B]
  
  val a: A = ???
  a.leftTF[F, B] // EitherT[F, A, B]
  ```
* Add `OptionT` extension methods (#231)
  ```scala
  val foa: F[Option[A]] = ???
  foa.optionT // OptionT[F, A]
  
  val oa: Option[A] = ???
  oa.optionT[F] // Option[F, A]
  
  val fa: F[A] = ???
  fa.someT OptionT[F, A] // OptionT[F, A]
  
  val a = ???
  a.someTF[F] // OptionT[F, A]
  ```
* `YesNo` in Scala 3 should derive `CanEqual` (#237)
