### PR TITLE
Effectie v1.15.0

### DIFF
--- a/changelogs/1.15.0.md
+++ b/changelogs/1.15.0.md
@@ -1,0 +1,9 @@
+## [1.15.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone21) - 2021-08-12
+
+## Done
+* Fix `CommonFutureFx` to use `Future.successful` for `pureOf` (#257)
+* Add project to test cats related code (#259)
+* Add `FxCtor` as an alternative to `EffectConstructor` (#261)
+* `Fx` should no longer be `Monad` (#265)
+* There should be a way to test each `Monad` law instead of testing all the laws at once. (#266)
+* ~~Make `Fx` `Monad` (#256)~~ (Undone in favor of #265)


### PR DESCRIPTION
# Effectie v1.15.0
## [1.15.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone21) - 2021-08-12

## Done
* Fix `CommonFutureFx` to use `Future.successful` for `pureOf` (#257)
* Add project to test cats related code (#259)
* Add `FxCtor` as an alternative to `EffectConstructor` (#261)
* `Fx` should no longer be `Monad` (#265)
* There should be a way to test each `Monad` law instead of testing all the laws at once. (#266)
* ~~Make `Fx` `Monad` (#256)~~ (Undone in favor of #265)
