### PR TITLE
Effectie v1.16.0 🎃

### DIFF
--- a/changelogs/1.16.0.md
+++ b/changelogs/1.16.0.md
@@ -1,0 +1,12 @@
+## [1.16.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone22) - 2021-10-31 🎃
+
+## Done
+* Add `catchNonFatalThrowable` (#274)
+* Add syntax for error handling (#277)
+* Add `AA >: A` to `catchNonFatalEither` and `catchNonFatalEitherT` (#279)
+* Add `handleError` for `F[Xor[A, B]]` (#281)
+* Add `recoverFrom` for `F[Xor[A, B]]` (#283)
+* More abstraction for `CanRecover` (#284)
+* More abstraction for `CanHandleError` (#287)
+* More abstraction for `CanCatch` (#289)
+* Add `Fx.errorOf(Throwable)` (#294)


### PR DESCRIPTION
# Effectie v1.16.0 🎃
## [1.16.0](https://github.com/Kevin-Lee/effectie/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone22) - 2021-10-31 🎃

## Done
* Add `catchNonFatalThrowable` (#274)
* Add syntax for error handling (#277)
* Add `AA >: A` to `catchNonFatalEither` and `catchNonFatalEitherT` (#279)
* Add `handleError` for `F[Xor[A, B]]` (#281)
* Add `recoverFrom` for `F[Xor[A, B]]` (#283)
* More abstraction for `CanRecover` (#284)
* More abstraction for `CanHandleError` (#287)
* More abstraction for `CanCatch` (#289)
* Add `Fx.errorOf(Throwable)` (#294)
