### PR TITLE
xorT and xorT2FXor no longer takes by-name params

### DIFF
--- a/cats-effect/src/main/scala-2/effectie/cats/CanRecover.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/CanRecover.scala
@@ -14,10 +14,10 @@ trait CanRecover[F[_]] extends effectie.CanRecover[F] {
   type Xor[+A, +B]  = Either[A, B]
   type XorT[A, B] = EitherT[F, A, B]
 
-  @inline override protected def xorT[A, B](fab: => F[Either[A, B]]): EitherT[F, A, B] =
+  @inline override protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] =
     EitherT(fab)
 
-  @inline override protected def xorT2FXor[A, B](efab: => EitherT[F, A, B]): F[Either[A, B]] =
+  @inline override protected def xorT2FXor[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] =
     efab.value
 }
 

--- a/cats-effect/src/main/scala-3/effectie/cats/CanRecover.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/CanRecover.scala
@@ -14,10 +14,10 @@ trait CanRecover[F[_]] extends effectie.CanRecover[F] {
   type Xor[+A, +B]  = Either[A, B]
   type XorT[A, B] = EitherT[F, A, B]
 
-  inline override protected def xorT[A, B](fab: => F[Either[A, B]]): EitherT[F, A, B] =
+  inline override protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] =
     EitherT(fab)
 
-  inline override protected def xorT2FXor[A, B](efab: => EitherT[F, A, B]): F[Either[A, B]] =
+  inline override protected def xorT2FXor[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] =
     efab.value
 }
 

--- a/cats-effect3/src/main/scala-2/effectie/cats/CanRecover.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/CanRecover.scala
@@ -14,10 +14,10 @@ trait CanRecover[F[_]] extends effectie.CanRecover[F] {
   type Xor[+A, +B]  = Either[A, B]
   type XorT[A, B] = EitherT[F, A, B]
 
-  @inline override protected def xorT[A, B](fab: => F[Either[A, B]]): EitherT[F, A, B] =
+  @inline override protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] =
     EitherT(fab)
 
-  @inline override protected def xorT2FXor[A, B](efab: => EitherT[F, A, B]): F[Either[A, B]] =
+  @inline override protected def xorT2FXor[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] =
     efab.value
 }
 

--- a/cats-effect3/src/main/scala-3/effectie/cats/CanRecover.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/CanRecover.scala
@@ -14,10 +14,10 @@ trait CanRecover[F[_]] extends effectie.CanRecover[F] {
   type Xor[+A, +B]  = Either[A, B]
   type XorT[A, B] = EitherT[F, A, B]
 
-  inline override protected def xorT[A, B](fab: => F[Either[A, B]]): EitherT[F, A, B] =
+  inline override protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] =
     EitherT(fab)
 
-  inline override protected def xorT2FXor[A, B](efab: => EitherT[F, A, B]): F[Either[A, B]] =
+  inline override protected def xorT2FXor[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] =
     efab.value
 }
 

--- a/core/src/main/scala/effectie/CanRecover.scala
+++ b/core/src/main/scala/effectie/CanRecover.scala
@@ -9,8 +9,8 @@ trait CanRecover[F[_]] {
   type Xor[+A, +B]
   type XorT[A, B]
 
-  protected def xorT[A, B](fab: => F[Xor[A, B]]): XorT[A, B]
-  protected def xorT2FXor[A, B](efab: => XorT[A, B]): F[Xor[A, B]]
+  protected def xorT[A, B](fab: F[Xor[A, B]]): XorT[A, B]
+  protected def xorT2FXor[A, B](efab: XorT[A, B]): F[Xor[A, B]]
 
   def recoverFromNonFatalWith[A, AA >: A](fa: => F[A])(handleError: PartialFunction[Throwable, F[AA]]): F[AA]
 

--- a/effectie-monix/src/main/scala/effectie/monix/CanRecover.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/CanRecover.scala
@@ -14,10 +14,10 @@ trait CanRecover[F[_]] extends effectie.CanRecover[F] {
   type Xor[+A, +B]  = Either[A, B]
   type XorT[A, B] = EitherT[F, A, B]
 
-  @inline override protected def xorT[A, B](fab: => F[Either[A, B]]): EitherT[F, A, B] =
+  @inline override protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] =
     EitherT(fab)
 
-  @inline override protected def xorT2FXor[A, B](efab: => EitherT[F, A, B]): F[Either[A, B]] =
+  @inline override protected def xorT2FXor[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] =
     efab.value
 }
 

--- a/scalaz-effect/src/main/scala/effectie/scalaz/CanRecover.scala
+++ b/scalaz-effect/src/main/scala/effectie/scalaz/CanRecover.scala
@@ -14,10 +14,10 @@ trait CanRecover[F[_]] extends effectie.CanRecover[F] {
   override type Xor[+A, +B]  = A \/ B
   override type XorT[A, B] = EitherT[F, A, B]
 
-  @inline override protected def xorT[A, B](fab: => F[A \/ B]): DisjunctionT[F, A, B] =
+  @inline override protected def xorT[A, B](fab: F[A \/ B]): EitherT[F, A, B] =
     EitherT(fab)
 
-  @inline override protected def xorT2FXor[A, B](efab: => DisjunctionT[F, A, B]): F[A \/ B] =
+  @inline override protected def xorT2FXor[A, B](efab: EitherT[F, A, B]): F[A \/ B] =
     efab.run
 }
 


### PR DESCRIPTION
`xorT` and `xorT2FXor` no longer takes by-name params