### PR TITLE
Effectie v1.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -191,16 +191,6 @@ lazy val props =
 
     final val IncludeTest = "compile->compile;test->test"
 
-    final val scala3cLanguageOptions =
-      "-language:" + List(
-        "dynamics",
-        "existentials",
-        "higherKinds",
-        "reflectiveCalls",
-        "experimental.macros",
-        "implicitConversions",
-      ).mkString(",")
-
     final val hedgehogLatestVersion = "0.7.0"
 
     final val catsVersion       = "2.5.0"
@@ -255,13 +245,10 @@ def libraryDependenciesPostProcess(
   isDotty: Boolean,
   libraries: Seq[ModuleID]
 ): Seq[ModuleID] =
-  (
-    if (isDotty) {
-      libraries
-        .filterNot(props.removeDottyIncompatible)
-    } else
-      libraries
-  )
+  if (isDotty)
+    libraries.filterNot(props.removeDottyIncompatible)
+  else
+    libraries
 
 def projectCommonSettings(id: String, projectName: ProjectName, file: File): Project =
   Project(id, file)

--- a/changelogs/1.13.0.md
+++ b/changelogs/1.13.0.md
@@ -1,0 +1,5 @@
+## [1.13.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone19) - 2021-07-24
+
+## Done
+* Drop Scala `2.11` support (#242)
+* Support Cats Effect 3 (#229)


### PR DESCRIPTION
# Effectie v1.13.0
## [1.13.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone19) - 2021-07-24

## Done
* Drop Scala `2.11` support (#242)
* Support Cats Effect 3 (#229)
