### PR TITLE
Close #257 - Fix CommonFutureFx to use Future.successful for pureOf

### DIFF
--- a/core/src/main/scala/effectie/CommonFx.scala
+++ b/core/src/main/scala/effectie/CommonFx.scala
@@ -14,11 +14,11 @@ object CommonFx {
 
     implicit def EC0: ExecutionContext
 
-    override def effectOf[A](a: => A): Future[A] = Future(a)
+    @inline override def effectOf[A](a: => A): Future[A] = Future(a)
 
-    override def pureOf[A](a: A): Future[A] = effectOf(a)
+    @inline override def pureOf[A](a: A): Future[A] = Future.successful(a)
 
-    override def unitOf: Future[Unit] = Future(())
+    @inline override def unitOf: Future[Unit] = pureOf(())
   }
 }
 


### PR DESCRIPTION
Close #257 - Fix `CommonFutureFx` to use `Future.successful` for `pureOf`