### PR TITLE
Close #249 - Replace sealed trait based ADT with enum for Scala 3 in effectie-cats-effect

### DIFF
--- a/cats-effect/src/test/scala-3/effectie/cats/CanCatchSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CanCatchSpec.scala
@@ -12,56 +12,136 @@ import hedgehog.runner._
 
 import scala.util.control.ControlThrowable
 
-/**
- * @author Kevin Lee
- * @since 2020-07-31
- */
+/** @author Kevin Lee
+  * @since 2020-07-31
+  */
 object CanCatchSpec extends Properties {
 
   override def tests: List[Test] = List(
     /* IO */
-    example("test CanCatch[IO]catchNonFatal should catch NonFatal", IoSpec.testCanCatch_IO_catchNonFatalShouldCatchNonFatal),
-    example("test CanCatch[IO]catchNonFatal should not catch Fatal", IoSpec.testCanCatch_IO_catchNonFatalShouldNotCatchFatal),
-    example("test CanCatch[IO]catchNonFatal should return the successful result", IoSpec.testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult),
-
-    example("test CanCatch[IO]catchNonFatalEither should catch NonFatal", IoSpec.testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal),
-    example("test CanCatch[IO]catchNonFatalEither should not catch Fatal", IoSpec.testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal),
-    example("test CanCatch[IO]catchNonFatalEither should return the successful result", IoSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult),
-    example("test CanCatch[IO]catchNonFatalEither should return the failed result", IoSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult),
-
-    example("test CanCatch[IO]catchNonFatalEitherT should catch NonFatal", IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal),
-    example("test CanCatch[IO]catchNonFatalEitherT should not catch Fatal", IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal),
-    example("test CanCatch[IO]catchNonFatalEitherT should return the successful result", IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult),
-    example("test CanCatch[IO]catchNonFatalEitherT should return the failed result", IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult),
-
+    example(
+      "test CanCatch[IO]catchNonFatal should catch NonFatal",
+      IoSpec.testCanCatch_IO_catchNonFatalShouldCatchNonFatal
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatal should not catch Fatal",
+      IoSpec.testCanCatch_IO_catchNonFatalShouldNotCatchFatal
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatal should return the successful result",
+      IoSpec.testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEither should catch NonFatal",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEither should not catch Fatal",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEither should return the successful result",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEither should return the failed result",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEitherT should catch NonFatal",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEitherT should not catch Fatal",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEitherT should return the successful result",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEitherT should return the failed result",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult
+    ),
     /* Future */
 
-    example("test CanCatch[Future]catchNonFatal should catch NonFatal", FutureSpec.testCanCatch_Future_catchNonFatalShouldCatchNonFatal),
-    example("test CanCatch[Future]catchNonFatal should return the successful result", FutureSpec.testCanCatch_Future_catchNonFatalShouldReturnSuccessfulResult),
-
-    example("test CanCatch[Future]catchNonFatalEither should catch NonFatal", FutureSpec.testCanCatch_Future_catchNonFatalEitherShouldCatchNonFatal),
-    example("test CanCatch[Future]catchNonFatalEither should return the successful result", FutureSpec.testCanCatch_Future_catchNonFatalEitherShouldReturnSuccessfulResult),
-    example("test CanCatch[Future]catchNonFatalEither should return the failed result", FutureSpec.testCanCatch_Future_catchNonFatalEitherShouldReturnFailedResult),
-
-    example("test CanCatch[Future]catchNonFatalEitherT should catch NonFatal", FutureSpec.testCanCatch_Future_catchNonFatalEitherTShouldCatchNonFatal),
-    example("test CanCatch[Future]catchNonFatalEitherT should return the successful result", FutureSpec.testCanCatch_Future_catchNonFatalEitherTShouldReturnSuccessfulResult),
-    example("test CanCatch[Future]catchNonFatalEitherT should return the failed result", FutureSpec.testCanCatch_Future_catchNonFatalEitherTShouldReturnFailedResult),
-
-
+    example(
+      "test CanCatch[Future]catchNonFatal should catch NonFatal",
+      FutureSpec.testCanCatch_Future_catchNonFatalShouldCatchNonFatal
+    ),
+    example(
+      "test CanCatch[Future]catchNonFatal should return the successful result",
+      FutureSpec.testCanCatch_Future_catchNonFatalShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanCatch[Future]catchNonFatalEither should catch NonFatal",
+      FutureSpec.testCanCatch_Future_catchNonFatalEitherShouldCatchNonFatal
+    ),
+    example(
+      "test CanCatch[Future]catchNonFatalEither should return the successful result",
+      FutureSpec.testCanCatch_Future_catchNonFatalEitherShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanCatch[Future]catchNonFatalEither should return the failed result",
+      FutureSpec.testCanCatch_Future_catchNonFatalEitherShouldReturnFailedResult
+    ),
+    example(
+      "test CanCatch[Future]catchNonFatalEitherT should catch NonFatal",
+      FutureSpec.testCanCatch_Future_catchNonFatalEitherTShouldCatchNonFatal
+    ),
+    example(
+      "test CanCatch[Future]catchNonFatalEitherT should return the successful result",
+      FutureSpec.testCanCatch_Future_catchNonFatalEitherTShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanCatch[Future]catchNonFatalEitherT should return the failed result",
+      FutureSpec.testCanCatch_Future_catchNonFatalEitherTShouldReturnFailedResult
+    ),
     /* Id */
-    example("test CanCatch[Id]catchNonFatal should catch NonFatal", IdSpec.testCanCatch_Id_catchNonFatalShouldCatchNonFatal),
-    example("test CanCatch[Id]catchNonFatal should not catch Fatal", IdSpec.testCanCatch_Id_catchNonFatalShouldNotCatchFatal),
-    example("test CanCatch[Id]catchNonFatal should return the successful result", IdSpec.testCanCatch_Id_catchNonFatalShouldReturnSuccessfulResult),
-
-    example("test CanCatch[Id]catchNonFatalEither should catch NonFatal", IdSpec.testCanCatch_Id_catchNonFatalEitherShouldCatchNonFatal),
-    example("test CanCatch[Id]catchNonFatalEither should not catch Fatal", IdSpec.testCanCatch_Id_catchNonFatalEitherShouldNotCatchFatal),
-    example("test CanCatch[Id]catchNonFatalEither should return the successful result", IdSpec.testCanCatch_Id_catchNonFatalEitherShouldReturnSuccessfulResult),
-    example("test CanCatch[Id]catchNonFatalEither should return the failed result", IdSpec.testCanCatch_Id_catchNonFatalEitherShouldReturnFailedResult),
-
-    example("test CanCatch[Id]catchNonFatalEitherT should catch NonFatal", IdSpec.testCanCatch_Id_catchNonFatalEitherTShouldCatchNonFatal),
-    example("test CanCatch[Id]catchNonFatalEitherT should not catch Fatal", IdSpec.testCanCatch_Id_catchNonFatalEitherTShouldNotCatchFatal),
-    example("test CanCatch[Id]catchNonFatalEitherT should return the successful result", IdSpec.testCanCatch_Id_catchNonFatalEitherTShouldReturnSuccessfulResult),
-    example("test CanCatch[Id]catchNonFatalEitherT should return the failed result", IdSpec.testCanCatch_Id_catchNonFatalEitherTShouldReturnFailedResult)
+    example(
+      "test CanCatch[Id]catchNonFatal should catch NonFatal",
+      IdSpec.testCanCatch_Id_catchNonFatalShouldCatchNonFatal
+    ),
+    example(
+      "test CanCatch[Id]catchNonFatal should not catch Fatal",
+      IdSpec.testCanCatch_Id_catchNonFatalShouldNotCatchFatal
+    ),
+    example(
+      "test CanCatch[Id]catchNonFatal should return the successful result",
+      IdSpec.testCanCatch_Id_catchNonFatalShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanCatch[Id]catchNonFatalEither should catch NonFatal",
+      IdSpec.testCanCatch_Id_catchNonFatalEitherShouldCatchNonFatal
+    ),
+    example(
+      "test CanCatch[Id]catchNonFatalEither should not catch Fatal",
+      IdSpec.testCanCatch_Id_catchNonFatalEitherShouldNotCatchFatal
+    ),
+    example(
+      "test CanCatch[Id]catchNonFatalEither should return the successful result",
+      IdSpec.testCanCatch_Id_catchNonFatalEitherShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanCatch[Id]catchNonFatalEither should return the failed result",
+      IdSpec.testCanCatch_Id_catchNonFatalEitherShouldReturnFailedResult
+    ),
+    example(
+      "test CanCatch[Id]catchNonFatalEitherT should catch NonFatal",
+      IdSpec.testCanCatch_Id_catchNonFatalEitherTShouldCatchNonFatal
+    ),
+    example(
+      "test CanCatch[Id]catchNonFatalEitherT should not catch Fatal",
+      IdSpec.testCanCatch_Id_catchNonFatalEitherTShouldNotCatchFatal
+    ),
+    example(
+      "test CanCatch[Id]catchNonFatalEitherT should return the successful result",
+      IdSpec.testCanCatch_Id_catchNonFatalEitherTShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanCatch[Id]catchNonFatalEitherT should return the failed result",
+      IdSpec.testCanCatch_Id_catchNonFatalEitherTShouldReturnFailedResult
+    )
   )
 
   def throwThrowable[A](throwable: => Throwable): A =
@@ -70,16 +150,13 @@ object CanCatchSpec extends Properties {
   def run[F[_]: EffectConstructor: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
-  sealed trait SomeError
+  enum SomeError   {
+    case SomeThrowable(throwable: Throwable)
+    case Message(message: String)
+  }
   object SomeError {
-
-    final case class SomeThrowable(throwable: Throwable) extends SomeError
-    final case class Message(message: String) extends SomeError
-
-    def someThrowable(throwable: Throwable): SomeError = SomeThrowable(throwable)
-
-    def message(message: String): SomeError = Message(message)
-
+    def someThrowable(throwable: Throwable): SomeError = SomeError.SomeThrowable(throwable)
+    def message(message: String): SomeError            = SomeError.Message(message)
   }
 
   object IoSpec {
@@ -87,9 +164,9 @@ object CanCatchSpec extends Properties {
     def testCanCatch_IO_catchNonFatalShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[IO, Int](throwThrowable[Int](expectedExpcetion))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
@@ -97,7 +174,7 @@ object CanCatchSpec extends Properties {
     def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      val fa = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
       try {
         val actual = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
@@ -114,20 +191,19 @@ object CanCatchSpec extends Properties {
 
     def testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[IO, Int](1)
+      val fa       = run[IO, Int](1)
       val expected = 1.asRight[SomeError]
-      val actual = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+      val actual   = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
 
-
     def testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
@@ -135,7 +211,7 @@ object CanCatchSpec extends Properties {
     def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
       try {
         val actual = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
@@ -152,9 +228,9 @@ object CanCatchSpec extends Properties {
 
     def testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
-      val actual = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+      val actual   = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
@@ -162,20 +238,19 @@ object CanCatchSpec extends Properties {
     def testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
-      val expected = expectedFailure.asLeft[Int]
-      val actual = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
 
-
     def testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+      val fa                = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
 
       actual ==== expected
     }
@@ -183,7 +258,7 @@ object CanCatchSpec extends Properties {
     def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fa             = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
@@ -200,9 +275,9 @@ object CanCatchSpec extends Properties {
 
     def testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
 
-      val fa = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
-      val actual = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+      val actual   = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
 
       actual ==== expected
     }
@@ -210,33 +285,31 @@ object CanCatchSpec extends Properties {
     def testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
-      val expected = expectedFailure.asLeft[Int]
-      val actual = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
 
       actual ==== expected
     }
 
   }
 
-
   object FutureSpec {
     import java.util.concurrent.{ExecutorService, Executors}
     import scala.concurrent.duration._
     import scala.concurrent.{ExecutionContext, Future}
-
 
     val waitFor: FiniteDuration = 1.second
 
     def testCanCatch_Future_catchNonFatalShouldCatchNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[Future, Int](throwThrowable[Int](expectedExpcetion))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val fa                = run[Future, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = ConcurrentSupport.futureToValueAndTerminate(
         CanCatch[Future].catchNonFatal(fa)(SomeError.someThrowable),
         waitFor
       )
@@ -247,11 +320,11 @@ object CanCatchSpec extends Properties {
     def testCanCatch_Future_catchNonFatalShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val fa = run[Future, Int](1)
+      val fa       = run[Future, Int](1)
       val expected = 1.asRight[SomeError]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         CanCatch[Future].catchNonFatal(fa)(SomeError.someThrowable),
         waitFor
       )
@@ -259,16 +332,15 @@ object CanCatchSpec extends Properties {
       actual ==== expected
     }
 
-
     def testCanCatch_Future_catchNonFatalEitherShouldCatchNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val fa                = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = ConcurrentSupport.futureToValueAndTerminate(
         CanCatch[Future].catchNonFatalEither(fa)(SomeError.someThrowable),
         waitFor
       )
@@ -279,11 +351,11 @@ object CanCatchSpec extends Properties {
     def testCanCatch_Future_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val fa = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
+      val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         CanCatch[Future].catchNonFatalEither(fa)(SomeError.someThrowable),
         waitFor
       )
@@ -294,12 +366,12 @@ object CanCatchSpec extends Properties {
     def testCanCatch_Future_catchNonFatalEitherShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
-      val expected = expectedFailure.asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = ConcurrentSupport.futureToValueAndTerminate(
         CanCatch[Future].catchNonFatalEither(fa)(SomeError.someThrowable),
         waitFor
       )
@@ -307,16 +379,15 @@ object CanCatchSpec extends Properties {
       actual ==== expected
     }
 
-
     def testCanCatch_Future_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val fa                = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = ConcurrentSupport.futureToValueAndTerminate(
         CanCatch[Future].catchNonFatalEitherT(fa)(SomeError.someThrowable).value,
         waitFor
       )
@@ -327,11 +398,11 @@ object CanCatchSpec extends Properties {
     def testCanCatch_Future_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val fa = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
+      val fa       = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         CanCatch[Future].catchNonFatalEitherT(fa)(SomeError.someThrowable).value,
         waitFor
       )
@@ -342,12 +413,12 @@ object CanCatchSpec extends Properties {
     def testCanCatch_Future_catchNonFatalEitherTShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
-      val expected = expectedFailure.asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val fa              = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = ConcurrentSupport.futureToValueAndTerminate(
         CanCatch[Future].catchNonFatalEitherT(fa)(SomeError.someThrowable).value,
         waitFor
       )
@@ -356,15 +427,14 @@ object CanCatchSpec extends Properties {
     }
   }
 
-
   object IdSpec {
 
     def testCanCatch_Id_catchNonFatalShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa = run[Id, Int](throwThrowable[Int](expectedExpcetion))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = CanCatch[Id].catchNonFatal(fa)(SomeError.someThrowable)
+      lazy val fa           = run[Id, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = CanCatch[Id].catchNonFatal(fa)(SomeError.someThrowable)
 
       actual ==== expected
     }
@@ -372,7 +442,7 @@ object CanCatchSpec extends Properties {
     def testCanCatch_Id_catchNonFatalShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      lazy val fa = run[Id, Int](throwThrowable[Int](fatalExpcetion))
+      lazy val fa        = run[Id, Int](throwThrowable[Int](fatalExpcetion))
 
       try {
         val actual = CanCatch[Id].catchNonFatal(fa)(SomeError.someThrowable)
@@ -389,20 +459,19 @@ object CanCatchSpec extends Properties {
 
     def testCanCatch_Id_catchNonFatalShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[Id, Int](1)
+      val fa       = run[Id, Int](1)
       val expected = 1.asRight[SomeError]
-      val actual = CanCatch[Id].catchNonFatal(fa)(SomeError.someThrowable)
+      val actual   = CanCatch[Id].catchNonFatal(fa)(SomeError.someThrowable)
 
       actual ==== expected
     }
 
-
     def testCanCatch_Id_catchNonFatalEitherShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = CanCatch[Id].catchNonFatalEither(fa)(SomeError.someThrowable)
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = CanCatch[Id].catchNonFatalEither(fa)(SomeError.someThrowable)
 
       actual ==== expected
     }
@@ -410,7 +479,7 @@ object CanCatchSpec extends Properties {
     def testCanCatch_Id_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      lazy val fa = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      lazy val fa        = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
       try {
         val actual = CanCatch[Id].catchNonFatalEither(fa)(SomeError.someThrowable)
@@ -427,9 +496,9 @@ object CanCatchSpec extends Properties {
 
     def testCanCatch_Id_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[Id, Either[SomeError, Int]](1.asRight[SomeError])
+      val fa       = run[Id, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
-      val actual = CanCatch[Id].catchNonFatalEither(fa)(SomeError.someThrowable)
+      val actual   = CanCatch[Id].catchNonFatalEither(fa)(SomeError.someThrowable)
 
       actual ==== expected
     }
@@ -437,20 +506,19 @@ object CanCatchSpec extends Properties {
     def testCanCatch_Id_catchNonFatalEitherShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
-      val expected = expectedFailure.asLeft[Int]
-      val actual = CanCatch[Id].catchNonFatalEither(fa)(SomeError.someThrowable)
+      val fa              = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanCatch[Id].catchNonFatalEither(fa)(SomeError.someThrowable)
 
       actual ==== expected
     }
 
-
     def testCanCatch_Id_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = CanCatch[Id].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
+      lazy val fa           = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = CanCatch[Id].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
 
       actual ==== expected
     }
@@ -458,7 +526,7 @@ object CanCatchSpec extends Properties {
     def testCanCatch_Id_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      lazy val fa        = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual = CanCatch[Id].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
@@ -475,9 +543,9 @@ object CanCatchSpec extends Properties {
 
     def testCanCatch_Id_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
 
-      val fa = EitherT(run[Id, Either[SomeError, Int]](1.asRight[SomeError]))
+      val fa       = EitherT(run[Id, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
-      val actual = CanCatch[Id].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
+      val actual   = CanCatch[Id].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
 
       actual ==== expected
     }
@@ -485,9 +553,9 @@ object CanCatchSpec extends Properties {
     def testCanCatch_Id_catchNonFatalEitherTShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = EitherT(run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
-      val expected = expectedFailure.asLeft[Int]
-      val actual = CanCatch[Id].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
+      val fa              = EitherT(run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanCatch[Id].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
 
       actual ==== expected
     }

--- a/cats-effect/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
@@ -12,97 +12,256 @@ import hedgehog.runner._
 
 import scala.util.control.{ControlThrowable, NonFatal}
 
-/**
- * @author Kevin Lee
- * @since 2020-08-17
- */
+/** @author Kevin Lee
+  * @since 2020-08-17
+  */
 object CanHandleErrorSpec extends Properties {
 
   override def tests: List[Test] = List(
     /* IO */
-    example("test CanHandleError[IO].handleNonFatalWith should handle NonFatal", IoSpec.testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith),
-    example("test CanHandleError[IO].handleNonFatalWith should not handle Fatal", IoSpec.testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith),
-    example("test CanHandleError[IO].handleNonFatalWith should return the successful result", IoSpec.testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult),
-
-    example("test CanHandleError[IO].handleNonFatalWithEither should handle NonFatal", IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith),
-    example("test CanHandleError[IO].handleNonFatalWithEither should not handle Fatal", IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith),
-    example("test CanHandleError[IO].handleNonFatalWithEither should return the successful result", IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult),
-    example("test CanHandleError[IO].handleNonFatalWithEither should return the failed result", IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult),
-
-    example("test CanHandleError[IO].handleEitherTNonFatalWith should handle NonFatal", IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith),
-    example("test CanHandleError[IO].handleEitherTNonFatalWith should not handle Fatal", IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith),
-    example("test CanHandleError[IO].handleEitherTNonFatalWith should return the successful result", IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult),
-    example("test CanHandleError[IO].handleEitherTNonFatalWith should return the failed result", IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult),
-
-    example("test CanHandleError[IO].handleNonFatal should handle NonFatal", IoSpec.testCanHandleError_IO_handleNonFatalShouldHandleNonFatal),
-    example("test CanHandleError[IO].handleNonFatal should not handle Fatal", IoSpec.testCanHandleError_IO_handleNonFatalShouldNotHandleFatal),
-    example("test CanHandleError[IO].handleNonFatal should return the successful result", IoSpec.testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult),
-
-    example("test CanHandleError[IO].handleNonFatalEither should handle NonFatal", IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal),
-    example("test CanHandleError[IO].handleNonFatalEither should not handle Fatal", IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal),
-    example("test CanHandleError[IO].handleNonFatalEither should return the successful result", IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult),
-    example("test CanHandleError[IO].handleNonFatalEither should return the failed result", IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult),
-
-    example("test CanHandleError[IO].handleEitherTNonFatal should handle NonFatal", IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal),
-    example("test CanHandleError[IO].handleEitherTNonFatal should not handle Fatal", IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal),
-    example("test CanHandleError[IO].handleEitherTNonFatal should return the successful result", IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult),
-    example("test CanHandleError[IO].handleEitherTNonFatal should return the failed result", IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult),
-
+    example(
+      "test CanHandleError[IO].handleNonFatalWith should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalWith should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalWith should return the successful result",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalWithEither should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalWithEither should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalWithEither should return the successful result",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalWithEither should return the failed result",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatalWith should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatalWith should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatalWith should return the successful result",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatalWith should return the failed result",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatal should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalShouldHandleNonFatal
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatal should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalShouldNotHandleFatal
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatal should return the successful result",
+      IoSpec.testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalEither should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalEither should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalEither should return the successful result",
+      IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalEither should return the failed result",
+      IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatal should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatal should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatal should return the successful result",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatal should return the failed result",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult
+    ),
     /* Future */
 
-    example("test CanHandleError[Future].handleNonFatalWith should handle NonFatal", FutureSpec.testCanHandleError_Future_handleNonFatalWithShouldHandleNonFatalWith),
-    example("test CanHandleError[Future].handleNonFatalWith should return the successful result", FutureSpec.testCanHandleError_Future_handleNonFatalWithShouldReturnSuccessfulResult),
-
-    example("test CanHandleError[Future].handleNonFatalWithEither should handle NonFatal", FutureSpec.testCanHandleError_Future_handleNonFatalWithEitherShouldHandleNonFatalWith),
-    example("test CanHandleError[Future].handleNonFatalWithEither should return the successful result", FutureSpec.testCanHandleError_Future_handleNonFatalWithEitherShouldReturnSuccessfulResult),
-    example("test CanHandleError[Future].handleNonFatalWithEither should return the failed result", FutureSpec.testCanHandleError_Future_handleNonFatalWithEitherShouldReturnFailedResult),
-
-    example("test CanHandleError[Future].handleEitherTNonFatalWith should handle NonFatal", FutureSpec.testCanHandleError_Future_handleEitherTNonFatalWithShouldHandleNonFatalWith),
-    example("test CanHandleError[Future].handleEitherTNonFatalWith should return the successful result", FutureSpec.testCanHandleError_Future_handleEitherTNonFatalWithShouldReturnSuccessfulResult),
-    example("test CanHandleError[Future].handleEitherTNonFatalWith should return the failed result", FutureSpec.testCanHandleError_Future_handleEitherTNonFatalWithShouldReturnFailedResult),
-
-
-    example("test CanHandleError[Future].handleNonFatal should handle NonFatal", FutureSpec.testCanHandleError_Future_handleNonFatalShouldHandleNonFatal),
-    example("test CanHandleError[Future].handleNonFatal should return the successful result", FutureSpec.testCanHandleError_Future_handleNonFatalShouldReturnSuccessfulResult),
-
-    example("test CanHandleError[Future].handleNonFatalEither should handle NonFatal", FutureSpec.testCanHandleError_Future_handleNonFatalEitherShouldHandleNonFatal),
-    example("test CanHandleError[Future].handleNonFatalEither should return the successful result", FutureSpec.testCanHandleError_Future_handleNonFatalEitherShouldReturnSuccessfulResult),
-    example("test CanHandleError[Future].handleNonFatalEither should return the failed result", FutureSpec.testCanHandleError_Future_handleNonFatalEitherShouldReturnFailedResult),
-
-    example("test CanHandleError[Future].handleEitherTNonFatal should handle NonFatal", FutureSpec.testCanHandleError_Future_handleEitherTNonFatalShouldHandleNonFatal),
-    example("test CanHandleError[Future].handleEitherTNonFatal should return the successful result", FutureSpec.testCanHandleError_Future_handleEitherTNonFatalShouldReturnSuccessfulResult),
-    example("test CanHandleError[Future].handleEitherTNonFatal should return the failed result", FutureSpec.testCanHandleError_Future_handleEitherTNonFatalShouldReturnFailedResult),
-
-
+    example(
+      "test CanHandleError[Future].handleNonFatalWith should handle NonFatal",
+      FutureSpec.testCanHandleError_Future_handleNonFatalWithShouldHandleNonFatalWith
+    ),
+    example(
+      "test CanHandleError[Future].handleNonFatalWith should return the successful result",
+      FutureSpec.testCanHandleError_Future_handleNonFatalWithShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[Future].handleNonFatalWithEither should handle NonFatal",
+      FutureSpec.testCanHandleError_Future_handleNonFatalWithEitherShouldHandleNonFatalWith
+    ),
+    example(
+      "test CanHandleError[Future].handleNonFatalWithEither should return the successful result",
+      FutureSpec.testCanHandleError_Future_handleNonFatalWithEitherShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[Future].handleNonFatalWithEither should return the failed result",
+      FutureSpec.testCanHandleError_Future_handleNonFatalWithEitherShouldReturnFailedResult
+    ),
+    example(
+      "test CanHandleError[Future].handleEitherTNonFatalWith should handle NonFatal",
+      FutureSpec.testCanHandleError_Future_handleEitherTNonFatalWithShouldHandleNonFatalWith
+    ),
+    example(
+      "test CanHandleError[Future].handleEitherTNonFatalWith should return the successful result",
+      FutureSpec.testCanHandleError_Future_handleEitherTNonFatalWithShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[Future].handleEitherTNonFatalWith should return the failed result",
+      FutureSpec.testCanHandleError_Future_handleEitherTNonFatalWithShouldReturnFailedResult
+    ),
+    example(
+      "test CanHandleError[Future].handleNonFatal should handle NonFatal",
+      FutureSpec.testCanHandleError_Future_handleNonFatalShouldHandleNonFatal
+    ),
+    example(
+      "test CanHandleError[Future].handleNonFatal should return the successful result",
+      FutureSpec.testCanHandleError_Future_handleNonFatalShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[Future].handleNonFatalEither should handle NonFatal",
+      FutureSpec.testCanHandleError_Future_handleNonFatalEitherShouldHandleNonFatal
+    ),
+    example(
+      "test CanHandleError[Future].handleNonFatalEither should return the successful result",
+      FutureSpec.testCanHandleError_Future_handleNonFatalEitherShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[Future].handleNonFatalEither should return the failed result",
+      FutureSpec.testCanHandleError_Future_handleNonFatalEitherShouldReturnFailedResult
+    ),
+    example(
+      "test CanHandleError[Future].handleEitherTNonFatal should handle NonFatal",
+      FutureSpec.testCanHandleError_Future_handleEitherTNonFatalShouldHandleNonFatal
+    ),
+    example(
+      "test CanHandleError[Future].handleEitherTNonFatal should return the successful result",
+      FutureSpec.testCanHandleError_Future_handleEitherTNonFatalShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[Future].handleEitherTNonFatal should return the failed result",
+      FutureSpec.testCanHandleError_Future_handleEitherTNonFatalShouldReturnFailedResult
+    ),
     /* Id */
-    example("test CanHandleError[Id].handleNonFatalWith should handle NonFatal", IdSpec.testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith),
-    example("test CanHandleError[Id].handleNonFatalWith should not handle Fatal", IdSpec.testCanHandleError_Id_handleNonFatalWithShouldNotHandleFatalWith),
-    example("test CanHandleError[Id].handleNonFatalWith should return the successful result", IdSpec.testCanHandleError_Id_handleNonFatalWithShouldReturnSuccessfulResult),
-
-    example("test CanHandleError[Id].handleNonFatalWithEither should handle NonFatal", IdSpec.testCanHandleError_Id_handleNonFatalWithEitherShouldHandleNonFatalWith),
-    example("test CanHandleError[Id].handleNonFatalWithEither should not handle Fatal", IdSpec.testCanHandleError_Id_handleNonFatalWithEitherShouldNotHandleFatalWith),
-    example("test CanHandleError[Id].handleNonFatalWithEither should return the successful result", IdSpec.testCanHandleError_Id_handleNonFatalWithEitherShouldReturnSuccessfulResult),
-    example("test CanHandleError[Id].handleNonFatalWithEither should return the failed result", IdSpec.testCanHandleError_Id_handleNonFatalWithEitherShouldReturnFailedResult),
-
-    example("test CanHandleError[Id].handleEitherTNonFatalWith should handle NonFatal", IdSpec.testCanHandleError_Id_handleEitherTNonFatalWithShouldHandleNonFatalWith),
-    example("test CanHandleError[Id].handleEitherTNonFatalWith should not handle Fatal", IdSpec.testCanHandleError_Id_handleEitherTNonFatalWithShouldNotHandleFatalWith),
-    example("test CanHandleError[Id].handleEitherTNonFatalWith should return the successful result", IdSpec.testCanHandleError_Id_handleEitherTNonFatalWithShouldReturnSuccessfulResult),
-    example("test CanHandleError[Id].handleEitherTNonFatalWith should return the failed result", IdSpec.testCanHandleError_Id_handleEitherTNonFatalWithShouldReturnFailedResult),
-
-    example("test CanHandleError[Id].handleNonFatal should handle NonFatal", IdSpec.testCanHandleError_Id_handleNonFatalShouldHandleNonFatal),
-    example("test CanHandleError[Id].handleNonFatal should not handle Fatal", IdSpec.testCanHandleError_Id_handleNonFatalShouldNotHandleFatal),
-    example("test CanHandleError[Id].handleNonFatal should return the successful result", IdSpec.testCanHandleError_Id_handleNonFatalShouldReturnSuccessfulResult),
-
-    example("test CanHandleError[Id].handleNonFatalEither should handle NonFatal", IdSpec.testCanHandleError_Id_handleNonFatalEitherShouldHandleNonFatal),
-    example("test CanHandleError[Id].handleNonFatalEither should not handle Fatal", IdSpec.testCanHandleError_Id_handleNonFatalEitherShouldNotHandleFatal),
-    example("test CanHandleError[Id].handleNonFatalEither should return the successful result", IdSpec.testCanHandleError_Id_handleNonFatalEitherShouldReturnSuccessfulResult),
-    example("test CanHandleError[Id].handleNonFatalEither should return the failed result", IdSpec.testCanHandleError_Id_handleNonFatalEitherShouldReturnFailedResult),
-
-    example("test CanHandleError[Id].handleEitherTNonFatal should handle NonFatal", IdSpec.testCanHandleError_Id_handleEitherTNonFatalShouldHandleNonFatal),
-    example("test CanHandleError[Id].handleEitherTNonFatal should not handle Fatal", IdSpec.testCanHandleError_Id_handleEitherTNonFatalShouldNotHandleFatal),
-    example("test CanHandleError[Id].handleEitherTNonFatal should return the successful result", IdSpec.testCanHandleError_Id_handleEitherTNonFatalShouldReturnSuccessfulResult),
-    example("test CanHandleError[Id].handleEitherTNonFatal should return the failed result", IdSpec.testCanHandleError_Id_handleEitherTNonFatalShouldReturnFailedResult)
-
+    example(
+      "test CanHandleError[Id].handleNonFatalWith should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalWith should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithShouldNotHandleFatalWith
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalWith should return the successful result",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalWithEither should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithEitherShouldHandleNonFatalWith
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalWithEither should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithEitherShouldNotHandleFatalWith
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalWithEither should return the successful result",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithEitherShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalWithEither should return the failed result",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithEitherShouldReturnFailedResult
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatalWith should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalWithShouldHandleNonFatalWith
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatalWith should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalWithShouldNotHandleFatalWith
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatalWith should return the successful result",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalWithShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatalWith should return the failed result",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalWithShouldReturnFailedResult
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatal should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalShouldHandleNonFatal
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatal should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalShouldNotHandleFatal
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatal should return the successful result",
+      IdSpec.testCanHandleError_Id_handleNonFatalShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalEither should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalEitherShouldHandleNonFatal
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalEither should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalEitherShouldNotHandleFatal
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalEither should return the successful result",
+      IdSpec.testCanHandleError_Id_handleNonFatalEitherShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalEither should return the failed result",
+      IdSpec.testCanHandleError_Id_handleNonFatalEitherShouldReturnFailedResult
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatal should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalShouldHandleNonFatal
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatal should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalShouldNotHandleFatal
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatal should return the successful result",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalShouldReturnSuccessfulResult
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatal should return the failed result",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalShouldReturnFailedResult
+    )
   )
 
   def throwThrowable[A](throwable: => Throwable): A =
@@ -111,16 +270,13 @@ object CanHandleErrorSpec extends Properties {
   def run[F[_]: EffectConstructor: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
-  sealed trait SomeError
+  enum SomeError   {
+    case SomeThrowable(throwable: Throwable)
+    case Message(message: String)
+  }
   object SomeError {
-
-    final case class SomeThrowable(throwable: Throwable) extends SomeError
-    final case class Message(message: String) extends SomeError
-
-    def someThrowable(throwable: Throwable): SomeError = SomeThrowable(throwable)
-
-    def message(message: String): SomeError = Message(message)
-
+    def someThrowable(throwable: Throwable): SomeError = SomeError.SomeThrowable(throwable)
+    def message(message: String): SomeError            = SomeError.Message(message)
   }
 
   object IoSpec {
@@ -128,12 +284,14 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[IO, Int](throwThrowable[Int](expectedExpcetion))
-      val expected = 123
-      val actual = CanHandleError[IO].handleNonFatalWith(fa) {
-        case NonFatal(`expectedExpcetion`) =>
-          IO.pure(expected)
-      }.unsafeRunSync()
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 123
+      val actual            = CanHandleError[IO]
+        .handleNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) =>
+            IO.pure(expected)
+        }
+        .unsafeRunSync()
 
       actual ==== expected
     }
@@ -141,7 +299,7 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      val fa = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
       try {
         val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
@@ -158,23 +316,24 @@ object CanHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[IO, Int](1)
+      val fa       = run[IO, Int](1)
       val expected = 1
-      val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(999)).unsafeRunSync()
+      val actual   = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(999)).unsafeRunSync()
 
       actual ==== expected
     }
 
-
     def testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = {
 
-      val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion    = new RuntimeException("Something's wrong")
+      val fa                   = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
-      val actualFailedResult = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(expectedFailedResult)).unsafeRunSync()
+      val actualFailedResult   =
+        CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(expectedFailedResult)).unsafeRunSync()
 
       val expectedSuccessResult = 1.asRight[SomeError]
-      val actualSuccessResult = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(1.asRight[SomeError])).unsafeRunSync()
+      val actualSuccessResult   =
+        CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(1.asRight[SomeError])).unsafeRunSync()
 
       actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
     }
@@ -182,10 +341,10 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
       try {
-        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_  => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
@@ -199,9 +358,9 @@ object CanHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
-      val actual = CanHandleError[IO].handleNonFatalWith(fa)(_  => IO(999.asRight[SomeError])).unsafeRunSync()
+      val actual   = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO(999.asRight[SomeError])).unsafeRunSync()
 
       actual ==== expected
     }
@@ -209,22 +368,25 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
-      val expected = expectedFailure.asLeft[Int]
-      val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
 
       actual ==== expected
     }
 
-
     def testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = {
 
-      val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actualFailedResult = CanHandleError[IO].handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int])).value.unsafeRunSync()
+      val expectedExpcetion     = new RuntimeException("Something's wrong")
+      val fa                    = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult    = CanHandleError[IO]
+        .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+        .value
+        .unsafeRunSync()
       val expectedSuccessResult = 123.asRight[SomeError]
-      val actualSuccessResult = CanHandleError[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
+      val actualSuccessResult   =
+        CanHandleError[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
 
       actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
     }
@@ -232,13 +394,14 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fa             = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual =
-          CanHandleError[IO].handleEitherTNonFatalWith(fa)(
-            err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-          ).value.unsafeRunSync()
+          CanHandleError[IO]
+            .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+            .value
+            .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -252,9 +415,10 @@ object CanHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result = {
 
-      val fa = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
-      val actual = CanHandleError[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
+      val actual   =
+        CanHandleError[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
 
       actual ==== expected
     }
@@ -262,9 +426,9 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
-      val expected = expectedFailure.asLeft[Int]
-      val actual =
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
         CanHandleError[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
 
       actual ==== expected
@@ -273,12 +437,14 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_IO_handleNonFatalShouldHandleNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[IO, Int](throwThrowable[Int](expectedExpcetion))
-      val expected = 123
-      val actual = CanHandleError[IO].handleNonFatal(fa) {
-        case NonFatal(`expectedExpcetion`) =>
-          expected
-      }.unsafeRunSync()
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 123
+      val actual            = CanHandleError[IO]
+        .handleNonFatal(fa) {
+          case NonFatal(`expectedExpcetion`) =>
+            expected
+        }
+        .unsafeRunSync()
 
       actual ==== expected
     }
@@ -286,7 +452,7 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      val fa = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
       try {
         val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
@@ -303,23 +469,22 @@ object CanHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[IO, Int](1)
+      val fa       = run[IO, Int](1)
       val expected = 1
-      val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 999).unsafeRunSync()
+      val actual   = CanHandleError[IO].handleNonFatal(fa)(_ => 999).unsafeRunSync()
 
       actual ==== expected
     }
 
-
     def testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal: Result = {
 
-      val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion    = new RuntimeException("Something's wrong")
+      val fa                   = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
-      val actualFailedResult = CanHandleError[IO].handleNonFatal(fa)(_ => expectedFailedResult).unsafeRunSync()
+      val actualFailedResult   = CanHandleError[IO].handleNonFatal(fa)(_ => expectedFailedResult).unsafeRunSync()
 
       val expectedSuccessResult = 1.asRight[SomeError]
-      val actualSuccessResult = CanHandleError[IO].handleNonFatal(fa)(_ => 1.asRight[SomeError]).unsafeRunSync()
+      val actualSuccessResult   = CanHandleError[IO].handleNonFatal(fa)(_ => 1.asRight[SomeError]).unsafeRunSync()
 
       actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
     }
@@ -327,10 +492,10 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
       try {
-        val actual = CanHandleError[IO].handleNonFatal(fa)(_  => 123.asRight[SomeError]).unsafeRunSync()
+        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -344,9 +509,9 @@ object CanHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
-      val actual = CanHandleError[IO].handleNonFatal(fa)(_  => 999.asRight[SomeError]).unsafeRunSync()
+      val actual   = CanHandleError[IO].handleNonFatal(fa)(_ => 999.asRight[SomeError]).unsafeRunSync()
 
       actual ==== expected
     }
@@ -354,22 +519,25 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
-      val expected = expectedFailure.asLeft[Int]
-      val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
 
       actual ==== expected
     }
 
-
     def testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal: Result = {
 
-      val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actualFailedResult = CanHandleError[IO].handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value.unsafeRunSync()
+      val expectedExpcetion     = new RuntimeException("Something's wrong")
+      val fa                    = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult    = CanHandleError[IO]
+        .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+        .value
+        .unsafeRunSync()
       val expectedSuccessResult = 123.asRight[SomeError]
-      val actualSuccessResult = CanHandleError[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
+      val actualSuccessResult   =
+        CanHandleError[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
 
       actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
     }
@@ -377,13 +545,14 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fa             = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual =
-          CanHandleError[IO].handleEitherTNonFatal(fa)(
-            err => SomeError.someThrowable(err).asLeft[Int]
-          ).value.unsafeRunSync()
+          CanHandleError[IO]
+            .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+            .value
+            .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -397,9 +566,9 @@ object CanHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = {
 
-      val fa = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
-      val actual = CanHandleError[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
+      val actual   = CanHandleError[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
 
       actual ==== expected
     }
@@ -407,16 +576,15 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
-      val expected = expectedFailure.asLeft[Int]
-      val actual =
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
         CanHandleError[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
 
       actual ==== expected
     }
 
   }
-
 
   object FutureSpec {
     import java.util.concurrent.{ExecutorService, Executors}
@@ -428,12 +596,12 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Future_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[Future, Int](throwThrowable[Int](expectedExpcetion))
-      val expected = 1
-      val actual = ConcurrentSupport.futureToValueAndTerminate[Int](
+      val fa                = run[Future, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 1
+      val actual            = ConcurrentSupport.futureToValueAndTerminate[Int](
         CanHandleError[Future].handleNonFatalWith(fa)(_ => Future(expected)),
         waitFor
       )
@@ -444,11 +612,11 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Future_handleNonFatalWithShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val fa = run[Future, Int](1)
+      val fa       = run[Future, Int](1)
       val expected = 1
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         CanHandleError[Future].handleNonFatalWith(fa)(_ => Future(123)),
         waitFor
       )
@@ -456,24 +624,23 @@ object CanHandleErrorSpec extends Properties {
       actual ==== expected
     }
 
-
     def testCanHandleError_Future_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion    = new RuntimeException("Something's wrong")
+      val fa                   = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actualFailedResult =
+      val actualFailedResult   =
         ConcurrentSupport.futureToValue(
           CanHandleError[Future].handleNonFatalWith(fa)(err => Future(SomeError.someThrowable(err).asLeft[Int])),
           waitFor
         )
 
-      val fa2 = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val fa2      = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expected = 1.asRight[SomeError]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         CanHandleError[Future].handleNonFatalWith(fa2)(_ => Future(expected)),
         waitFor
       )
@@ -484,11 +651,11 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Future_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val fa = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
+      val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
-      val actual =
+      val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
           CanHandleError[Future].handleNonFatalWith(fa)(err => Future(SomeError.someThrowable(err).asLeft[Int])),
           waitFor
@@ -500,12 +667,12 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Future_handleNonFatalWithEitherShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
-      val expected = expectedFailure.asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = ConcurrentSupport.futureToValueAndTerminate(
         CanHandleError[Future].handleNonFatalWith(fa)(_ => Future(1.asRight[SomeError])),
         waitFor
       )
@@ -513,25 +680,24 @@ object CanHandleErrorSpec extends Properties {
       actual ==== expected
     }
 
-
     def testCanHandleError_Future_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion    = new RuntimeException("Something's wrong")
+      val fa                   = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actualFailedResult = ConcurrentSupport.futureToValue(
-        CanHandleError[Future].handleEitherTNonFatalWith(fa)(err =>
-            Future(SomeError.someThrowable(err).asLeft[Int])
-        ).value,
+      val actualFailedResult   = ConcurrentSupport.futureToValue(
+        CanHandleError[Future]
+          .handleEitherTNonFatalWith(fa)(err => Future(SomeError.someThrowable(err).asLeft[Int]))
+          .value,
         waitFor
       )
 
-      val fa2 = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val fa2      = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expected = 1.asRight[SomeError]
-      val actual =
+      val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
           CanHandleError[Future].handleEitherTNonFatalWith(fa2)(err => Future(expected)).value,
           waitFor
@@ -543,14 +709,14 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Future_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val fa = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
+      val fa       = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
-        CanHandleError[Future].handleEitherTNonFatalWith(fa)(err =>
-            Future(SomeError.someThrowable(err).asLeft[Int])
-        ).value,
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
+        CanHandleError[Future]
+          .handleEitherTNonFatalWith(fa)(err => Future(SomeError.someThrowable(err).asLeft[Int]))
+          .value,
         waitFor
       )
 
@@ -560,12 +726,12 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Future_handleEitherTNonFatalWithShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
-      val expected = expectedFailure.asLeft[Int]
-      val actual =
+      val fa              = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
         ConcurrentSupport.futureToValueAndTerminate(
           CanHandleError[Future].handleEitherTNonFatalWith(fa)(_ => Future(expected)).value,
           waitFor
@@ -574,16 +740,15 @@ object CanHandleErrorSpec extends Properties {
       actual ==== expected
     }
 
-
     def testCanHandleError_Future_handleNonFatalShouldHandleNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[Future, Int](throwThrowable[Int](expectedExpcetion))
-      val expected = 1
-      val actual = ConcurrentSupport.futureToValueAndTerminate[Int](
+      val fa                = run[Future, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 1
+      val actual            = ConcurrentSupport.futureToValueAndTerminate[Int](
         CanHandleError[Future].handleNonFatal(fa)(_ => expected),
         waitFor
       )
@@ -594,11 +759,11 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Future_handleNonFatalShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val fa = run[Future, Int](1)
+      val fa       = run[Future, Int](1)
       val expected = 1
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         CanHandleError[Future].handleNonFatal(fa)(_ => 123),
         waitFor
       )
@@ -606,24 +771,23 @@ object CanHandleErrorSpec extends Properties {
       actual ==== expected
     }
 
-
     def testCanHandleError_Future_handleNonFatalEitherShouldHandleNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion    = new RuntimeException("Something's wrong")
+      val fa                   = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actualFailedResult =
+      val actualFailedResult   =
         ConcurrentSupport.futureToValue(
           CanHandleError[Future].handleNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]),
           waitFor
         )
 
-      val fa2 = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val fa2      = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expected = 1.asRight[SomeError]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         CanHandleError[Future].handleNonFatal(fa2)(_ => expected),
         waitFor
       )
@@ -634,11 +798,11 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Future_handleNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val fa = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
+      val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
-      val actual =
+      val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
           CanHandleError[Future].handleNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]),
           waitFor
@@ -650,12 +814,12 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Future_handleNonFatalEitherShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
-      val expected = expectedFailure.asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = ConcurrentSupport.futureToValueAndTerminate(
         CanHandleError[Future].handleNonFatal(fa)(_ => 1.asRight[SomeError]),
         waitFor
       )
@@ -663,25 +827,22 @@ object CanHandleErrorSpec extends Properties {
       actual ==== expected
     }
 
-
     def testCanHandleError_Future_handleEitherTNonFatalShouldHandleNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion    = new RuntimeException("Something's wrong")
+      val fa                   = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actualFailedResult = ConcurrentSupport.futureToValue(
-        CanHandleError[Future].handleEitherTNonFatal(fa)(err =>
-          SomeError.someThrowable(err).asLeft[Int]
-        ).value,
+      val actualFailedResult   = ConcurrentSupport.futureToValue(
+        CanHandleError[Future].handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value,
         waitFor
       )
 
-      val fa2 = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val fa2      = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expected = 1.asRight[SomeError]
-      val actual =
+      val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
           CanHandleError[Future].handleEitherTNonFatal(fa2)(err => expected).value,
           waitFor
@@ -693,14 +854,12 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Future_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val fa = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
+      val fa       = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
-        CanHandleError[Future].handleEitherTNonFatal(fa)(err =>
-          SomeError.someThrowable(err).asLeft[Int]
-        ).value,
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
+        CanHandleError[Future].handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value,
         waitFor
       )
 
@@ -710,12 +869,12 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Future_handleEitherTNonFatalShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
-      val expected = expectedFailure.asLeft[Int]
-      val actual =
+      val fa              = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
         ConcurrentSupport.futureToValueAndTerminate(
           CanHandleError[Future].handleEitherTNonFatal(fa)(_ => expected).value,
           waitFor
@@ -726,15 +885,14 @@ object CanHandleErrorSpec extends Properties {
 
   }
 
-
   object IdSpec {
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa = run[Id, Int](throwThrowable[Int](expectedExpcetion))
-      val expected = 1
-      val actual: Id[Int] = CanHandleError[Id].handleNonFatalWith(fa)(_ => expected)
+      lazy val fa           = run[Id, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 1
+      val actual: Id[Int]   = CanHandleError[Id].handleNonFatalWith(fa)(_ => expected)
 
       actual ==== expected
     }
@@ -742,7 +900,7 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Id_handleNonFatalWithShouldNotHandleFatalWith: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      lazy val fa = run[Id, Int](throwThrowable[Int](fatalExpcetion))
+      lazy val fa        = run[Id, Int](throwThrowable[Int](fatalExpcetion))
 
       try {
         val actual: Id[Int] = CanHandleError[Id].handleNonFatalWith(fa)(_ => 1)
@@ -759,24 +917,24 @@ object CanHandleErrorSpec extends Properties {
 
     def testCanHandleError_Id_handleNonFatalWithShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[Id, Int](1)
-      val expected = 1
+      val fa              = run[Id, Int](1)
+      val expected        = 1
       val actual: Id[Int] = CanHandleError[Id].handleNonFatalWith(fa)(_ => 123)
 
       actual ==== expected
     }
 
-
     def testCanHandleError_Id_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = {
 
-      val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion    = new RuntimeException("Something's wrong")
+      lazy val fa              = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actualFailedResult = CanHandleError[Id].handleNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+      val actualFailedResult   =
+        CanHandleError[Id].handleNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int])
 
       lazy val fa2 = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expected = 1.asRight[SomeError]
-      val actual = CanHandleError[Id].handleNonFatalWith(fa2)(_ => expected)
+      val actual   = CanHandleError[Id].handleNonFatalWith(fa2)(_ => expected)
 
       actualFailedResult ==== expectedFailedResult and actual ==== expected
     }
@@ -784,7 +942,7 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Id_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      lazy val fa = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      lazy val fa        = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
       try {
         val actual = CanHandleError[Id].handleNonFatalWith(fa)(_ => 1.asRight[SomeError])
@@ -801,9 +959,9 @@ object CanHandleErrorSpec extends Properties {
 
     def testCanHandleError_Id_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[Id, Either[SomeError, Int]](1.asRight[SomeError])
+      val fa       = run[Id, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
-      val actual = CanHandleError[Id].handleNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+      val actual   = CanHandleError[Id].handleNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int])
 
       actual ==== expected
     }
@@ -811,24 +969,24 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Id_handleNonFatalWithEitherShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
-      val expected = expectedFailure.asLeft[Int]
-      val actual = CanHandleError[Id].handleNonFatalWith(fa)(_ => 1.asRight[SomeError])
+      val fa              = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[Id].handleNonFatalWith(fa)(_ => 1.asRight[SomeError])
 
       actual ==== expected
     }
 
-
     def testCanHandleError_Id_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = {
 
-      val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion    = new RuntimeException("Something's wrong")
+      lazy val fa              = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actualFailedResult = CanHandleError[Id].handleEitherTNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value
+      val actualFailedResult   =
+        CanHandleError[Id].handleEitherTNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value
 
       lazy val fa2 = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expected = 1.asRight[SomeError]
-      val actual = CanHandleError[Id].handleEitherTNonFatalWith(fa2)(_ => expected).value
+      val actual   = CanHandleError[Id].handleEitherTNonFatalWith(fa2)(_ => expected).value
 
       actualFailedResult ==== expectedFailedResult and actual ==== expected
     }
@@ -836,7 +994,7 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Id_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      lazy val fa        = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual = CanHandleError[Id].handleEitherTNonFatalWith(fa)(_ => 1.asRight[SomeError]).value
@@ -853,9 +1011,10 @@ object CanHandleErrorSpec extends Properties {
 
     def testCanHandleError_Id_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result = {
 
-      val fa = EitherT(run[Id, Either[SomeError, Int]](1.asRight[SomeError]))
+      val fa       = EitherT(run[Id, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
-      val actual = CanHandleError[Id].handleEitherTNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value
+      val actual   =
+        CanHandleError[Id].handleEitherTNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value
 
       actual ==== expected
     }
@@ -863,9 +1022,9 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Id_handleEitherTNonFatalWithShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = EitherT(run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
-      val expected = expectedFailure.asLeft[Int]
-      val actual = CanHandleError[Id].handleEitherTNonFatalWith(fa)(_ => 1.asRight[SomeError]).value
+      val fa              = EitherT(run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[Id].handleEitherTNonFatalWith(fa)(_ => 1.asRight[SomeError]).value
 
       actual ==== expected
     }
@@ -873,9 +1032,9 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Id_handleNonFatalShouldHandleNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa = run[Id, Int](throwThrowable[Int](expectedExpcetion))
-      val expected = 1
-      val actual: Id[Int] = CanHandleError[Id].handleNonFatal(fa)(_ => expected)
+      lazy val fa           = run[Id, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 1
+      val actual: Id[Int]   = CanHandleError[Id].handleNonFatal(fa)(_ => expected)
 
       actual ==== expected
     }
@@ -883,7 +1042,7 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Id_handleNonFatalShouldNotHandleFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      lazy val fa = run[Id, Int](throwThrowable[Int](fatalExpcetion))
+      lazy val fa        = run[Id, Int](throwThrowable[Int](fatalExpcetion))
 
       try {
         val actual: Id[Int] = CanHandleError[Id].handleNonFatal(fa)(_ => 1)
@@ -900,24 +1059,23 @@ object CanHandleErrorSpec extends Properties {
 
     def testCanHandleError_Id_handleNonFatalShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[Id, Int](1)
-      val expected = 1
+      val fa              = run[Id, Int](1)
+      val expected        = 1
       val actual: Id[Int] = CanHandleError[Id].handleNonFatal(fa)(_ => 123)
 
       actual ==== expected
     }
 
-
     def testCanHandleError_Id_handleNonFatalEitherShouldHandleNonFatal: Result = {
 
-      val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion    = new RuntimeException("Something's wrong")
+      lazy val fa              = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actualFailedResult = CanHandleError[Id].handleNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+      val actualFailedResult   = CanHandleError[Id].handleNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
 
       lazy val fa2 = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expected = 1.asRight[SomeError]
-      val actual = CanHandleError[Id].handleNonFatal(fa2)(_ => expected)
+      val actual   = CanHandleError[Id].handleNonFatal(fa2)(_ => expected)
 
       actualFailedResult ==== expectedFailedResult and actual ==== expected
     }
@@ -925,7 +1083,7 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Id_handleNonFatalEitherShouldNotHandleFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      lazy val fa = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      lazy val fa        = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
       try {
         val actual = CanHandleError[Id].handleNonFatal(fa)(_ => 1.asRight[SomeError])
@@ -942,9 +1100,9 @@ object CanHandleErrorSpec extends Properties {
 
     def testCanHandleError_Id_handleNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[Id, Either[SomeError, Int]](1.asRight[SomeError])
+      val fa       = run[Id, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
-      val actual = CanHandleError[Id].handleNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+      val actual   = CanHandleError[Id].handleNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
 
       actual ==== expected
     }
@@ -952,24 +1110,24 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Id_handleNonFatalEitherShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
-      val expected = expectedFailure.asLeft[Int]
-      val actual = CanHandleError[Id].handleNonFatal(fa)(_ => 1.asRight[SomeError])
+      val fa              = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[Id].handleNonFatal(fa)(_ => 1.asRight[SomeError])
 
       actual ==== expected
     }
 
-
     def testCanHandleError_Id_handleEitherTNonFatalShouldHandleNonFatal: Result = {
 
-      val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion    = new RuntimeException("Something's wrong")
+      lazy val fa              = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actualFailedResult = CanHandleError[Id].handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value
+      val actualFailedResult   =
+        CanHandleError[Id].handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value
 
       lazy val fa2 = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expected = 1.asRight[SomeError]
-      val actual = CanHandleError[Id].handleEitherTNonFatal(fa2)(_ => expected).value
+      val actual   = CanHandleError[Id].handleEitherTNonFatal(fa2)(_ => expected).value
 
       actualFailedResult ==== expectedFailedResult and actual ==== expected
     }
@@ -977,7 +1135,7 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Id_handleEitherTNonFatalShouldNotHandleFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      lazy val fa        = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual = CanHandleError[Id].handleEitherTNonFatal(fa)(_ => 1.asRight[SomeError]).value
@@ -994,9 +1152,9 @@ object CanHandleErrorSpec extends Properties {
 
     def testCanHandleError_Id_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = {
 
-      val fa = EitherT(run[Id, Either[SomeError, Int]](1.asRight[SomeError]))
+      val fa       = EitherT(run[Id, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
-      val actual = CanHandleError[Id].handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value
+      val actual   = CanHandleError[Id].handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value
 
       actual ==== expected
     }
@@ -1004,9 +1162,9 @@ object CanHandleErrorSpec extends Properties {
     def testCanHandleError_Id_handleEitherTNonFatalShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = EitherT(run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
-      val expected = expectedFailure.asLeft[Int]
-      val actual = CanHandleError[Id].handleEitherTNonFatal(fa)(_ => 1.asRight[SomeError]).value
+      val fa              = EitherT(run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[Id].handleEitherTNonFatal(fa)(_ => 1.asRight[SomeError]).value
 
       actual ==== expected
     }

--- a/cats-effect/src/test/scala-3/effectie/cats/CanRecoverSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CanRecoverSpec.scala
@@ -114,16 +114,13 @@ object CanRecoverSpec extends Properties {
   def run[F[_]: EffectConstructor: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
-  sealed trait SomeError
+  enum SomeError {
+    case SomeThrowable(throwable: Throwable)
+    case Message(message: String)
+  }
   object SomeError {
-
-    final case class SomeThrowable(throwable: Throwable) extends SomeError
-    final case class Message(message: String) extends SomeError
-
     def someThrowable(throwable: Throwable): SomeError = SomeThrowable(throwable)
-
     def message(message: String): SomeError = Message(message)
-
   }
 
   object IOSpec {

--- a/cats-effect/src/test/scala-3/effectie/cats/CatchingSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CatchingSpec.scala
@@ -13,81 +13,212 @@ import hedgehog.runner._
 
 import scala.util.control.ControlThrowable
 
-/**
- * @author Kevin Lee
- * @since 2020-07-31
- */
+/** @author Kevin Lee
+  * @since 2020-07-31
+  */
 object CatchingSpec extends Properties {
 
   override def tests: List[Test] = List(
     /* IO */
-    example("test Catching.catchNonFatal[IO] should catch NonFatal", IoSpec.testCatching_IO_catchNonFatalShouldCatchNonFatal),
-    example("test Catching.catchNonFatal[IO] should not catch Fatal", IoSpec.testCatching_IO_catchNonFatalShouldNotCatchFatal),
-    example("test Catching.catchNonFatal[IO] should return the successful result", IoSpec.testCatching_IO_catchNonFatalShouldReturnSuccessfulResult),
-
-    example("test Catching.catchNonFatalF[IO] should catch NonFatal", IoSpec.testCatching_IO_catchNonFatalFShouldCatchNonFatal),
-    example("test Catching.catchNonFatalF[IO] should not catch Fatal", IoSpec.testCatching_IO_catchNonFatalFShouldNotCatchFatal),
-    example("test Catching.catchNonFatalF[IO] should return the successful result", IoSpec.testCatching_IO_catchNonFatalFShouldReturnSuccessfulResult),
-
-    example("test Catching.catchNonFatalEither[IO] should catch NonFatal", IoSpec.testCatching_IO_catchNonFatalEitherShouldCatchNonFatal),
-    example("test Catching.catchNonFatalEither[IO] should not catch Fatal", IoSpec.testCatching_IO_catchNonFatalEitherShouldNotCatchFatal),
-    example("test Catching.catchNonFatalEither[IO] should return the successful result", IoSpec.testCatching_IO_catchNonFatalEitherShouldReturnSuccessfulResult),
-    example("test Catching.catchNonFatalEither[IO] should return the failed result", IoSpec.testCatching_IO_catchNonFatalEitherShouldReturnFailedResult),
-
-    example("test Catching.catchNonFatalEitherF[IO] should catch NonFatal", IoSpec.testCatching_IO_catchNonFatalEitherFShouldCatchNonFatal),
-    example("test Catching.catchNonFatalEitherF[IO] should not catch Fatal", IoSpec.testCatching_IO_catchNonFatalEitherFShouldNotCatchFatal),
-    example("test Catching.catchNonFatalEitherF[IO] should return the successful result", IoSpec.testCatching_IO_catchNonFatalEitherFShouldReturnSuccessfulResult),
-    example("test Catching.catchNonFatalEitherF[IO] should return the failed result", IoSpec.testCatching_IO_catchNonFatalEitherFShouldReturnFailedResult),
-
-    example("test Catching.catchNonFatalEitherT[IO] should catch NonFatal", IoSpec.testCatching_IO_catchNonFatalEitherTShouldCatchNonFatal),
-    example("test Catching.catchNonFatalEitherT[IO] should not catch Fatal", IoSpec.testCatching_IO_catchNonFatalEitherTShouldNotCatchFatal),
-    example("test Catching.catchNonFatalEitherT[IO] should return the successful result", IoSpec.testCatching_IO_catchNonFatalEitherTShouldReturnSuccessfulResult),
-    example("test Catching.catchNonFatalEitherT[IO] should return the failed result", IoSpec.testCatching_IO_catchNonFatalEitherTShouldReturnFailedResult),
-
+    example(
+      "test Catching.catchNonFatal[IO] should catch NonFatal",
+      IoSpec.testCatching_IO_catchNonFatalShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatal[IO] should not catch Fatal",
+      IoSpec.testCatching_IO_catchNonFatalShouldNotCatchFatal
+    ),
+    example(
+      "test Catching.catchNonFatal[IO] should return the successful result",
+      IoSpec.testCatching_IO_catchNonFatalShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalF[IO] should catch NonFatal",
+      IoSpec.testCatching_IO_catchNonFatalFShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatalF[IO] should not catch Fatal",
+      IoSpec.testCatching_IO_catchNonFatalFShouldNotCatchFatal
+    ),
+    example(
+      "test Catching.catchNonFatalF[IO] should return the successful result",
+      IoSpec.testCatching_IO_catchNonFatalFShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalEither[IO] should catch NonFatal",
+      IoSpec.testCatching_IO_catchNonFatalEitherShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEither[IO] should not catch Fatal",
+      IoSpec.testCatching_IO_catchNonFatalEitherShouldNotCatchFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEither[IO] should return the successful result",
+      IoSpec.testCatching_IO_catchNonFatalEitherShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalEither[IO] should return the failed result",
+      IoSpec.testCatching_IO_catchNonFatalEitherShouldReturnFailedResult
+    ),
+    example(
+      "test Catching.catchNonFatalEitherF[IO] should catch NonFatal",
+      IoSpec.testCatching_IO_catchNonFatalEitherFShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEitherF[IO] should not catch Fatal",
+      IoSpec.testCatching_IO_catchNonFatalEitherFShouldNotCatchFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEitherF[IO] should return the successful result",
+      IoSpec.testCatching_IO_catchNonFatalEitherFShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalEitherF[IO] should return the failed result",
+      IoSpec.testCatching_IO_catchNonFatalEitherFShouldReturnFailedResult
+    ),
+    example(
+      "test Catching.catchNonFatalEitherT[IO] should catch NonFatal",
+      IoSpec.testCatching_IO_catchNonFatalEitherTShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEitherT[IO] should not catch Fatal",
+      IoSpec.testCatching_IO_catchNonFatalEitherTShouldNotCatchFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEitherT[IO] should return the successful result",
+      IoSpec.testCatching_IO_catchNonFatalEitherTShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalEitherT[IO] should return the failed result",
+      IoSpec.testCatching_IO_catchNonFatalEitherTShouldReturnFailedResult
+    ),
     /* Future */
 
-    example("test Catching.catchNonFatal[Future] should catch NonFatal", FutureSpec.testCatching_Future_catchNonFatalShouldCatchNonFatal),
-    example("test Catching.catchNonFatal[Future] should return the successful result", FutureSpec.testCatching_Future_catchNonFatalShouldReturnSuccessfulResult),
-
-    example("test Catching.catchNonFatalF[Future] should catch NonFatal", FutureSpec.testCatching_Future_catchNonFatalFShouldCatchNonFatal),
-    example("test Catching.catchNonFatalF[Future] should return the successful result", FutureSpec.testCatching_Future_catchNonFatalFShouldReturnSuccessfulResult),
-
-    example("test Catching.catchNonFatalEither[Future] should catch NonFatal", FutureSpec.testCatching_Future_catchNonFatalEitherShouldCatchNonFatal),
-    example("test Catching.catchNonFatalEither[Future] should return the successful result", FutureSpec.testCatching_Future_catchNonFatalEitherShouldReturnSuccessfulResult),
-    example("test Catching.catchNonFatalEither[Future] should return the failed result", FutureSpec.testCatching_Future_catchNonFatalEitherShouldReturnFailedResult),
-
-    example("test Catching.catchNonFatalEitherF[Future] should catch NonFatal", FutureSpec.testCatching_Future_catchNonFatalEitherFShouldCatchNonFatal),
-    example("test Catching.catchNonFatalEitherF[Future] should return the successful result", FutureSpec.testCatching_Future_catchNonFatalEitherFShouldReturnSuccessfulResult),
-    example("test Catching.catchNonFatalEitherF[Future] should return the failed result", FutureSpec.testCatching_Future_catchNonFatalEitherFShouldReturnFailedResult),
-
-    example("test Catching.catchNonFatalEitherT[Future] should catch NonFatal", FutureSpec.testCatching_Future_catchNonFatalEitherTShouldCatchNonFatal),
-    example("test Catching.catchNonFatalEitherT[Future] should return the successful result", FutureSpec.testCatching_Future_catchNonFatalEitherTShouldReturnSuccessfulResult),
-    example("test Catching.catchNonFatalEitherT[Future] should return the failed result", FutureSpec.testCatching_Future_catchNonFatalEitherTShouldReturnFailedResult),
-
-
+    example(
+      "test Catching.catchNonFatal[Future] should catch NonFatal",
+      FutureSpec.testCatching_Future_catchNonFatalShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatal[Future] should return the successful result",
+      FutureSpec.testCatching_Future_catchNonFatalShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalF[Future] should catch NonFatal",
+      FutureSpec.testCatching_Future_catchNonFatalFShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatalF[Future] should return the successful result",
+      FutureSpec.testCatching_Future_catchNonFatalFShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalEither[Future] should catch NonFatal",
+      FutureSpec.testCatching_Future_catchNonFatalEitherShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEither[Future] should return the successful result",
+      FutureSpec.testCatching_Future_catchNonFatalEitherShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalEither[Future] should return the failed result",
+      FutureSpec.testCatching_Future_catchNonFatalEitherShouldReturnFailedResult
+    ),
+    example(
+      "test Catching.catchNonFatalEitherF[Future] should catch NonFatal",
+      FutureSpec.testCatching_Future_catchNonFatalEitherFShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEitherF[Future] should return the successful result",
+      FutureSpec.testCatching_Future_catchNonFatalEitherFShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalEitherF[Future] should return the failed result",
+      FutureSpec.testCatching_Future_catchNonFatalEitherFShouldReturnFailedResult
+    ),
+    example(
+      "test Catching.catchNonFatalEitherT[Future] should catch NonFatal",
+      FutureSpec.testCatching_Future_catchNonFatalEitherTShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEitherT[Future] should return the successful result",
+      FutureSpec.testCatching_Future_catchNonFatalEitherTShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalEitherT[Future] should return the failed result",
+      FutureSpec.testCatching_Future_catchNonFatalEitherTShouldReturnFailedResult
+    ),
     /* Id */
-    example("test Catching.catchNonFatal[Id] should catch NonFatal", IdSpec.testCatching_Id_catchNonFatalShouldCatchNonFatal),
-    example("test Catching.catchNonFatal[Id] should not catch Fatal", IdSpec.testCatching_Id_catchNonFatalShouldNotCatchFatal),
-    example("test Catching.catchNonFatal[Id] should return the successful result", IdSpec.testCatching_Id_catchNonFatalShouldReturnSuccessfulResult),
-
-    example("test Catching.catchNonFatalF[Id] should catch NonFatal", IdSpec.testCatching_Id_catchNonFatalFShouldCatchNonFatal),
-    example("test Catching.catchNonFatalF[Id] should not catch Fatal", IdSpec.testCatching_Id_catchNonFatalFShouldNotCatchFatal),
-    example("test Catching.catchNonFatalF[Id] should return the successful result", IdSpec.testCatching_Id_catchNonFatalFShouldReturnSuccessfulResult),
-
-    example("test Catching.catchNonFatalEither[Id] should catch NonFatal", IdSpec.testCatching_Id_catchNonFatalEitherShouldCatchNonFatal),
-    example("test Catching.catchNonFatalEither[Id] should not catch Fatal", IdSpec.testCatching_Id_catchNonFatalEitherShouldNotCatchFatal),
-    example("test Catching.catchNonFatalEither[Id] should return the successful result", IdSpec.testCatching_Id_catchNonFatalEitherShouldReturnSuccessfulResult),
-    example("test Catching.catchNonFatalEither[Id] should return the failed result", IdSpec.testCatching_Id_catchNonFatalEitherShouldReturnFailedResult),
-
-    example("test Catching.catchNonFatalEitherF[Id] should catch NonFatal", IdSpec.testCatching_Id_catchNonFatalEitherFShouldCatchNonFatal),
-    example("test Catching.catchNonFatalEitherF[Id] should not catch Fatal", IdSpec.testCatching_Id_catchNonFatalEitherFShouldNotCatchFatal),
-    example("test Catching.catchNonFatalEitherF[Id] should return the successful result", IdSpec.testCatching_Id_catchNonFatalEitherFShouldReturnSuccessfulResult),
-    example("test Catching.catchNonFatalEitherF[Id] should return the failed result", IdSpec.testCatching_Id_catchNonFatalEitherFShouldReturnFailedResult),
-
-    example("test Catching.catchNonFatalEitherT[Id] should catch NonFatal", IdSpec.testCatching_Id_catchNonFatalEitherTShouldCatchNonFatal),
-    example("test Catching.catchNonFatalEitherT[Id] should not catch Fatal", IdSpec.testCatching_Id_catchNonFatalEitherTShouldNotCatchFatal),
-    example("test Catching.catchNonFatalEitherT[Id] should return the successful result", IdSpec.testCatching_Id_catchNonFatalEitherTShouldReturnSuccessfulResult),
-    example("test Catching.catchNonFatalEitherT[Id] should return the failed result", IdSpec.testCatching_Id_catchNonFatalEitherTShouldReturnFailedResult)
+    example(
+      "test Catching.catchNonFatal[Id] should catch NonFatal",
+      IdSpec.testCatching_Id_catchNonFatalShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatal[Id] should not catch Fatal",
+      IdSpec.testCatching_Id_catchNonFatalShouldNotCatchFatal
+    ),
+    example(
+      "test Catching.catchNonFatal[Id] should return the successful result",
+      IdSpec.testCatching_Id_catchNonFatalShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalF[Id] should catch NonFatal",
+      IdSpec.testCatching_Id_catchNonFatalFShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatalF[Id] should not catch Fatal",
+      IdSpec.testCatching_Id_catchNonFatalFShouldNotCatchFatal
+    ),
+    example(
+      "test Catching.catchNonFatalF[Id] should return the successful result",
+      IdSpec.testCatching_Id_catchNonFatalFShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalEither[Id] should catch NonFatal",
+      IdSpec.testCatching_Id_catchNonFatalEitherShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEither[Id] should not catch Fatal",
+      IdSpec.testCatching_Id_catchNonFatalEitherShouldNotCatchFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEither[Id] should return the successful result",
+      IdSpec.testCatching_Id_catchNonFatalEitherShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalEither[Id] should return the failed result",
+      IdSpec.testCatching_Id_catchNonFatalEitherShouldReturnFailedResult
+    ),
+    example(
+      "test Catching.catchNonFatalEitherF[Id] should catch NonFatal",
+      IdSpec.testCatching_Id_catchNonFatalEitherFShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEitherF[Id] should not catch Fatal",
+      IdSpec.testCatching_Id_catchNonFatalEitherFShouldNotCatchFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEitherF[Id] should return the successful result",
+      IdSpec.testCatching_Id_catchNonFatalEitherFShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalEitherF[Id] should return the failed result",
+      IdSpec.testCatching_Id_catchNonFatalEitherFShouldReturnFailedResult
+    ),
+    example(
+      "test Catching.catchNonFatalEitherT[Id] should catch NonFatal",
+      IdSpec.testCatching_Id_catchNonFatalEitherTShouldCatchNonFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEitherT[Id] should not catch Fatal",
+      IdSpec.testCatching_Id_catchNonFatalEitherTShouldNotCatchFatal
+    ),
+    example(
+      "test Catching.catchNonFatalEitherT[Id] should return the successful result",
+      IdSpec.testCatching_Id_catchNonFatalEitherTShouldReturnSuccessfulResult
+    ),
+    example(
+      "test Catching.catchNonFatalEitherT[Id] should return the failed result",
+      IdSpec.testCatching_Id_catchNonFatalEitherTShouldReturnFailedResult
+    )
   )
 
   def throwThrowable[A](throwable: => Throwable): A =
@@ -96,25 +227,22 @@ object CatchingSpec extends Properties {
   def run[F[_]: EffectConstructor: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
-  sealed trait SomeError
+  enum SomeError   {
+    case SomeThrowable(throwable: Throwable)
+    case Message(message: String)
+  }
   object SomeError {
-
-    final case class SomeThrowable(throwable: Throwable) extends SomeError
-    final case class Message(message: String) extends SomeError
-
-    def someThrowable(throwable: Throwable): SomeError = SomeThrowable(throwable)
-
-    def message(message: String): SomeError = Message(message)
-
+    def someThrowable(throwable: Throwable): SomeError = SomeError.SomeThrowable(throwable)
+    def message(message: String): SomeError            = SomeError.Message(message)
   }
 
   object IoSpec {
     def testCatching_IO_catchNonFatalShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[IO, Int](throwThrowable[Int](expectedExpcetion))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
@@ -122,7 +250,7 @@ object CatchingSpec extends Properties {
     def testCatching_IO_catchNonFatalShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      val fa = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
       try {
         val actual = catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
@@ -139,19 +267,18 @@ object CatchingSpec extends Properties {
 
     def testCatching_IO_catchNonFatalShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[IO, Int](1)
+      val fa       = run[IO, Int](1)
       val expected = 1.asRight[SomeError]
-      val actual = catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+      val actual   = catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
 
-
     def testCatching_IO_catchNonFatalFShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = catchNonFatalF[IO](throwThrowable[Int](expectedExpcetion))(SomeError.someThrowable).unsafeRunSync()
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = catchNonFatalF[IO](throwThrowable[Int](expectedExpcetion))(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
@@ -176,18 +303,17 @@ object CatchingSpec extends Properties {
     def testCatching_IO_catchNonFatalFShouldReturnSuccessfulResult: Result = {
 
       val expected = 1.asRight[SomeError]
-      val actual = catchNonFatalF[IO](1)(SomeError.someThrowable).unsafeRunSync()
+      val actual   = catchNonFatalF[IO](1)(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
 
-
     def testCatching_IO_catchNonFatalEitherShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
@@ -195,7 +321,7 @@ object CatchingSpec extends Properties {
     def testCatching_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
       try {
         val actual = catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
@@ -212,9 +338,9 @@ object CatchingSpec extends Properties {
 
     def testCatching_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
-      val actual = catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+      val actual   = catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
@@ -222,19 +348,20 @@ object CatchingSpec extends Properties {
     def testCatching_IO_catchNonFatalEitherShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
-      val expected = expectedFailure.asLeft[Int]
-      val actual = catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
 
-
     def testCatching_IO_catchNonFatalEitherFShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = catchNonFatalEitherF[IO](throwThrowable[Either[SomeError, Int]](expectedExpcetion))(SomeError.someThrowable).unsafeRunSync()
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            =
+        catchNonFatalEitherF[IO](throwThrowable[Either[SomeError, Int]](expectedExpcetion))(SomeError.someThrowable)
+          .unsafeRunSync()
 
       actual ==== expected
     }
@@ -244,7 +371,9 @@ object CatchingSpec extends Properties {
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = catchNonFatalEitherF[IO](throwThrowable[Either[SomeError, Int]](fatalExpcetion))(SomeError.someThrowable).unsafeRunSync()
+        val actual =
+          catchNonFatalEitherF[IO](throwThrowable[Either[SomeError, Int]](fatalExpcetion))(SomeError.someThrowable)
+            .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -259,7 +388,7 @@ object CatchingSpec extends Properties {
     def testCatching_IO_catchNonFatalEitherFShouldReturnSuccessfulResult: Result = {
 
       val expected = 1.asRight[SomeError]
-      val actual = catchNonFatalEitherF[IO](1.asRight[SomeError])(SomeError.someThrowable).unsafeRunSync()
+      val actual   = catchNonFatalEitherF[IO](1.asRight[SomeError])(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
@@ -267,19 +396,18 @@ object CatchingSpec extends Properties {
     def testCatching_IO_catchNonFatalEitherFShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val expected = expectedFailure.asLeft[Int]
-      val actual = catchNonFatalEitherF[IO](expectedFailure.asLeft[Int])(SomeError.someThrowable).unsafeRunSync()
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = catchNonFatalEitherF[IO](expectedFailure.asLeft[Int])(SomeError.someThrowable).unsafeRunSync()
 
       actual ==== expected
     }
 
-
     def testCatching_IO_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual =
+      val fa                = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            =
         catchNonFatalEitherT[IO](fa)(SomeError.someThrowable).value.unsafeRunSync()
 
       actual ==== expected
@@ -288,7 +416,7 @@ object CatchingSpec extends Properties {
     def testCatching_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fa             = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual = catchNonFatalEitherT[IO](fa)(SomeError.someThrowable).value.unsafeRunSync()
@@ -306,9 +434,9 @@ object CatchingSpec extends Properties {
     def testCatching_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
-      val expected = 1.asRight[SomeError]
-      val actual = catchNonFatalEitherT[IO](fa)(SomeError.someThrowable).value.unsafeRunSync()
+      val fa                = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected          = 1.asRight[SomeError]
+      val actual            = catchNonFatalEitherT[IO](fa)(SomeError.someThrowable).value.unsafeRunSync()
 
       actual ==== expected
     }
@@ -316,9 +444,9 @@ object CatchingSpec extends Properties {
     def testCatching_IO_catchNonFatalEitherTShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
-      val expected = expectedFailure.asLeft[Int]
-      val actual = catchNonFatalEitherT[IO](fa)(SomeError.someThrowable).value.unsafeRunSync()
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = catchNonFatalEitherT[IO](fa)(SomeError.someThrowable).value.unsafeRunSync()
 
       actual ==== expected
     }
@@ -336,12 +464,12 @@ object CatchingSpec extends Properties {
     def testCatching_Future_catchNonFatalShouldCatchNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[Future, Int](throwThrowable[Int](expectedExpcetion))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val fa                = run[Future, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = ConcurrentSupport.futureToValueAndTerminate(
         catchNonFatal(fa)(SomeError.someThrowable),
         waitFor
       )
@@ -352,11 +480,11 @@ object CatchingSpec extends Properties {
     def testCatching_Future_catchNonFatalShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val fa = run[Future, Int](1)
+      val fa       = run[Future, Int](1)
       val expected = 1.asRight[SomeError]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         catchNonFatal(fa)(SomeError.someThrowable),
         waitFor
       )
@@ -364,15 +492,14 @@ object CatchingSpec extends Properties {
       actual ==== expected
     }
 
-
     def testCatching_Future_catchNonFatalFShouldCatchNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = ConcurrentSupport.futureToValueAndTerminate(
         catchNonFatalF[Future](throwThrowable[Int](expectedExpcetion))(SomeError.someThrowable),
         waitFor
       )
@@ -383,10 +510,10 @@ object CatchingSpec extends Properties {
     def testCatching_Future_catchNonFatalFShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expected = 1.asRight[SomeError]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         catchNonFatalF[Future](1)(SomeError.someThrowable),
         waitFor
       )
@@ -394,16 +521,15 @@ object CatchingSpec extends Properties {
       actual ==== expected
     }
 
-
     def testCatching_Future_catchNonFatalEitherShouldCatchNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val fa                = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = ConcurrentSupport.futureToValueAndTerminate(
         catchNonFatalEither(fa)(SomeError.someThrowable),
         waitFor
       )
@@ -414,11 +540,11 @@ object CatchingSpec extends Properties {
     def testCatching_Future_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val fa = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
+      val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         catchNonFatalEither(fa)(SomeError.someThrowable),
         waitFor
       )
@@ -429,12 +555,12 @@ object CatchingSpec extends Properties {
     def testCatching_Future_catchNonFatalEitherShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
-      val expected = expectedFailure.asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = ConcurrentSupport.futureToValueAndTerminate(
         catchNonFatalEither(fa)(SomeError.someThrowable),
         waitFor
       )
@@ -442,15 +568,14 @@ object CatchingSpec extends Properties {
       actual ==== expected
     }
 
-
     def testCatching_Future_catchNonFatalEitherFShouldCatchNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual =
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            =
         ConcurrentSupport.futureToValueAndTerminate(
           catchNonFatalEitherF[Future](
             throwThrowable[Either[SomeError, Int]](expectedExpcetion)
@@ -464,10 +589,10 @@ object CatchingSpec extends Properties {
     def testCatching_Future_catchNonFatalEitherFShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expected = 1.asRight[SomeError]
-      val actual =
+      val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
           catchNonFatalEitherF[Future](1.asRight[SomeError])(SomeError.someThrowable),
           waitFor
@@ -479,11 +604,11 @@ object CatchingSpec extends Properties {
     def testCatching_Future_catchNonFatalEitherFShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedFailure = SomeError.message("Failed")
-      val expected = expectedFailure.asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = ConcurrentSupport.futureToValueAndTerminate(
         catchNonFatalEitherF[Future](expectedFailure.asLeft[Int])(SomeError.someThrowable),
         waitFor
       )
@@ -491,16 +616,15 @@ object CatchingSpec extends Properties {
       actual ==== expected
     }
 
-
     def testCatching_Future_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val fa                = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = ConcurrentSupport.futureToValueAndTerminate(
         catchNonFatalEitherT[Future](fa)(SomeError.someThrowable).value,
         waitFor
       )
@@ -511,11 +635,11 @@ object CatchingSpec extends Properties {
     def testCatching_Future_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
-      val fa = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
+      val fa       = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         catchNonFatalEitherT[Future](fa)(SomeError.someThrowable).value,
         waitFor
       )
@@ -526,12 +650,12 @@ object CatchingSpec extends Properties {
     def testCatching_Future_catchNonFatalEitherTShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext = ConcurrentSupport.newExecutionContext(executorService)
+      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService)
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
-      val expected = expectedFailure.asLeft[Int]
-      val actual = ConcurrentSupport.futureToValueAndTerminate(
+      val fa              = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = ConcurrentSupport.futureToValueAndTerminate(
         catchNonFatalEitherT[Future](fa)(SomeError.someThrowable).value,
         waitFor
       )
@@ -540,15 +664,14 @@ object CatchingSpec extends Properties {
     }
   }
 
-
   object IdSpec {
 
     def testCatching_Id_catchNonFatalShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa = run[Id, Int](throwThrowable[Int](expectedExpcetion))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = catchNonFatal(fa)(SomeError.someThrowable)
+      lazy val fa           = run[Id, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = catchNonFatal(fa)(SomeError.someThrowable)
 
       actual ==== expected
     }
@@ -556,7 +679,7 @@ object CatchingSpec extends Properties {
     def testCatching_Id_catchNonFatalShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      lazy val fa = run[Id, Int](throwThrowable[Int](fatalExpcetion))
+      lazy val fa        = run[Id, Int](throwThrowable[Int](fatalExpcetion))
 
       try {
         val actual = catchNonFatal(fa)(SomeError.someThrowable)
@@ -573,19 +696,18 @@ object CatchingSpec extends Properties {
 
     def testCatching_Id_catchNonFatalShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[Id, Int](1)
+      val fa       = run[Id, Int](1)
       val expected = 1.asRight[SomeError]
-      val actual = catchNonFatal(fa)(SomeError.someThrowable)
+      val actual   = catchNonFatal(fa)(SomeError.someThrowable)
 
       actual ==== expected
     }
 
-
     def testCatching_Id_catchNonFatalFShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = catchNonFatalF[Id](throwThrowable[Int](expectedExpcetion))(SomeError.someThrowable)
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = catchNonFatalF[Id](throwThrowable[Int](expectedExpcetion))(SomeError.someThrowable)
 
       actual ==== expected
     }
@@ -610,18 +732,17 @@ object CatchingSpec extends Properties {
     def testCatching_Id_catchNonFatalFShouldReturnSuccessfulResult: Result = {
 
       val expected = 1.asRight[SomeError]
-      val actual = catchNonFatalF[Id](1)(SomeError.someThrowable)
+      val actual   = catchNonFatalF[Id](1)(SomeError.someThrowable)
 
       actual ==== expected
     }
 
-
     def testCatching_Id_catchNonFatalEitherShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = catchNonFatalEither(fa)(SomeError.someThrowable)
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = catchNonFatalEither(fa)(SomeError.someThrowable)
 
       actual ==== expected
     }
@@ -629,7 +750,7 @@ object CatchingSpec extends Properties {
     def testCatching_Id_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      lazy val fa = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      lazy val fa        = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
       try {
         val actual = catchNonFatalEither(fa)(SomeError.someThrowable)
@@ -646,9 +767,9 @@ object CatchingSpec extends Properties {
 
     def testCatching_Id_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
-      val fa = run[Id, Either[SomeError, Int]](1.asRight[SomeError])
+      val fa       = run[Id, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
-      val actual = catchNonFatalEither(fa)(SomeError.someThrowable)
+      val actual   = catchNonFatalEither(fa)(SomeError.someThrowable)
 
       actual ==== expected
     }
@@ -656,19 +777,18 @@ object CatchingSpec extends Properties {
     def testCatching_Id_catchNonFatalEitherShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
-      val expected = expectedFailure.asLeft[Int]
-      val actual = catchNonFatalEither(fa)(SomeError.someThrowable)
+      val fa              = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = catchNonFatalEither(fa)(SomeError.someThrowable)
 
       actual ==== expected
     }
 
-
     def testCatching_Id_catchNonFatalEitherFShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual =
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            =
         catchNonFatalEitherF[Id](throwThrowable[Either[SomeError, Int]](expectedExpcetion))(SomeError.someThrowable)
 
       actual ==== expected
@@ -695,7 +815,7 @@ object CatchingSpec extends Properties {
     def testCatching_Id_catchNonFatalEitherFShouldReturnSuccessfulResult: Result = {
 
       val expected = 1.asRight[SomeError]
-      val actual = catchNonFatalEitherF[Id](1.asRight[SomeError])(SomeError.someThrowable)
+      val actual   = catchNonFatalEitherF[Id](1.asRight[SomeError])(SomeError.someThrowable)
 
       actual ==== expected
     }
@@ -703,19 +823,18 @@ object CatchingSpec extends Properties {
     def testCatching_Id_catchNonFatalEitherFShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val expected = expectedFailure.asLeft[Int]
-      val actual = catchNonFatalEitherF[Id](expectedFailure.asLeft[Int])(SomeError.someThrowable)
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = catchNonFatalEitherF[Id](expectedFailure.asLeft[Int])(SomeError.someThrowable)
 
       actual ==== expected
     }
 
-
     def testCatching_Id_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual = catchNonFatalEitherT[Id](fa)(SomeError.someThrowable).value
+      lazy val fa           = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = catchNonFatalEitherT[Id](fa)(SomeError.someThrowable).value
 
       actual ==== expected
     }
@@ -723,7 +842,7 @@ object CatchingSpec extends Properties {
     def testCatching_Id_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = new SomeControlThrowable("Something's wrong")
-      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      lazy val fa        = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual = catchNonFatalEitherT[Id](fa)(SomeError.someThrowable).value
@@ -740,9 +859,9 @@ object CatchingSpec extends Properties {
 
     def testCatching_Id_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
 
-      val fa = EitherT(run[Id, Either[SomeError, Int]](1.asRight[SomeError]))
+      val fa       = EitherT(run[Id, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
-      val actual = catchNonFatalEitherT[Id](fa)(SomeError.someThrowable).value
+      val actual   = catchNonFatalEitherT[Id](fa)(SomeError.someThrowable).value
 
       actual ==== expected
     }
@@ -750,9 +869,9 @@ object CatchingSpec extends Properties {
     def testCatching_Id_catchNonFatalEitherTShouldReturnFailedResult: Result = {
 
       val expectedFailure = SomeError.message("Failed")
-      val fa = EitherT(run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
-      val expected = expectedFailure.asLeft[Int]
-      val actual = catchNonFatalEitherT[Id](fa)(SomeError.someThrowable).value
+      val fa              = EitherT(run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = catchNonFatalEitherT[Id](fa)(SomeError.someThrowable).value
 
       actual ==== expected
     }


### PR DESCRIPTION
Close #249 - Replace `sealed trait` based ADT with enum for Scala 3 in `effectie-cats-effect`