### PR TITLE
Fixed: Scala 2 import syntax to Scala 3's

### DIFF
--- a/cats-effect/src/main/scala-3/effectie/cats/CanRecover.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/CanRecover.scala
@@ -1,8 +1,8 @@
 package effectie.cats
 
-import cats._
+import cats.*
 import cats.data.EitherT
-import cats.effect._
+import cats.effect.*
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal

--- a/cats-effect/src/main/scala-3/effectie/cats/Catching.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/Catching.scala
@@ -7,7 +7,7 @@ import cats.data.EitherT
   */
 trait Catching {
 
-  import Catching._
+  import Catching.*
 
   final def catchNonFatal[F[_]]: CurriedCanCatch1[F] =
     new CurriedCanCatch1[F]

--- a/cats-effect/src/main/scala-3/effectie/cats/ConsoleEffect.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/ConsoleEffect.scala
@@ -1,7 +1,7 @@
 package effectie.cats
 
-import cats._
-import cats.syntax.all._
+import cats.*
+import cats.syntax.all.*
 import effectie.ConsoleEffect.ConsoleEffectWithoutFlatMap
 import effectie.YesNo
 

--- a/cats-effect/src/main/scala-3/effectie/cats/Effectful.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/Effectful.scala
@@ -1,6 +1,6 @@
 package effectie.cats
 
-import effectie.cats.Effectful._
+import effectie.cats.Effectful.*
 
 trait Effectful {
 

--- a/cats-effect/src/main/scala-3/effectie/cats/EitherTSupport.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/EitherTSupport.scala
@@ -2,11 +2,11 @@ package effectie.cats
 
 import cats.{Applicative, Functor}
 import cats.data.EitherT
-import cats.syntax.all._
+import cats.syntax.all.*
 
 trait EitherTSupport {
 
-  import EitherTSupport._
+  import EitherTSupport.*
 
   def eitherTOf[F[_]]: PartiallyAppliedEitherTEffectOf[F] =
     new PartiallyAppliedEitherTEffectOf[F]

--- a/cats-effect/src/main/scala-3/effectie/cats/OptionTSupport.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/OptionTSupport.scala
@@ -5,7 +5,7 @@ import cats.data.OptionT
 
 trait OptionTSupport {
 
-  import OptionTSupport._
+  import OptionTSupport.*
 
   def optionTOf[F[_]]: PartiallyAppliedOptionTOf[F] =
     new PartiallyAppliedOptionTOf[F]

--- a/cats-effect/src/main/scala-3/effectie/cats/ToFuture.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/ToFuture.scala
@@ -1,7 +1,7 @@
 package effectie.cats
 
 import cats.Id
-import cats.effect._
+import cats.effect.*
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/cats-effect/src/test/scala-3/effectie/cats/CanCatchSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CanCatchSpec.scala
@@ -1,14 +1,14 @@
 package effectie.cats
 
-import cats._
+import cats.*
 import cats.data.EitherT
-import cats.effect._
-import cats.instances.all._
-import cats.syntax.all._
-import effectie.cats.Effectful._
+import cats.effect.*
+import cats.instances.all.*
+import cats.syntax.all.*
+import effectie.cats.Effectful.*
 import effectie.{ConcurrentSupport, SomeControlThrowable}
-import hedgehog._
-import hedgehog.runner._
+import hedgehog.*
+import hedgehog.runner.*
 
 import scala.util.control.ControlThrowable
 
@@ -296,7 +296,7 @@ object CanCatchSpec extends Properties {
 
   object FutureSpec {
     import java.util.concurrent.{ExecutorService, Executors}
-    import scala.concurrent.duration._
+    import scala.concurrent.duration.*
     import scala.concurrent.{ExecutionContext, Future}
 
     val waitFor: FiniteDuration = 1.second

--- a/cats-effect/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
@@ -1,14 +1,14 @@
 package effectie.cats
 
-import cats._
+import cats.*
 import cats.data.EitherT
 import cats.effect.IO
-import cats.instances.all._
-import cats.syntax.all._
-import effectie.cats.Effectful._
+import cats.instances.all.*
+import cats.syntax.all.*
+import effectie.cats.Effectful.*
 import effectie.{ConcurrentSupport, SomeControlThrowable}
-import hedgehog._
-import hedgehog.runner._
+import hedgehog.*
+import hedgehog.runner.*
 
 import scala.util.control.{ControlThrowable, NonFatal}
 
@@ -588,7 +588,7 @@ object CanHandleErrorSpec extends Properties {
 
   object FutureSpec {
     import java.util.concurrent.{ExecutorService, Executors}
-    import scala.concurrent.duration._
+    import scala.concurrent.duration.*
     import scala.concurrent.{ExecutionContext, Future}
 
     val waitFor: FiniteDuration = 1.second

--- a/cats-effect/src/test/scala-3/effectie/cats/CanRecoverSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CanRecoverSpec.scala
@@ -1,14 +1,14 @@
 package effectie.cats
 
-import cats._
+import cats.*
 import cats.data.EitherT
 import cats.effect.IO
-import cats.instances.all._
-import cats.syntax.all._
-import effectie.cats.Effectful._
+import cats.instances.all.*
+import cats.syntax.all.*
+import effectie.cats.Effectful.*
 import effectie.{ConcurrentSupport, SomeControlThrowable}
-import hedgehog._
-import hedgehog.runner._
+import hedgehog.*
+import hedgehog.runner.*
 
 import scala.util.control.{ControlThrowable, NonFatal}
 
@@ -452,7 +452,7 @@ object CanRecoverSpec extends Properties {
 
   object FutureSpec {
     import java.util.concurrent.{ExecutorService, Executors}
-    import scala.concurrent.duration._
+    import scala.concurrent.duration.*
     import scala.concurrent.{ExecutionContext, Future}
     import scala.util.control.NonFatal
 

--- a/cats-effect/src/test/scala-3/effectie/cats/CatchingSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CatchingSpec.scala
@@ -1,15 +1,15 @@
 package effectie.cats
 
-import Catching._
-import cats._
+import Catching.*
+import cats.*
 import cats.data.EitherT
-import cats.effect._
-import cats.instances.all._
-import cats.syntax.all._
-import effectie.cats.Effectful._
+import cats.effect.*
+import cats.instances.all.*
+import cats.syntax.all.*
+import effectie.cats.Effectful.*
 import effectie.{ConcurrentSupport, SomeControlThrowable}
-import hedgehog._
-import hedgehog.runner._
+import hedgehog.*
+import hedgehog.runner.*
 
 import scala.util.control.ControlThrowable
 
@@ -456,7 +456,7 @@ object CatchingSpec extends Properties {
 
   object FutureSpec {
     import java.util.concurrent.{ExecutorService, Executors}
-    import scala.concurrent.duration._
+    import scala.concurrent.duration.*
     import scala.concurrent.{ExecutionContext, Future}
 
     val waitFor: FiniteDuration = 1.second

--- a/cats-effect/src/test/scala-3/effectie/cats/EffectConstructorSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/EffectConstructorSpec.scala
@@ -1,10 +1,10 @@
 package effectie.cats
 
 import cats.Id
-import cats.effect._
+import cats.effect.*
 import effectie.ConcurrentSupport
-import hedgehog._
-import hedgehog.runner._
+import hedgehog.*
+import hedgehog.runner.*
 
 /**
   * @author Kevin Lee
@@ -72,7 +72,7 @@ object EffectConstructorSpec extends Properties {
 
   object FutureSpec {
     import java.util.concurrent.{ExecutorService, Executors}
-    import scala.concurrent.duration._
+    import scala.concurrent.duration.*
     import scala.concurrent.{ExecutionContext, Future}
 
     val waitFor: FiniteDuration = 1.second

--- a/cats-effect/src/test/scala-3/effectie/cats/EffectfulSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/EffectfulSpec.scala
@@ -3,9 +3,9 @@ package effectie.cats
 import cats.Id
 import cats.effect.IO
 import effectie.ConcurrentSupport
-import effectie.testing.tools._
-import hedgehog._
-import hedgehog.runner._
+import effectie.testing.tools.*
+import hedgehog.*
+import hedgehog.runner.*
 
 /** @author Kevin Lee
   * @since 2021-05-16
@@ -26,7 +26,7 @@ object EffectfulSpec extends Properties {
     example("test Effectful.unitOf[Id]", IdSpec.testUnitOf)
   )
 
-  import Effectful._
+  import Effectful.*
 
   trait FxClient[F[_]] {
     def eftOf[A](a: A): F[A]
@@ -147,7 +147,7 @@ object EffectfulSpec extends Properties {
   object FutureSpec {
 
     import java.util.concurrent.{ExecutorService, Executors}
-    import scala.concurrent.duration._
+    import scala.concurrent.duration.*
     import scala.concurrent.{ExecutionContext, Future}
 
     val waitFor: FiniteDuration = 1.second

--- a/cats-effect/src/test/scala-3/effectie/cats/FxSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/FxSpec.scala
@@ -1,10 +1,10 @@
 package effectie.cats
 
 import cats.Id
-import cats.effect._
+import cats.effect.*
 import effectie.ConcurrentSupport
-import hedgehog._
-import hedgehog.runner._
+import hedgehog.*
+import hedgehog.runner.*
 
 /**
   * @author Kevin Lee
@@ -72,7 +72,7 @@ object FxSpec extends Properties {
 
   object FutureSpec {
     import java.util.concurrent.{ExecutorService, Executors}
-    import scala.concurrent.duration._
+    import scala.concurrent.duration.*
     import scala.concurrent.{ExecutionContext, Future}
 
     val waitFor: FiniteDuration = 1.second

--- a/cats-effect/src/test/scala-3/effectie/cats/OptionTSupportSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/OptionTSupportSpec.scala
@@ -1,7 +1,7 @@
 package effectie.cats
 
-import hedgehog._
-import hedgehog.runner._
+import hedgehog.*
+import hedgehog.runner.*
 
 /** @author Kevin Lee
   * @since 2021-07-20
@@ -32,9 +32,9 @@ object OptionTSupportSpec extends Properties {
 
   object OptionTFOptionOpsSpec {
 
-    import cats.data._
-    import cats.effect._
-    import cats.syntax.option._
+    import cats.data.*
+    import cats.effect.*
+    import cats.syntax.option.*
     import effectie.cats.OptionTSupport.optionT
 
     def fab[F[_]: Fx, A](oa: Option[A]): F[Option[A]] = Fx[F].effectOf(oa)
@@ -64,7 +64,7 @@ object OptionTSupportSpec extends Properties {
     import cats.Applicative
     import cats.data.OptionT
     import cats.effect.IO
-    import cats.syntax.option._
+    import cats.syntax.option.*
     import effectie.cats.OptionTSupport.optionT
 
     def testOptionT: Property = for {
@@ -119,7 +119,7 @@ object OptionTSupportSpec extends Properties {
     import cats.Applicative
     import cats.data.OptionT
     import cats.effect.IO
-    import cats.syntax.option._
+    import cats.syntax.option.*
     import effectie.cats.OptionTSupport.someTF
 
     def testOptionTF: Property = for {
@@ -145,10 +145,10 @@ object OptionTSupportSpec extends Properties {
   object OptionTSupportAllSpec {
 
     import cats.Applicative
-    import cats.data._
-    import cats.effect._
-    import cats.syntax.option._
-    import effectie.cats.OptionTSupport._
+    import cats.data.*
+    import cats.effect.*
+    import cats.syntax.option.*
+    import effectie.cats.OptionTSupport.*
 
     def fab[F[_]: Fx, A](oa: Option[A]): F[Option[A]] = Fx[F].effectOf(oa)
 

--- a/cats-effect/src/test/scala-3/effectie/cats/compat/CatsEffectIoCompatForFuture.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/compat/CatsEffectIoCompatForFuture.scala
@@ -1,6 +1,6 @@
 package effectie.cats.compat
 
-import cats.effect._
+import cats.effect.*
 import effectie.ConcurrentSupport
 
 import java.util.concurrent.ExecutorService


### PR DESCRIPTION
Fixed: Scala 2 `import` syntax to Scala 3's