### PR TITLE
Close #320 - Remove `Fx`, `FxCtor` and `CanCatch` `trait`s from `effectie-cats-effect`, `effectie-cats-effect3` and `effectie-monix`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -269,7 +269,7 @@ def projectCommonSettings(id: String, projectName: ProjectName, file: File): Pro
     .settings(
       name                                    := prefixedProjectName(projectName.projectName),
       scalacOptions ~= (_.filterNot(props.isScala3IncompatibleScalacOption)),
-      libraryDependencies ++= libs.hedgehogLibs.map(_ % Test),
+      libraryDependencies ++= libs.hedgehogLibs.map(_ % Test) ++ List("io.kevinlee" %% "extras-cats" % "0.2.0" % Test),
       /* WartRemover and scalacOptions { */
 //      Compile / compile / wartremoverErrors ++= commonWarts((update / scalaBinaryVersion).value),
 //      Test / compile / wartremoverErrors ++= commonWarts((update / scalaBinaryVersion).value),

--- a/cats-effect/src/main/scala-2/effectie/cats/CanCatch.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/CanCatch.scala
@@ -1,27 +1,15 @@
 package effectie.cats
 
 import cats.Id
-import cats.data.EitherT
 import cats.effect.IO
 import cats.syntax.all._
 
-import scala.concurrent.{ExecutionContext, Future}
 
 /** @author Kevin Lee
   * @since 2020-06-07
   */
-trait CanCatch[F[_]] extends effectie.CanCatch[F] {
-
-  override type XorT[A, B] = EitherT[F, A, B]
-
-  @inline override final protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] = EitherT(fab)
-
-  @inline override final protected def xorT2FEither[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] = efab.value
-
-}
-
 object CanCatch {
-  def apply[F[_]: CanCatch]: CanCatch[F] = implicitly[CanCatch[F]]
+  type CanCatch[F[_]] = effectie.CanCatch[F]
 
   implicit object CanCatchIo extends CanCatch[IO] {
 
@@ -31,26 +19,6 @@ object CanCatch {
       fa.attempt
 
   }
-
-  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
-  implicit def canCatchFuture(implicit EC: ExecutionContext): CanCatch[Future] =
-    new effectie.CanCatch.CanCatchFuture with CanCatch[Future] {
-
-      override val EC0: ExecutionContext = EC
-
-      override def catchNonFatalThrowable[A](fa: => Future[A]): Future[Either[Throwable, A]] =
-        fa.transform {
-          case scala.util.Success(a) =>
-            scala.util.Try[Either[Throwable, A]](Right(a))
-
-          case scala.util.Failure(scala.util.control.NonFatal(ex)) =>
-            scala.util.Try[Either[Throwable, A]](Left(ex))
-
-          case scala.util.Failure(ex) =>
-            throw ex
-        }(EC0)
-
-    }
 
   implicit object CanCatchId extends CanCatch[Id] {
 

--- a/cats-effect/src/main/scala-2/effectie/cats/Catching.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/Catching.scala
@@ -7,7 +7,7 @@ import cats.data.EitherT
   */
 trait Catching {
 
-  import Catching._
+  import effectie.cats.Catching._
 
   final def catchNonFatalThrowable[F[_]]: CurriedCanCatchThrowable[F] =
     new CurriedCanCatchThrowable[F]
@@ -27,8 +27,6 @@ trait Catching {
   def catchNonFatalEitherT[F[_]]: CurriedCanCatchEitherT1[F] =
     new CurriedCanCatchEitherT1[F]
 
-//  def catchNonFatalEitherT[F[_], A, B](fab: => EitherT[F, A, B])(f: Throwable => A)(implicit CC: CanCatch[F]): EitherT[F, A, B] =
-//    CanCatch[F].catchNonFatalEitherT(fab)(f)
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -37,8 +35,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchThrowable[F[_]](
     private val dummy: Boolean = true
   ) extends AnyVal {
-    def apply[B](fb: => F[B])(implicit CC: CanCatch[F]): F[Either[Throwable, B]] =
-      CanCatch[F].catchNonFatalThrowable[B](fb)
+    def apply[B](fb: => F[B])(implicit CC: effectie.CanCatch[F]): F[Either[Throwable, B]] =
+      effectie.CanCatch[F].catchNonFatalThrowable[B](fb)
   }
 
   private[Catching] final class CurriedCanCatch1[F[_]](
@@ -51,8 +49,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatch2[F[_], B](
     private val fb: () => F[B]
   ) extends AnyVal {
-    def apply[A](f: Throwable => A)(implicit CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatal(fb())(f)
+    def apply[A](f: Throwable => A)(implicit CC: effectie.CanCatch[F]): F[Either[A, B]] =
+      effectie.CanCatch[F].catchNonFatal(fb())(f)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -66,8 +64,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchF2[F[_], B](
     private val b: () => B
   ) extends AnyVal {
-    def apply[A](f: Throwable => A)(implicit EC: FxCtor[F], CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatal(FxCtor[F].effectOf(b()))(f)
+    def apply[A](f: Throwable => A)(implicit EC: effectie.FxCtor[F], CC: effectie.CanCatch[F]): F[Either[A, B]] =
+      effectie.CanCatch[F].catchNonFatal(effectie.FxCtor[F].effectOf(b()))(f)
   }
 
   private[Catching] final class CurriedCanCatchEither1[F[_]](
@@ -80,8 +78,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchEither2[F[_], A, B](
     private val fab: () => F[Either[A, B]]
   ) extends AnyVal {
-    def apply(f: Throwable => A)(implicit CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatalEither(fab())(f)
+    def apply(f: Throwable => A)(implicit CC: effectie.CanCatch[F]): F[Either[A, B]] =
+      effectie.CanCatch[F].catchNonFatalEither(fab())(f)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -95,8 +93,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchEitherF2[F[_], A, B](
     private val ab: () => Either[A, B]
   ) extends AnyVal {
-    def apply(f: Throwable => A)(implicit EC: FxCtor[F], CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatalEither(FxCtor[F].effectOf(ab()))(f)
+    def apply(f: Throwable => A)(implicit EC: effectie.FxCtor[F], CC: effectie.CanCatch[F]): F[Either[A, B]] =
+      effectie.CanCatch[F].catchNonFatalEither(effectie.FxCtor[F].effectOf(ab()))(f)
   }
 
   private[Catching] final class CurriedCanCatchEitherT1[F[_]](
@@ -109,8 +107,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchEitherT2[F[_], A, B](
     private val fab: () => EitherT[F, A, B]
   ) extends AnyVal {
-    def apply(f: Throwable => A)(implicit CC: CanCatch[F]): EitherT[F, A, B] =
-      CanCatch[F].catchNonFatalEitherT(fab())(f)
+    def apply(f: Throwable => A)(implicit CC: effectie.CanCatch[F]): EitherT[F, A, B] =
+      CC.catchNonFatalEitherT(fab())(f)
   }
 
 }

--- a/cats-effect/src/main/scala-2/effectie/cats/ConsoleEffect.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/ConsoleEffect.scala
@@ -11,10 +11,10 @@ object ConsoleEffect {
   def apply[F[_]: ConsoleEffect]: ConsoleEffect[F] =
     implicitly[ConsoleEffect[F]]
 
-  implicit def consoleEffectF[F[_]: FxCtor: FlatMap]: ConsoleEffect[F] =
+  implicit def consoleEffectF[F[_]: effectie.FxCtor: FlatMap]: ConsoleEffect[F] =
     new ConsoleEffectF[F]
 
-  final class ConsoleEffectF[F[_]: FxCtor: FlatMap] extends ConsoleEffectWithoutFlatMap[F] with ConsoleEffect[F] {
+  final class ConsoleEffectF[F[_]: effectie.FxCtor: FlatMap] extends ConsoleEffectWithoutFlatMap[F] with ConsoleEffect[F] {
 
     @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
     override def readYesNo(prompt: String): F[YesNo] = for {
@@ -22,9 +22,9 @@ object ConsoleEffect {
       answer <- readLn
       yesOrN <- answer match {
                   case "y" | "Y" =>
-                    FxCtor[F].effectOf(YesNo.yes)
+                    effectie.FxCtor[F].effectOf(YesNo.yes)
                   case "n" | "N" =>
-                    FxCtor[F].effectOf(YesNo.no)
+                    effectie.FxCtor[F].effectOf(YesNo.no)
                   case _         =>
                     readYesNo(prompt)
                 }

--- a/cats-effect/src/main/scala-2/effectie/cats/Effectful.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/Effectful.scala
@@ -2,13 +2,14 @@ package effectie.cats
 
 import effectie.cats.Effectful._
 
+
 trait Effectful {
 
   def effectOf[F[_]]: CurriedEffectOf[F] = new CurriedEffectOf[F]
 
   def pureOf[F[_]]: CurriedEffectOfPure[F] = new CurriedEffectOfPure[F]
 
-  def unitOf[F[_]: FxCtor]: F[Unit] = FxCtor[F].unitOf
+  def unitOf[F[_]: effectie.FxCtor]: F[Unit] = effectie.FxCtor[F].unitOf
 
   def errorOf[F[_]]: CurriedErrorOf[F] = new CurriedErrorOf[F]
 
@@ -16,7 +17,7 @@ trait Effectful {
   @inline final def effectOfPure[F[_]]: CurriedEffectOfPure[F] = pureOf[F]
 
   @deprecated(message = "Use unitOf instead", since = "1.4.0")
-  @inline final def effectOfUnit[F[_]: FxCtor]: F[Unit] = unitOf[F]
+  @inline final def effectOfUnit[F[_]: effectie.FxCtor]: F[Unit] = unitOf[F]
 
 }
 
@@ -26,22 +27,22 @@ object Effectful extends Effectful {
   private[Effectful] final class CurriedEffectOf[F[_]](
     private val dummy: Boolean = true
   ) extends AnyVal {
-    def apply[A](a: => A)(implicit EF: FxCtor[F]): F[A] =
-      FxCtor[F].effectOf(a)
+    def apply[A](a: => A)(implicit EF: effectie.FxCtor[F]): F[A] =
+      effectie.FxCtor[F].effectOf(a)
   }
 
   private[Effectful] final class CurriedEffectOfPure[F[_]](
     private val dummy: Boolean = true
   ) extends AnyVal {
-    def apply[A](a: A)(implicit EF: FxCtor[F]): F[A] =
-      FxCtor[F].pureOf(a)
+    def apply[A](a: A)(implicit EF: effectie.FxCtor[F]): F[A] =
+      effectie.FxCtor[F].pureOf(a)
   }
 
   private[Effectful] final class CurriedErrorOf[F[_]](
     private val dummy: Boolean = true
   ) extends AnyVal {
-    def apply[A](throwable: Throwable)(implicit EF: FxCtor[F]): F[A] =
-      FxCtor[F].errorOf(throwable)
+    def apply[A](throwable: Throwable)(implicit EF: effectie.FxCtor[F]): F[A] =
+      effectie.FxCtor[F].errorOf(throwable)
   }
 
 }

--- a/cats-effect/src/main/scala-2/effectie/cats/Fx.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/Fx.scala
@@ -3,12 +3,8 @@ package effectie.cats
 import cats.effect.IO
 import cats.Id
 
-import scala.concurrent.{ExecutionContext, Future}
-
-trait Fx[F[_]] extends effectie.Fx[F] with FxCtor[F] with effectie.FxCtor[F] with CanCatch[F]
-
 object Fx {
-  def apply[F[_]: Fx]: Fx[F] = implicitly[Fx[F]]
+  type Fx[F[_]] = effectie.Fx[F]
 
   implicit object IoFx extends Fx[IO] {
 
@@ -25,18 +21,6 @@ object Fx {
 
     override def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       CanCatch.CanCatchIo.catchNonFatalThrowable(fa)
-  }
-
-  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
-  implicit def futureFx(implicit EC: ExecutionContext): Fx[Future] = new FutureFx
-
-  final class FutureFx(implicit override val EC0: ExecutionContext)
-      extends Fx[Future]
-      with FxCtor[Future]
-      with effectie.FxCtor.FutureFxCtor
-      with effectie.CanCatch.CanCatchFuture {
-    override def catchNonFatalThrowable[A](fa: => Future[A]): Future[Either[Throwable, A]] =
-      CanCatch.canCatchFuture.catchNonFatalThrowable(fa)
   }
 
   implicit object IdFx extends Fx[Id] {

--- a/cats-effect/src/main/scala-2/effectie/cats/FxCtor.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/FxCtor.scala
@@ -3,18 +3,10 @@ package effectie.cats
 import cats.Id
 import cats.effect.IO
 
-import scala.concurrent.{ExecutionContext, Future}
-
-trait FxCtor[F[_]] extends effectie.FxCtor[F]
-
 object FxCtor {
-  def apply[F[_]: FxCtor]: FxCtor[F] = implicitly[FxCtor[F]]
+  type FxCtor[F[_]] = effectie.FxCtor[F]
 
   implicit final val ioFxCtor: FxCtor[IO] = Fx.IoFx
-
-  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
-  implicit def futureFxCtor(implicit EC: ExecutionContext): FxCtor[Future] =
-    Fx.futureFx
 
   implicit final val idFxCtor: FxCtor[Id] = Fx.IdFx
 

--- a/cats-effect/src/main/scala-2/effectie/cats/package.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/package.scala
@@ -1,0 +1,24 @@
+package effectie
+
+import _root_.cats.data.EitherT
+
+/** @author Kevin Lee
+  * @since 2021-11-14
+  */
+package object cats {
+
+  implicit final class CanCatchOps[F[_]](private val canCatch: effectie.CanCatch[F]) extends AnyVal {
+
+    def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =
+      EitherT(canCatch.catchNonFatalEither[A, AA, B](fab.value)(f))
+
+  }
+
+  implicit final class FxhOps[F[_]](private val fx: Fx[F]) extends AnyVal {
+
+    def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =
+      EitherT(fx.catchNonFatalEither[A, AA, B](fab.value)(f))
+
+  }
+
+}

--- a/cats-effect/src/main/scala-2/effectie/cats/syntax/error.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/syntax/error.scala
@@ -1,8 +1,10 @@
 package effectie.cats.syntax
 
 import cats.data.EitherT
+import effectie.CanCatch
 import effectie.cats.syntax.error.{EitherTFABErrorHandlingOps, FAErrorHandlingOps, FEitherABErrorHandlingOps}
-import effectie.cats.{CanCatch, CanHandleError, CanRecover}
+import effectie.cats.{CanHandleError, CanRecover}
+import effectie.cats._
 
 /** @author Kevin Lee
   * @since 2021-10-16

--- a/cats-effect/src/main/scala-3/effectie/cats/CanHandleError.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/CanHandleError.scala
@@ -10,7 +10,7 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2020-08-17
   */
-trait CanHandleError[F[_]] extends effectie.CanHandleError[F] {
+trait CanHandleError[F[*]] extends effectie.CanHandleError[F] {
 
   type XorT[A, B] = EitherT[F, A, B]
 
@@ -24,7 +24,7 @@ trait CanHandleError[F[_]] extends effectie.CanHandleError[F] {
 
 object CanHandleError {
 
-  def apply[F[_]: CanHandleError]: CanHandleError[F] = summon[CanHandleError[F]]
+  def apply[F[*]: CanHandleError]: CanHandleError[F] = summon[CanHandleError[F]]
 
   given ioCanHandleError: CanHandleError[IO] with {
 

--- a/cats-effect/src/main/scala-3/effectie/cats/CanRecover.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/CanRecover.scala
@@ -10,7 +10,7 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2020-08-17
   */
-trait CanRecover[F[_]] extends effectie.CanRecover[F] {
+trait CanRecover[F[*]] extends effectie.CanRecover[F] {
 
   type XorT[A, B] = EitherT[F, A, B]
 
@@ -23,7 +23,7 @@ trait CanRecover[F[_]] extends effectie.CanRecover[F] {
 
 object CanRecover {
 
-  def apply[F[_]: CanRecover]: CanRecover[F] = summon[CanRecover[F]]
+  def apply[F[*]: CanRecover]: CanRecover[F] = summon[CanRecover[F]]
 
   given ioCanRecover: CanRecover[IO] with {
     override def recoverFromNonFatalWith[A, AA >: A](fa: => IO[A])(

--- a/cats-effect/src/main/scala-3/effectie/cats/Catching.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/Catching.scala
@@ -1,6 +1,7 @@
 package effectie.cats
 
 import cats.data.EitherT
+import effectie.{CanCatch, Fx}
 
 /** @author Kevin Lee
   * @since 2020-06-07
@@ -9,89 +10,89 @@ trait Catching {
 
   import Catching.*
 
-  final def catchNonFatal[F[_]]: CurriedCanCatch1[F] =
+  final def catchNonFatal[F[*]]: CurriedCanCatch1[F] =
     new CurriedCanCatch1[F]
 
-  final def catchNonFatalF[F[_]]: CurriedCanCatchF1[F] =
+  final def catchNonFatalF[F[*]]: CurriedCanCatchF1[F] =
     new CurriedCanCatchF1[F]
 
-  def catchNonFatalEither[F[_]]: CurriedCanCatchEither1[F] =
+  def catchNonFatalEither[F[*]]: CurriedCanCatchEither1[F] =
     new CurriedCanCatchEither1[F]
 
-  def catchNonFatalEitherF[F[_]]: CurriedCanCatchEitherF1[F] =
+  def catchNonFatalEitherF[F[*]]: CurriedCanCatchEitherF1[F] =
     new CurriedCanCatchEitherF1[F]
 
-  def catchNonFatalEitherT[F[_]]: CurriedCanCatchEitherT1[F] =
+  def catchNonFatalEitherT[F[*]]: CurriedCanCatchEitherT1[F] =
     new CurriedCanCatchEitherT1[F]
 
 }
 
 object Catching extends Catching {
 
-  private[Catching] final class CurriedCanCatch1[F[_]](
+  private[Catching] final class CurriedCanCatch1[F[*]](
     private val dummy: Boolean = true
   ) extends AnyVal {
     def apply[B](fb: => F[B]): CurriedCanCatch2[F, B] =
       new CurriedCanCatch2[F, B](() => fb)
   }
 
-  private[Catching] final class CurriedCanCatch2[F[_], B](
+  private[Catching] final class CurriedCanCatch2[F[*], B](
     private val fb: () => F[B]
   ) extends AnyVal {
     def apply[A](f: Throwable => A)(using CC: CanCatch[F]): F[Either[A, B]] =
       CanCatch[F].catchNonFatal(fb())(f)
   }
 
-  private[Catching] final class CurriedCanCatchF1[F[_]](
+  private[Catching] final class CurriedCanCatchF1[F[*]](
     private val dummy: Boolean = true
   ) extends AnyVal {
     def apply[B](b: => B): CurriedCanCatchF2[F, B] =
       new CurriedCanCatchF2[F, B](() => b)
   }
 
-  private[Catching] final class CurriedCanCatchF2[F[_], B](
+  private[Catching] final class CurriedCanCatchF2[F[*], B](
     private val b: () => B
   ) extends AnyVal {
-    def apply[A](f: Throwable => A)(using EC: FxCtor[F], CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatal(FxCtor[F].effectOf(b()))(f)
+    def apply[A](f: Throwable => A)(using EC: Fx[F], CC: CanCatch[F]): F[Either[A, B]] =
+      CanCatch[F].catchNonFatal(Fx[F].effectOf(b()))(f)
   }
 
-  private[Catching] final class CurriedCanCatchEither1[F[_]](
+  private[Catching] final class CurriedCanCatchEither1[F[*]](
     private val dummy: Boolean = true
   ) extends AnyVal {
     def apply[A, B](fab: => F[Either[A, B]]): CurriedCanCatchEither2[F, A, B] =
       new CurriedCanCatchEither2[F, A, B](() => fab)
   }
 
-  private[Catching] final class CurriedCanCatchEither2[F[_], A, B](
+  private[Catching] final class CurriedCanCatchEither2[F[*], A, B](
     private val fab: () => F[Either[A, B]]
   ) extends AnyVal {
     def apply(f: Throwable => A)(using CC: CanCatch[F]): F[Either[A, B]] =
       CanCatch[F].catchNonFatalEither(fab())(f)
   }
 
-  private[Catching] final class CurriedCanCatchEitherF1[F[_]](
+  private[Catching] final class CurriedCanCatchEitherF1[F[*]](
     private val dummy: Boolean = true
   ) extends AnyVal {
     def apply[A, B](ab: => Either[A, B]): CurriedCanCatchEitherF2[F, A, B] =
       new CurriedCanCatchEitherF2[F, A, B](() => ab)
   }
 
-  private[Catching] final class CurriedCanCatchEitherF2[F[_], A, B](
+  private[Catching] final class CurriedCanCatchEitherF2[F[*], A, B](
     private val ab: () => Either[A, B]
   ) extends AnyVal {
-    def apply(f: Throwable => A)(using EC: FxCtor[F], CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatalEither(FxCtor[F].effectOf(ab()))(f)
+    def apply(f: Throwable => A)(using EC: Fx[F], CC: CanCatch[F]): F[Either[A, B]] =
+      CanCatch[F].catchNonFatalEither(Fx[F].effectOf(ab()))(f)
   }
 
-  private[Catching] final class CurriedCanCatchEitherT1[F[_]](
+  private[Catching] final class CurriedCanCatchEitherT1[F[*]](
     private val dummy: Boolean = true
   ) extends AnyVal {
     def apply[A, B](fab: => EitherT[F, A, B]): CurriedCanCatchEitherT2[F, A, B] =
       new CurriedCanCatchEitherT2[F, A, B](() => fab)
   }
 
-  private[Catching] final class CurriedCanCatchEitherT2[F[_], A, B](
+  private[Catching] final class CurriedCanCatchEitherT2[F[*], A, B](
     private val fab: () => EitherT[F, A, B]
   ) extends AnyVal {
     def apply(f: Throwable => A)(using CC: CanCatch[F]): EitherT[F, A, B] =

--- a/cats-effect/src/main/scala-3/effectie/cats/ConsoleEffect.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/ConsoleEffect.scala
@@ -3,17 +3,17 @@ package effectie.cats
 import cats.*
 import cats.syntax.all.*
 import effectie.ConsoleEffect.ConsoleEffectWithoutFlatMap
-import effectie.YesNo
+import effectie.{FxCtor, YesNo}
 
-trait ConsoleEffect[F[_]] extends effectie.ConsoleEffect[F]
+trait ConsoleEffect[F[*]] extends effectie.ConsoleEffect[F]
 
 object ConsoleEffect {
-  def apply[F[_]: ConsoleEffect]: ConsoleEffect[F] = summon[ConsoleEffect[F]]
+  def apply[F[*]: ConsoleEffect]: ConsoleEffect[F] = summon[ConsoleEffect[F]]
 
-  given consoleEffectF[F[_]: FxCtor: FlatMap]: ConsoleEffect[F] =
+  given consoleEffectF[F[*]: FxCtor: FlatMap]: ConsoleEffect[F] =
     new ConsoleEffectF[F]
 
-  final class ConsoleEffectF[F[_]: FxCtor: FlatMap] extends ConsoleEffectWithoutFlatMap[F] with ConsoleEffect[F] {
+  final class ConsoleEffectF[F[*]: FxCtor: FlatMap] extends ConsoleEffectWithoutFlatMap[F] with ConsoleEffect[F] {
 
     override def readYesNo(prompt: String): F[YesNo] = for {
       _      <- putStrLn(prompt)

--- a/cats-effect/src/main/scala-3/effectie/cats/ConsoleEffectful.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/ConsoleEffectful.scala
@@ -4,15 +4,15 @@ import effectie.YesNo
 
 trait ConsoleEffectful {
 
-  def readLn[F[_]: ConsoleEffect]: F[String] = ConsoleEffect[F].readLn
+  def readLn[F[*]: ConsoleEffect]: F[String] = ConsoleEffect[F].readLn
 
-  def readPassword[F[_]: ConsoleEffect]: F[Array[Char]] = ConsoleEffect[F].readPassword
+  def readPassword[F[*]: ConsoleEffect]: F[Array[Char]] = ConsoleEffect[F].readPassword
 
-  def putStrLn[F[_]: ConsoleEffect](value: String): F[Unit] = ConsoleEffect[F].putStrLn(value)
+  def putStrLn[F[*]: ConsoleEffect](value: String): F[Unit] = ConsoleEffect[F].putStrLn(value)
 
-  def putErrStrLn[F[_]: ConsoleEffect](value: String): F[Unit] = ConsoleEffect[F].putErrStrLn(value)
+  def putErrStrLn[F[*]: ConsoleEffect](value: String): F[Unit] = ConsoleEffect[F].putErrStrLn(value)
 
-  def readYesNo[F[_]: ConsoleEffect](prompt: String): F[YesNo] = ConsoleEffect[F].readYesNo(prompt)
+  def readYesNo[F[*]: ConsoleEffect](prompt: String): F[YesNo] = ConsoleEffect[F].readYesNo(prompt)
 
 }
 

--- a/cats-effect/src/main/scala-3/effectie/cats/Effectful.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/Effectful.scala
@@ -1,42 +1,43 @@
 package effectie.cats
 
+import effectie.FxCtor
 import effectie.cats.Effectful.*
 
 trait Effectful {
 
-  def effectOf[F[_]]: CurriedEffectOf[F] = new CurriedEffectOf[F]
+  def effectOf[F[*]]: CurriedEffectOf[F] = new CurriedEffectOf[F]
 
-  def pureOf[F[_]]: CurriedEffectOfPure[F] = new CurriedEffectOfPure[F]
+  def pureOf[F[*]]: CurriedEffectOfPure[F] = new CurriedEffectOfPure[F]
 
-  inline final def unitOf[F[_]: FxCtor]: F[Unit] = FxCtor[F].unitOf
+  inline final def unitOf[F[*]: FxCtor]: F[Unit] = FxCtor[F].unitOf
 
-  def errorOf[F[_]]: CurriedErrorOf[F] = new CurriedErrorOf[F]
+  def errorOf[F[*]]: CurriedErrorOf[F] = new CurriedErrorOf[F]
 
   @deprecated(message = "Use pureOf instead.", since = "1.4.0")
-  inline final def effectOfPure[F[_]]: CurriedEffectOfPure[F] = pureOf[F]
+  inline final def effectOfPure[F[*]]: CurriedEffectOfPure[F] = pureOf[F]
 
   @deprecated(message = "Use unitOf instead", since = "1.4.0")
-  inline final def effectOfUnit[F[_]: FxCtor]: F[Unit] = unitOf[F]
+  inline final def effectOfUnit[F[*]: FxCtor]: F[Unit] = unitOf[F]
 
 }
 
 object Effectful extends Effectful {
 
-  private[Effectful] final class CurriedEffectOf[F[_]](
+  private[Effectful] final class CurriedEffectOf[F[*]](
     private val dummy: Boolean = true
   ) extends AnyVal {
     def apply[A](a: => A)(using EF: FxCtor[F]): F[A] =
       FxCtor[F].effectOf(a)
   }
 
-  private[Effectful] final class CurriedEffectOfPure[F[_]](
+  private[Effectful] final class CurriedEffectOfPure[F[*]](
     private val dummy: Boolean = true
   ) extends AnyVal {
     def apply[A](a: A)(using EF: FxCtor[F]): F[A] =
       FxCtor[F].pureOf(a)
   }
 
-  private[Effectful] final class CurriedErrorOf[F[_]](
+  private[Effectful] final class CurriedErrorOf[F[*]](
     private val dummy: Boolean = true
   ) extends AnyVal {
     def apply[A](throwable: Throwable)(using EF: FxCtor[F]): F[A] =

--- a/cats-effect/src/main/scala-3/effectie/cats/FromFuture.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/FromFuture.scala
@@ -9,13 +9,13 @@ import scala.concurrent.{Await, Future}
 /** @author Kevin Lee
   * @since 2020-09-22
   */
-trait FromFuture[F[_]] {
+trait FromFuture[F[*]] {
   def toEffect[A](future: => Future[A]): F[A]
 }
 
 object FromFuture {
 
-  def apply[F[_]: FromFuture]: FromFuture[F] = summon[FromFuture[F]]
+  def apply[F[*]: FromFuture]: FromFuture[F] = summon[FromFuture[F]]
 
   given fromFutureToIo(using cs: ContextShift[IO]): FromFuture[IO] with {
     override def toEffect[A](future: => Future[A]): IO[A] =

--- a/cats-effect/src/main/scala-3/effectie/cats/Fx.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/Fx.scala
@@ -5,10 +5,8 @@ import cats.{Applicative, Id, Monad}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait Fx[F[_]] extends effectie.Fx[F] with FxCtor[F] with effectie.FxCtor[F] with CanCatch[F]
-
 object Fx {
-  def apply[F[_]: Fx]: Fx[F] = summon[Fx[F]]
+  type Fx[F[*]] = effectie.Fx[F]
 
   given ioFx: Fx[IO] with {
 
@@ -25,19 +23,6 @@ object Fx {
     inline override def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       fa.attempt
 
-  }
-
-  given futureFx(using EC: ExecutionContext): Fx[Future] =
-    new FutureFx
-
-  final class FutureFx(using override val EC0: ExecutionContext)
-      extends Fx[Future]
-      with FxCtor[Future]
-      with effectie.FxCtor.FutureFxCtor
-      with effectie.CanCatch.CanCatchFuture {
-
-    override def catchNonFatalThrowable[A](fa: => Future[A]): Future[Either[Throwable, A]] =
-      CanCatch.canCatchFuture.catchNonFatalThrowable(fa)
   }
 
   given idFx: Fx[Id] with {

--- a/cats-effect/src/main/scala-3/effectie/cats/FxCtor.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/FxCtor.scala
@@ -5,15 +5,13 @@ import cats.effect.IO
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait FxCtor[F[_]] extends effectie.FxCtor[F]
-
 object FxCtor {
-  def apply[F[_]: FxCtor]: FxCtor[F] = summon[FxCtor[F]]
+  type FxCtor[F[*]] = effectie.FxCtor[F]
 
   given ioFxCtor: FxCtor[IO] = Fx.ioFx
 
   given futureFxCtor(using EC: ExecutionContext): FxCtor[Future] =
-    Fx.futureFx
+    effectie.Fx.fxFuture
 
   given idFxCtor: FxCtor[Id] = Fx.idFx
 

--- a/cats-effect/src/main/scala-3/effectie/cats/ToFuture.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/ToFuture.scala
@@ -8,7 +8,7 @@ import scala.concurrent.{ExecutionContext, Future}
 /** @author Kevin Lee
   * @since 2020-09-23
   */
-trait ToFuture[F[_]] {
+trait ToFuture[F[*]] {
 
   def unsafeToFuture[A](fa: F[A]): Future[A]
 
@@ -16,7 +16,7 @@ trait ToFuture[F[_]] {
 
 object ToFuture {
 
-  def apply[F[_]: ToFuture]: ToFuture[F] = summon[ToFuture[F]]
+  def apply[F[*]: ToFuture]: ToFuture[F] = summon[ToFuture[F]]
 
   given ioToFuture: ToFuture[IO] with {
 

--- a/cats-effect/src/main/scala-3/effectie/cats/cats.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/cats.scala
@@ -1,0 +1,21 @@
+package effectie.cats
+
+import _root_.cats.data.EitherT
+import effectie.Fx
+
+/** @author Kevin Lee
+  * @since 2021-11-25
+  */
+extension [F[*]](canCatch: effectie.CanCatch[F]) {
+
+  def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =
+    EitherT(canCatch.catchNonFatalEither[A, AA, B](fab.value)(f))
+
+}
+
+extension [F[*]](fx: Fx[F]) {
+
+  def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =
+    EitherT(fx.catchNonFatalEither[A, AA, B](fab.value)(f))
+
+}

--- a/cats-effect/src/main/scala-3/effectie/cats/syntax/error.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/syntax/error.scala
@@ -1,7 +1,8 @@
 package effectie.cats.syntax
 
 import cats.data.EitherT
-import effectie.cats.{CanCatch, CanHandleError, CanRecover}
+import effectie.CanCatch
+import effectie.cats.*
 
 /** @author Kevin Lee
   * @since 2021-10-16
@@ -92,7 +93,7 @@ trait error {
     )(
       using canCatch: CanCatch[F]
     ): EitherT[F, AA, B] =
-      canCatch.catchNonFatalEitherT[A, AA, B](efab)(f)
+      EitherT(canCatch.catchNonFatalEither[A, AA, B](efab.value)(f))
 
     def handleEitherTNonFatalWith[AA >: A, BB >: B](
       handleError: Throwable => F[Either[AA, BB]]

--- a/cats-effect/src/test/scala-2/effectie/cats/CanCatchSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/CanCatchSpec.scala
@@ -5,6 +5,7 @@ import cats.data.EitherT
 import cats.effect._
 import cats.instances.all._
 import cats.syntax.all._
+import effectie.cats.Fx._
 import effectie.cats.Effectful._
 import effectie.testing.types._
 import effectie.{ConcurrentSupport, SomeControlThrowable}
@@ -17,6 +18,10 @@ import scala.util.control.ControlThrowable
   * @since 2020-07-31
   */
 object CanCatchSpec extends Properties {
+
+  type FxCtor[F[_]] = effectie.FxCtor[F]
+  type CanCatch[F[_]] = effectie.CanCatch[F]
+  val CanCatch: effectie.CanCatch.type = effectie.CanCatch
 
   override def tests: List[Test] = List(
     /* IO */

--- a/cats-effect/src/test/scala-2/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/CanHandleErrorSpec.scala
@@ -8,6 +8,7 @@ import cats.syntax.all._
 import effectie.cats.Effectful._
 import effectie.testing.types.SomeError
 import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.cats.FxCtor._
 import hedgehog._
 import hedgehog.runner._
 
@@ -17,6 +18,10 @@ import scala.util.control.{ControlThrowable, NonFatal}
   * @since 2020-08-17
   */
 object CanHandleErrorSpec extends Properties {
+
+  type FxCtor[F[_]] = effectie.FxCtor[F]
+  val FxCtor: effectie.FxCtor.type = effectie.FxCtor
+
 
   override def tests: List[Test] = List(
     /* IO */

--- a/cats-effect/src/test/scala-2/effectie/cats/CanRecoverSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/CanRecoverSpec.scala
@@ -6,6 +6,7 @@ import cats.effect.IO
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.cats.Effectful._
+import effectie.cats.FxCtor._
 import effectie.testing.types.SomeError
 import effectie.{ConcurrentSupport, SomeControlThrowable}
 import hedgehog._
@@ -17,6 +18,8 @@ import scala.util.control.{ControlThrowable, NonFatal}
   * @since 2020-08-17
   */
 object CanRecoverSpec extends Properties {
+  type FxCtor[F[_]] = effectie.FxCtor[F]
+  val FxCtor: effectie.FxCtor.type = effectie.FxCtor
 
   override def tests: List[Test] = List(
     /* IO */

--- a/cats-effect/src/test/scala-2/effectie/cats/CatchingSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/CatchingSpec.scala
@@ -9,6 +9,7 @@ import cats.syntax.all._
 import effectie.cats.Effectful._
 import effectie.testing.types.SomeError
 import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.cats.Fx._
 import hedgehog._
 import hedgehog.runner._
 
@@ -18,6 +19,8 @@ import scala.util.control.ControlThrowable
   * @since 2020-07-31
   */
 object CatchingSpec extends Properties {
+  type FxCtor[F[_]] = effectie.FxCtor[F]
+  val FxCtor: effectie.FxCtor.type = effectie.FxCtor
 
   override def tests: List[Test] = List(
     /* IO */

--- a/cats-effect/src/test/scala-2/effectie/cats/EffectfulSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/EffectfulSpec.scala
@@ -12,6 +12,10 @@ import hedgehog.runner._
   * @since 2021-05-16
   */
 object EffectfulSpec extends Properties {
+  type Fx[F[_]] = effectie.Fx[F]
+  val Fx: effectie.Fx.type = effectie.Fx
+  type FxCtor[F[_]] = effectie.FxCtor[F]
+
   override def tests: List[Test] = List(
     property("test Effectful.{effectOf, pureOf, unitOf} for IO", IoSpec.testAll),
     property("test Effectful.effectOf[IO]", IoSpec.testEffectOf),
@@ -64,6 +68,7 @@ object EffectfulSpec extends Properties {
   }
 
   object IoSpec {
+    import effectie.cats.Fx._
 
     @SuppressWarnings(Array("org.wartremover.warts.Any", "org.wartremover.warts.Nothing"))
     def testAll: Property = for {
@@ -276,6 +281,7 @@ object EffectfulSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.cats.Fx._
 
     def testAll: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/cats-effect/src/test/scala-2/effectie/cats/FxCtorSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/FxCtorSpec.scala
@@ -10,6 +10,12 @@ import hedgehog.runner._
   * @since 2020-12-06
   */
 object FxCtorSpec extends Properties {
+
+  type Fx[F[_]] = effectie.Fx[F]
+  val Fx: effectie.Fx.type = effectie.Fx
+  type FxCtor[F[_]] = effectie.FxCtor[F]
+  val FxCtor: effectie.FxCtor.type = effectie.FxCtor
+
   override def tests: List[Test] = List(
     property("test FxCtor[IO].effectOf", IoSpec.testEffectOf),
     property("test FxCtor[IO].pureOf", IoSpec.testPureOf),
@@ -23,6 +29,7 @@ object FxCtorSpec extends Properties {
   )
 
   object IoSpec {
+    import effectie.cats.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
@@ -134,6 +141,7 @@ object FxCtorSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.cats.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/cats-effect/src/test/scala-2/effectie/cats/syntax/errorSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/syntax/errorSpec.scala
@@ -5,10 +5,10 @@ import cats.data.EitherT
 import cats.effect._
 import cats.syntax.all._
 import effectie.cats.Effectful._
-import effectie.cats.FxCtor
+import effectie.cats.Fx._
 import effectie.cats.syntax.error._
 import effectie.testing.types._
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, FxCtor, SomeControlThrowable}
 import hedgehog._
 import hedgehog.runner._
 

--- a/cats-effect/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
@@ -7,7 +7,7 @@ import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.cats.Effectful.*
 import effectie.testing.types.SomeError
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, FxCtor, SomeControlThrowable}
 import hedgehog.*
 import hedgehog.runner.*
 
@@ -356,10 +356,11 @@ object CanHandleErrorSpec extends Properties {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: FxCtor: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IoSpec {
+    import effectie.cats.Fx.given
 
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -1195,6 +1196,7 @@ object CanHandleErrorSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 

--- a/cats-effect/src/test/scala-3/effectie/cats/CanRecoverSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CanRecoverSpec.scala
@@ -7,7 +7,7 @@ import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.cats.Effectful.*
 import effectie.testing.types.SomeError
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, FxCtor, SomeControlThrowable}
 import hedgehog.*
 import hedgehog.runner.*
 
@@ -357,10 +357,11 @@ object CanRecoverSpec extends Properties {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: FxCtor: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IOSpec {
+    import effectie.cats.Fx.given
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
@@ -1331,6 +1332,7 @@ object CanRecoverSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 

--- a/cats-effect/src/test/scala-3/effectie/cats/CatchingSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CatchingSpec.scala
@@ -8,7 +8,7 @@ import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.cats.Effectful.*
 import effectie.testing.types.SomeError
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, FxCtor, SomeControlThrowable}
 import hedgehog.*
 import hedgehog.runner.*
 
@@ -225,10 +225,13 @@ object CatchingSpec extends Properties {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: FxCtor: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IoSpec {
+
+    import effectie.cats.Fx.given
+
     def testCatching_IO_catchNonFatalShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
@@ -657,6 +660,8 @@ object CatchingSpec extends Properties {
   }
 
   object IdSpec {
+
+    import effectie.cats.Fx.given
 
     def testCatching_Id_catchNonFatalShouldCatchNonFatal: Result = {
 

--- a/cats-effect/src/test/scala-3/effectie/cats/EffectfulSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/EffectfulSpec.scala
@@ -2,7 +2,7 @@ package effectie.cats
 
 import cats.Id
 import cats.effect.IO
-import effectie.ConcurrentSupport
+import effectie.{ConcurrentSupport, Fx, FxCtor}
 import effectie.testing.tools.*
 import effectie.testing.types.SomeThrowableError
 import hedgehog.*
@@ -32,29 +32,29 @@ object EffectfulSpec extends Properties {
 
   import Effectful.*
 
-  trait FxCtorClient[F[_]] {
+  trait FxCtorClient[F[*]] {
     def eftOf[A](a: A): F[A]
     def of[A](a: A): F[A]
     def unit: F[Unit]
   }
   object FxCtorClient      {
-    def apply[F[_]: FxCtorClient]: FxCtorClient[F] = summon[FxCtorClient[F]]
-    given eftClientF[F[_]: FxCtor]: FxCtorClient[F] with {
+    def apply[F[*]: FxCtorClient]: FxCtorClient[F] = summon[FxCtorClient[F]]
+    given eftClientF[F[*]: FxCtor]: FxCtorClient[F] with {
       override def eftOf[A](a: A): F[A] = effectOf(a)
       override def of[A](a: A): F[A]    = pureOf(a)
       override def unit: F[Unit]        = unitOf
     }
   }
 
-  trait FxClient[F[_]] {
+  trait FxClient[F[*]] {
     def eftOf[A](a: A): F[A]
     def of[A](a: A): F[A]
     def unit: F[Unit]
   }
   object FxClient      {
-    def apply[F[_]: FxClient]: FxClient[F] =
+    def apply[F[*]: FxClient]: FxClient[F] =
       summon[FxClient[F]]
-    given eftClientF[F[_]: Fx]: FxClient[F] with {
+    given eftClientF[F[*]: Fx]: FxClient[F] with {
       override def eftOf[A](a: A): F[A] = effectOf(a)
       override def of[A](a: A): F[A]    = pureOf(a)
       override def unit: F[Unit]        = unitOf
@@ -62,6 +62,8 @@ object EffectfulSpec extends Properties {
   }
 
   object IoSpec {
+
+    import effectie.cats.Fx.given
 
     def testAll: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
@@ -271,6 +273,8 @@ object EffectfulSpec extends Properties {
   }
 
   object IdSpec {
+
+    import effectie.cats.Fx.given
 
     def testAll: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/cats-effect/src/test/scala-3/effectie/cats/FxCtorSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/FxCtorSpec.scala
@@ -3,6 +3,7 @@ package effectie.cats
 import cats.Id
 import cats.effect.*
 import effectie.ConcurrentSupport
+import effectie.FxCtor
 import hedgehog.*
 import hedgehog.runner.*
 
@@ -23,6 +24,8 @@ object FxCtorSpec extends Properties {
   )
 
   object IoSpec {
+
+    import effectie.cats.FxCtor.given
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
@@ -130,6 +133,8 @@ object FxCtorSpec extends Properties {
   }
 
   object IdSpec {
+
+    import effectie.cats.FxCtor.given
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/cats-effect/src/test/scala-3/effectie/cats/syntax/errorSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/syntax/errorSpec.scala
@@ -5,7 +5,7 @@ import cats.data.EitherT
 import cats.syntax.all.*
 import cats.effect.*
 import effectie.cats.FxCtor
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, Fx, SomeControlThrowable}
 import effectie.cats.Effectful.*
 import effectie.cats.syntax.error.*
 import effectie.testing.types.SomeError
@@ -185,10 +185,11 @@ object CanCatchSyntaxSpec {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: Fx: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IoSpec {
+    import effectie.cats.Fx.given
 
     def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -525,6 +526,8 @@ object CanCatchSyntaxSpec {
   }
 
   object IdSpec {
+
+    import effectie.cats.Fx.given
 
     def testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -1037,10 +1040,12 @@ object CanHandleErrorSyntaxSpec {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: Fx: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IoSpec {
+
+    import effectie.cats.Fx.given
 
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -1865,6 +1870,7 @@ object CanHandleErrorSyntaxSpec {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -2596,10 +2602,11 @@ object CanRecoverSyntaxSpec {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: Fx: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IOSpec {
+    import effectie.cats.Fx.given
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
@@ -3538,6 +3545,7 @@ object CanRecoverSyntaxSpec {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 

--- a/cats-effect/src/test/scala/effectie/cats/MonadSpec.scala
+++ b/cats-effect/src/test/scala/effectie/cats/MonadSpec.scala
@@ -4,6 +4,8 @@ import cats.{Eq, Monad}
 import hedgehog.runner.Test
 
 object MonadSpec {
+  type Fx[F[_]] = effectie.Fx[F]
+
   def testMonadLaws[F[_]: Fx: Monad](name: String)(implicit eqF: Eq[F[Int]]): List[Test] =
     effectie.testing.cats.MonadSpec.testAllLaws[F](s"Fx[$name]")
 }

--- a/cats-effect3/src/main/scala-2/effectie/cats/CanCatch.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/CanCatch.scala
@@ -1,29 +1,14 @@
 package effectie.cats
 
 import cats.Id
-import cats.data.EitherT
 import cats.effect.IO
 import cats.syntax.all._
-
-import scala.concurrent.{ExecutionContext, Future}
 
 /** @author Kevin Lee
   * @since 2020-06-07
   */
-trait CanCatch[F[_]] extends effectie.CanCatch[F] {
-
-  override type XorT[A, B] = EitherT[F, A, B]
-
-  @inline override final protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] =
-    EitherT(fab)
-
-  @inline override final protected def xorT2FEither[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] =
-    efab.value
-
-}
-
 object CanCatch {
-  def apply[F[_]: CanCatch]: CanCatch[F] = implicitly[CanCatch[F]]
+  type CanCatch[F[_]] = effectie.CanCatch[F]
 
   implicit object CanCatchIo extends CanCatch[IO] {
 
@@ -33,26 +18,6 @@ object CanCatch {
       fa.attempt
 
   }
-
-  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
-  implicit def canCatchFuture(implicit EC: ExecutionContext): CanCatch[Future] =
-    new effectie.CanCatch.CanCatchFuture with CanCatch[Future] {
-
-      override val EC0: ExecutionContext = EC
-
-      override def catchNonFatalThrowable[A](fa: => Future[A]): Future[Either[Throwable, A]] =
-        fa.transform {
-          case scala.util.Success(a) =>
-            scala.util.Try[Either[Throwable, A]](Right(a))
-
-          case scala.util.Failure(scala.util.control.NonFatal(ex)) =>
-            scala.util.Try[Either[Throwable, A]](Left(ex))
-
-          case scala.util.Failure(ex) =>
-            throw ex
-        }(EC0)
-
-    }
 
   implicit object CanCatchId extends CanCatch[Id] {
 

--- a/cats-effect3/src/main/scala-2/effectie/cats/Catching.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/Catching.scala
@@ -35,8 +35,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchThrowable[F[_]](
     private val dummy: Boolean = true
   ) extends AnyVal {
-    def apply[B](fb: => F[B])(implicit CC: CanCatch[F]): F[Either[Throwable, B]] =
-      CanCatch[F].catchNonFatalThrowable[B](fb)
+    def apply[B](fb: => F[B])(implicit CC: effectie.CanCatch[F]): F[Either[Throwable, B]] =
+      effectie.CanCatch[F].catchNonFatalThrowable[B](fb)
   }
 
   private[Catching] final class CurriedCanCatch1[F[_]](
@@ -49,8 +49,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatch2[F[_], B](
     private val fb: () => F[B]
   ) extends AnyVal {
-    def apply[A](f: Throwable => A)(implicit CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatal(fb())(f)
+    def apply[A](f: Throwable => A)(implicit CC: effectie.CanCatch[F]): F[Either[A, B]] =
+      effectie.CanCatch[F].catchNonFatal(fb())(f)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -64,8 +64,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchF2[F[_], B](
     private val b: () => B
   ) extends AnyVal {
-    def apply[A](f: Throwable => A)(implicit EC: FxCtor[F], CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatal(FxCtor[F].effectOf(b()))(f)
+    def apply[A](f: Throwable => A)(implicit EC: effectie.FxCtor[F], CC: effectie.CanCatch[F]): F[Either[A, B]] =
+      effectie.CanCatch[F].catchNonFatal(FxCtor[F].effectOf(b()))(f)
   }
 
   private[Catching] final class CurriedCanCatchEither1[F[_]](
@@ -78,8 +78,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchEither2[F[_], A, B](
     private val fab: () => F[Either[A, B]]
   ) extends AnyVal {
-    def apply(f: Throwable => A)(implicit CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatalEither(fab())(f)
+    def apply(f: Throwable => A)(implicit CC: effectie.CanCatch[F]): F[Either[A, B]] =
+      effectie.CanCatch[F].catchNonFatalEither(fab())(f)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -93,8 +93,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchEitherF2[F[_], A, B](
     private val ab: () => Either[A, B]
   ) extends AnyVal {
-    def apply(f: Throwable => A)(implicit EC: FxCtor[F], CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatalEither(FxCtor[F].effectOf(ab()))(f)
+    def apply(f: Throwable => A)(implicit EC: effectie.FxCtor[F], CC: effectie.CanCatch[F]): F[Either[A, B]] =
+      effectie.CanCatch[F].catchNonFatalEither(FxCtor[F].effectOf(ab()))(f)
   }
 
   private[Catching] final class CurriedCanCatchEitherT1[F[_]](
@@ -107,8 +107,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchEitherT2[F[_], A, B](
     private val fab: () => EitherT[F, A, B]
   ) extends AnyVal {
-    def apply(f: Throwable => A)(implicit CC: CanCatch[F]): EitherT[F, A, B] =
-      CanCatch[F].catchNonFatalEitherT(fab())(f)
+    def apply(f: Throwable => A)(implicit CC: effectie.CanCatch[F]): EitherT[F, A, B] =
+      effectie.CanCatch[F].catchNonFatalEitherT(fab())(f)
   }
 
 }

--- a/cats-effect3/src/main/scala-2/effectie/cats/ConsoleEffect.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/ConsoleEffect.scala
@@ -11,10 +11,10 @@ object ConsoleEffect {
   def apply[F[_]: ConsoleEffect]: ConsoleEffect[F] =
     implicitly[ConsoleEffect[F]]
 
-  implicit def consoleEffectF[F[_]: FxCtor: FlatMap]: ConsoleEffect[F] =
+  implicit def consoleEffectF[F[_]: effectie.FxCtor: FlatMap]: ConsoleEffect[F] =
     new ConsoleEffectF[F]
 
-  final class ConsoleEffectF[F[_]: FxCtor: FlatMap] extends ConsoleEffectWithoutFlatMap[F] with ConsoleEffect[F] {
+  final class ConsoleEffectF[F[_]: effectie.FxCtor: FlatMap] extends ConsoleEffectWithoutFlatMap[F] with ConsoleEffect[F] {
 
     @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
     override def readYesNo(prompt: String): F[YesNo] = for {
@@ -22,9 +22,9 @@ object ConsoleEffect {
       answer <- readLn
       yesOrN <- answer match {
                   case "y" | "Y" =>
-                    FxCtor[F].effectOf(YesNo.yes)
+                    effectie.FxCtor[F].effectOf(YesNo.yes)
                   case "n" | "N" =>
-                    FxCtor[F].effectOf(YesNo.no)
+                    effectie.FxCtor[F].effectOf(YesNo.no)
                   case _         =>
                     readYesNo(prompt)
                 }

--- a/cats-effect3/src/main/scala-2/effectie/cats/Effectful.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/Effectful.scala
@@ -8,7 +8,7 @@ trait Effectful {
 
   def pureOf[F[_]]: CurriedEffectOfPure[F] = new CurriedEffectOfPure[F]
 
-  def unitOf[F[_]: FxCtor]: F[Unit] = FxCtor[F].unitOf
+  def unitOf[F[_]: effectie.FxCtor]: F[Unit] = effectie.FxCtor[F].unitOf
 
   def errorOf[F[_]]: CurriedErrorOf[F] = new CurriedErrorOf[F]
 
@@ -16,7 +16,7 @@ trait Effectful {
   @inline final def effectOfPure[F[_]]: CurriedEffectOfPure[F] = pureOf[F]
 
   @deprecated(message = "Use unitOf instead", since = "1.4.0")
-  @inline final def effectOfUnit[F[_]: FxCtor]: F[Unit] = unitOf[F]
+  @inline final def effectOfUnit[F[_]: effectie.FxCtor]: F[Unit] = unitOf[F]
 
 }
 
@@ -26,22 +26,22 @@ object Effectful extends Effectful {
   private[Effectful] final class CurriedEffectOf[F[_]](
     private val dummy: Boolean = true
   ) extends AnyVal {
-    def apply[A](a: => A)(implicit EF: FxCtor[F]): F[A] =
-      FxCtor[F].effectOf(a)
+    def apply[A](a: => A)(implicit EF: effectie.FxCtor[F]): F[A] =
+      effectie.FxCtor[F].effectOf(a)
   }
 
   private[Effectful] final class CurriedEffectOfPure[F[_]](
     private val dummy: Boolean = true
   ) extends AnyVal {
-    def apply[A](a: A)(implicit EF: FxCtor[F]): F[A] =
-      FxCtor[F].pureOf(a)
+    def apply[A](a: A)(implicit EF: effectie.FxCtor[F]): F[A] =
+      effectie.FxCtor[F].pureOf(a)
   }
 
   private[Effectful] final class CurriedErrorOf[F[_]](
     private val dummy: Boolean = true
   ) extends AnyVal {
-    def apply[A](throwable: Throwable)(implicit EF: FxCtor[F]): F[A] =
-      FxCtor[F].errorOf(throwable)
+    def apply[A](throwable: Throwable)(implicit EF: effectie.FxCtor[F]): F[A] =
+      effectie.FxCtor[F].errorOf(throwable)
   }
 
 }

--- a/cats-effect3/src/main/scala-2/effectie/cats/Fx.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/Fx.scala
@@ -3,11 +3,9 @@ package effectie.cats
 import cats.effect.IO
 import cats.Id
 
-import scala.concurrent.{ExecutionContext, Future}
-
-trait Fx[F[_]] extends effectie.Fx[F] with FxCtor[F] with effectie.FxCtor[F] with CanCatch[F]
-
 object Fx {
+  type Fx[F[_]] = effectie.Fx[F]
+
   def apply[F[_]: Fx]: Fx[F] = implicitly[Fx[F]]
 
   implicit object IoFx extends Fx[IO] {
@@ -26,18 +24,6 @@ object Fx {
     override def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       CanCatch.CanCatchIo.catchNonFatalThrowable(fa)
 
-  }
-
-  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
-  implicit def futureFx(implicit EC: ExecutionContext): Fx[Future] = new FutureFx
-
-  final class FutureFx(implicit override val EC0: ExecutionContext)
-      extends Fx[Future]
-      with FxCtor[Future]
-      with effectie.FxCtor.FutureFxCtor
-      with effectie.CanCatch.CanCatchFuture {
-    override def catchNonFatalThrowable[A](fa: => Future[A]): Future[Either[Throwable, A]] =
-      CanCatch.canCatchFuture.catchNonFatalThrowable(fa)
   }
 
   implicit object IdFx extends Fx[Id] {

--- a/cats-effect3/src/main/scala-2/effectie/cats/FxCtor.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/FxCtor.scala
@@ -3,18 +3,12 @@ package effectie.cats
 import cats.Id
 import cats.effect.IO
 
-import scala.concurrent.{ExecutionContext, Future}
-
-trait FxCtor[F[_]] extends effectie.FxCtor[F]
-
 object FxCtor {
+  type FxCtor[F[_]] = effectie.FxCtor[F]
+
   def apply[F[_]: FxCtor]: FxCtor[F] = implicitly[FxCtor[F]]
 
   implicit final val ioFxCtor: FxCtor[IO] = Fx.IoFx
-
-  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
-  implicit def futureFxCtor(implicit EC: ExecutionContext): FxCtor[Future] =
-    Fx.futureFx
 
   implicit final val idFxCtor: FxCtor[Id] = Fx.IdFx
 

--- a/cats-effect3/src/main/scala-2/effectie/cats/package.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/package.scala
@@ -1,0 +1,24 @@
+package effectie
+
+import _root_.cats.data.EitherT
+
+/** @author Kevin Lee
+  * @since 2021-11-23
+  */
+package object cats {
+
+  implicit final class CanCatchOps[F[_]](private val canCatch: effectie.CanCatch[F]) extends AnyVal {
+
+    def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =
+      EitherT(canCatch.catchNonFatalEither[A, AA, B](fab.value)(f))
+
+  }
+
+  implicit final class FxhOps[F[_]](private val fx: Fx[F]) extends AnyVal {
+
+    def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =
+      EitherT(fx.catchNonFatalEither[A, AA, B](fab.value)(f))
+
+  }
+
+}

--- a/cats-effect3/src/main/scala-2/effectie/cats/syntax/error.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/syntax/error.scala
@@ -1,8 +1,10 @@
 package effectie.cats.syntax
 
 import cats.data.EitherT
+import effectie.CanCatch
 import effectie.cats.syntax.error.{EitherTFABErrorHandlingOps, FAErrorHandlingOps, FEitherABErrorHandlingOps}
-import effectie.cats.{CanCatch, CanHandleError, CanRecover}
+import effectie.cats.{CanHandleError, CanRecover}
+import effectie.cats.CanCatchOps
 
 /** @author Kevin Lee
   * @since 2021-10-16

--- a/cats-effect3/src/main/scala-3/effectie/cats/CanCatch.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/CanCatch.scala
@@ -10,18 +10,8 @@ import scala.concurrent.{ExecutionContext, Future}
 /** @author Kevin Lee
   * @since 2020-06-07
   */
-trait CanCatch[F[_]] extends effectie.CanCatch[F] {
-
-  override type XorT[A, B] = EitherT[F, A, B]
-
-  inline override final protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] = EitherT(fab)
-
-  inline override final protected def xorT2FEither[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] = efab.value
-
-}
-
 object CanCatch {
-  def apply[F[_]: CanCatch]: CanCatch[F] = summon[CanCatch[F]]
+  type CanCatch[F[*]] = effectie.CanCatch[F]
 
   given canCatchIo: CanCatch[IO] with {
 
@@ -31,25 +21,6 @@ object CanCatch {
       fa.attempt
 
   }
-
-  given canCatchFuture(using EC: ExecutionContext): CanCatch[Future] =
-    new effectie.CanCatch.CanCatchFuture with CanCatch[Future] {
-
-      override val EC0: ExecutionContext = EC
-
-      override def catchNonFatalThrowable[A](fa: => Future[A]): Future[Either[Throwable, A]] =
-        fa.transform {
-          case scala.util.Success(a) =>
-            scala.util.Try[Either[Throwable, A]](Right(a))
-
-          case scala.util.Failure(scala.util.control.NonFatal(ex)) =>
-            scala.util.Try[Either[Throwable, A]](Left(ex))
-
-          case scala.util.Failure(ex) =>
-            throw ex
-        }(EC0)
-
-    }
 
   given canCatchId: CanCatch[Id] with {
 

--- a/cats-effect3/src/main/scala-3/effectie/cats/Catching.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/Catching.scala
@@ -1,6 +1,7 @@
 package effectie.cats
 
 import cats.data.EitherT
+import effectie.{CanCatch, FxCtor}
 
 /** @author Kevin Lee
   * @since 2020-06-07

--- a/cats-effect3/src/main/scala-3/effectie/cats/ConsoleEffect.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/ConsoleEffect.scala
@@ -3,17 +3,17 @@ package effectie.cats
 import cats.*
 import cats.syntax.all.*
 import effectie.ConsoleEffect.ConsoleEffectWithoutFlatMap
-import effectie.YesNo
+import effectie.{FxCtor, YesNo}
 
-trait ConsoleEffect[F[_]] extends effectie.ConsoleEffect[F]
+trait ConsoleEffect[F[*]] extends effectie.ConsoleEffect[F]
 
 object ConsoleEffect {
-  def apply[F[_]: ConsoleEffect]: ConsoleEffect[F] =
+  def apply[F[*]: ConsoleEffect]: ConsoleEffect[F] =
     summon[ConsoleEffect[F]]
 
-  given consoleEffectF[F[_]: FxCtor: FlatMap]: ConsoleEffect[F] = new ConsoleEffectF[F]
+  given consoleEffectF[F[*]: FxCtor: FlatMap]: ConsoleEffect[F] = new ConsoleEffectF[F]
 
-  final class ConsoleEffectF[F[_]: FxCtor: FlatMap] extends ConsoleEffectWithoutFlatMap[F] with ConsoleEffect[F] {
+  final class ConsoleEffectF[F[*]: FxCtor: FlatMap] extends ConsoleEffectWithoutFlatMap[F] with ConsoleEffect[F] {
 
     override def readYesNo(prompt: String): F[YesNo] = for {
       _      <- putStrLn(prompt)

--- a/cats-effect3/src/main/scala-3/effectie/cats/Effectful.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/Effectful.scala
@@ -1,5 +1,6 @@
 package effectie.cats
 
+import effectie.FxCtor
 import effectie.cats.Effectful.*
 
 trait Effectful {

--- a/cats-effect3/src/main/scala-3/effectie/cats/Fx.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/Fx.scala
@@ -5,9 +5,9 @@ import cats.{Applicative, Id, Monad}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait Fx[F[_]] extends effectie.Fx[F] with FxCtor[F] with effectie.FxCtor[F] with CanCatch[F]
-
 object Fx {
+
+  type Fx[F[*]] = effectie.Fx[F]
 
   def apply[F[_]: Fx]: Fx[F] = summon[Fx[F]]
 
@@ -26,19 +26,6 @@ object Fx {
     inline override def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       fa.attempt
 
-  }
-
-  given futureFx(using EC: ExecutionContext): Fx[Future] =
-    new FutureFx
-
-  final class FutureFx(using override val EC0: ExecutionContext)
-      extends Fx[Future]
-      with FxCtor[Future]
-      with effectie.FxCtor.FutureFxCtor
-      with effectie.CanCatch.CanCatchFuture {
-
-    override def catchNonFatalThrowable[A](fa: => Future[A]): Future[Either[Throwable, A]] =
-      CanCatch.canCatchFuture.catchNonFatalThrowable(fa)
   }
 
   given idFx: Fx[Id] with {

--- a/cats-effect3/src/main/scala-3/effectie/cats/FxCtor.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/FxCtor.scala
@@ -5,15 +5,10 @@ import cats.effect.IO
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait FxCtor[F[_]] extends effectie.FxCtor[F]
-
 object FxCtor {
-  def apply[F[_]: FxCtor]: FxCtor[F] = summon[FxCtor[F]]
+  type FxCtor[F[*]] = effectie.FxCtor[F]
 
   given ioFxCtor: FxCtor[IO] = Fx.ioFx
-
-  given futureFxCtor(using EC: ExecutionContext): FxCtor[Future] =
-    Fx.futureFx
 
   given idFxCtor: FxCtor[Id] = Fx.idFx
 

--- a/cats-effect3/src/main/scala-3/effectie/cats/cats.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/cats.scala
@@ -1,0 +1,21 @@
+package effectie.cats
+
+import _root_.cats.data.EitherT
+import effectie.Fx
+
+/** @author Kevin Lee
+  * @since 2021-11-25
+  */
+extension [F[_]](canCatch: effectie.CanCatch[F]) {
+
+  def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =
+    EitherT(canCatch.catchNonFatalEither[A, AA, B](fab.value)(f))
+
+}
+
+extension [F[_]](fx: Fx[F]) {
+
+  def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =
+    EitherT(fx.catchNonFatalEither[A, AA, B](fab.value)(f))
+
+}

--- a/cats-effect3/src/main/scala-3/effectie/cats/syntax/error.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/syntax/error.scala
@@ -1,7 +1,8 @@
 package effectie.cats.syntax
 
 import cats.data.EitherT
-import effectie.cats.{CanCatch, CanHandleError, CanRecover}
+import effectie.CanCatch
+import effectie.cats.*
 
 /** @author Kevin Lee
  * @since 2021-10-16
@@ -92,7 +93,7 @@ trait error {
     )(
       using canCatch: CanCatch[F]
     ): EitherT[F, AA, B] =
-      canCatch.catchNonFatalEitherT[A, AA, B](efab)(f)
+      EitherT(canCatch.catchNonFatalEither[A, AA, B](efab.value)(f))
 
     def handleEitherTNonFatalWith[AA >: A, BB >: B](
       handleError: Throwable => F[Either[AA, BB]]

--- a/cats-effect3/src/test/scala-2/effectie/cats/CanCatchSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/CanCatchSpec.scala
@@ -7,7 +7,7 @@ import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.cats.Effectful._
-import effectie.testing.types.SomeError
+import effectie.testing.types._
 import effectie.{ConcurrentSupport, SomeControlThrowable}
 import hedgehog._
 import hedgehog.runner._
@@ -19,6 +19,10 @@ import scala.util.control.ControlThrowable
   * @since 2020-07-31
   */
 object CanCatchSpec extends Properties {
+
+  type FxCtor[F[_]] = effectie.FxCtor[F]
+  type CanCatch[F[_]] = effectie.CanCatch[F]
+  val CanCatch: effectie.CanCatch.type = effectie.CanCatch
 
   override def tests: List[Test] = List(
     /* IO */
@@ -188,6 +192,8 @@ object CanCatchSpec extends Properties {
     effectOf[F](a)
 
   object IoSpec {
+
+    import effectie.cats.Fx.IoFx
 
     def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -406,6 +412,7 @@ object CanCatchSpec extends Properties {
   }
 
   object FutureSpec {
+
     import java.util.concurrent.{ExecutorService, Executors}
     import scala.concurrent.duration._
     import scala.concurrent.{ExecutionContext, Future}
@@ -570,6 +577,8 @@ object CanCatchSpec extends Properties {
   }
 
   object IdSpec {
+
+    import effectie.cats.Fx.IdFx
 
     def testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala-2/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/CanHandleErrorSpec.scala
@@ -19,6 +19,7 @@ import scala.util.control.{ControlThrowable, NonFatal}
   * @since 2020-08-17
   */
 object CanHandleErrorSpec extends Properties {
+  type FxCtor[F[_]] = effectie.FxCtor[F]
 
   override def tests: List[Test] = List(
     /* IO */
@@ -363,6 +364,7 @@ object CanHandleErrorSpec extends Properties {
     effectOf[F](a)
 
   object IoSpec {
+    import effectie.cats.Fx.IoFx
 
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -1294,6 +1296,8 @@ object CanHandleErrorSpec extends Properties {
   }
 
   object IdSpec {
+
+    import effectie.cats.Fx.IdFx
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 

--- a/cats-effect3/src/test/scala-2/effectie/cats/CanRecoverSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/CanRecoverSpec.scala
@@ -20,6 +20,9 @@ import scala.util.control.{ControlThrowable, NonFatal}
   */
 object CanRecoverSpec extends Properties {
 
+  type FxCtor[F[_]] = effectie.FxCtor[F]
+
+
   override def tests: List[Test] = List(
     /* IO */
     example(
@@ -364,6 +367,8 @@ object CanRecoverSpec extends Properties {
     effectOf[F](a)
 
   object IOSpec {
+
+    import effectie.cats.Fx.IoFx
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
@@ -1429,6 +1434,7 @@ object CanRecoverSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.cats.Fx._
 
     def testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala-2/effectie/cats/CatchingSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/CatchingSpec.scala
@@ -20,6 +20,9 @@ import scala.util.control.ControlThrowable
   * @since 2020-07-31
   */
 object CatchingSpec extends Properties {
+  type Fx[F[_]] = effectie.Fx[F]
+  type FxCtor[F[_]] = effectie.FxCtor[F]
+
 
   override def tests: List[Test] = List(
     /* IO */
@@ -232,6 +235,8 @@ object CatchingSpec extends Properties {
     effectOf[F](a)
 
   object IoSpec {
+
+    import effectie.cats.Fx._
 
     def testCatching_IO_catchNonFatalShouldCatchNonFatal: Result = {
 
@@ -720,6 +725,8 @@ object CatchingSpec extends Properties {
   }
 
   object IdSpec {
+
+    import effectie.cats.Fx._
 
     def testCatching_Id_catchNonFatalShouldCatchNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala-2/effectie/cats/FxCtorSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/FxCtorSpec.scala
@@ -25,6 +25,8 @@ object FxCtorSpec extends Properties {
   )
 
   object IoSpec {
+    import effectie.cats.Fx._
+
     val compat                 = new CatsEffectIoCompatForFuture
     implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
@@ -138,6 +140,8 @@ object FxCtorSpec extends Properties {
   }
 
   object IdSpec {
+
+    import effectie.cats.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/cats-effect3/src/test/scala-2/effectie/cats/FxSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/FxSpec.scala
@@ -20,6 +20,9 @@ import scala.util.control.ControlThrowable
   * @since 2020-12-06
   */
 object FxSpec extends Properties {
+
+  type Fx[F[_]] = effectie.Fx[F]
+
   override def tests: List[Test] = List(
     property("test Fx[IO].effectOf", IoSpec.testEffectOf),
     property("test Fx[IO].pureOf", IoSpec.testPureOf),
@@ -233,10 +236,11 @@ object FxSpec extends Properties {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
-    FxCtor[F].effectOf(a)
+  def run[F[_]: Fx: Functor, A](a: => A): F[A] =
+    Fx[F].effectOf(a)
 
   object IoSpec {
+    import effectie.cats.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
@@ -316,8 +320,6 @@ object FxSpec extends Properties {
       implicit val eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      implicit val ioFx: Fx[IO] = Fx.IoFx
-
       MonadSpec.test1_Identity[IO]
     }
 
@@ -329,7 +331,6 @@ object FxSpec extends Properties {
       implicit val eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      implicit val ioFx: Fx[IO] = Fx.IoFx
 
       MonadSpec.test2_Composition[IO]
     }
@@ -342,8 +343,6 @@ object FxSpec extends Properties {
       implicit val eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      implicit val ioFx: Fx[IO] = Fx.IoFx
-
       MonadSpec.test3_IdentityAp[IO]
     }
 
@@ -354,8 +353,6 @@ object FxSpec extends Properties {
 
       implicit val eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
-
-      implicit val ioFx: Fx[IO] = Fx.IoFx
 
       MonadSpec.test4_Homomorphism[IO]
     }
@@ -368,8 +365,6 @@ object FxSpec extends Properties {
       implicit val eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      implicit val ioFx: Fx[IO] = Fx.IoFx
-
       MonadSpec.test5_Interchange[IO]
     }
 
@@ -380,8 +375,6 @@ object FxSpec extends Properties {
 
       implicit val eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
-
-      implicit val ioFx: Fx[IO] = Fx.IoFx
 
       MonadSpec.test6_CompositionAp[IO]
     }
@@ -394,8 +387,6 @@ object FxSpec extends Properties {
       implicit val eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      implicit val ioFx: Fx[IO] = Fx.IoFx
-
       MonadSpec.test7_LeftIdentity[IO]
     }
 
@@ -406,8 +397,6 @@ object FxSpec extends Properties {
 
       implicit val eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
-
-      implicit val ioFx: Fx[IO] = Fx.IoFx
 
       MonadSpec.test8_RightIdentity[IO]
     }
@@ -420,7 +409,7 @@ object FxSpec extends Properties {
       implicit val eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      implicit val ioFx: Fx[IO] = Fx.IoFx
+//      implicit val ioFx: Fx[IO] = Fx.IoFx
 
       MonadSpec.test9_Associativity[IO]
     }
@@ -939,6 +928,8 @@ object FxSpec extends Properties {
   }
 
   object IdSpec {
+
+    import effectie.cats.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/cats-effect3/src/test/scala-2/effectie/cats/syntax/errorSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/syntax/errorSpec.scala
@@ -8,9 +8,9 @@ import cats.syntax.all._
 import effectie.cats.Effectful._
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.cats.syntax.error._
-import effectie.cats.{FxCtor, testing}
+import effectie.cats.testing
 import effectie.testing.types.SomeError
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, Fx, SomeControlThrowable}
 import hedgehog._
 import hedgehog.runner._
 
@@ -189,10 +189,12 @@ object CanCatchSyntaxSpec {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[_]: Fx: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IoSpec {
+
+    import effectie.cats.Fx._
 
     def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -575,6 +577,8 @@ object CanCatchSyntaxSpec {
   }
 
   object IdSpec {
+
+    import effectie.cats.Fx._
 
     def testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -1092,10 +1096,12 @@ object CanHandleErrorSyntaxSpec {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[_]: Fx: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IoSpec {
+
+    import effectie.cats.Fx._
 
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -2017,6 +2023,7 @@ object CanHandleErrorSyntaxSpec {
   }
 
   object IdSpec {
+    import effectie.cats.Fx._
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -2757,10 +2764,12 @@ object CanRecoverSyntaxSpec {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[_]: Fx: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IOSpec {
+
+    import effectie.cats.Fx._
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
@@ -3794,6 +3803,8 @@ object CanRecoverSyntaxSpec {
   }
 
   object IdSpec {
+
+    import effectie.cats.Fx._
 
     def testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala-3/effectie/cats/CanCatchSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/CanCatchSpec.scala
@@ -7,8 +7,9 @@ import cats.effect.unsafe.IORuntime
 import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.cats.Effectful.*
+import effectie.CanCatch
 import effectie.testing.types.SomeError
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, FxCtor, SomeControlThrowable}
 import hedgehog.*
 import hedgehog.runner.*
 
@@ -183,10 +184,12 @@ object CanCatchSpec extends Properties {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: FxCtor
+  : Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IoSpec {
+    import effectie.cats.Fx.given
 
     def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -565,6 +568,7 @@ object CanCatchSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
@@ -8,7 +8,7 @@ import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.cats.Effectful.*
 import effectie.testing.types.SomeError
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, FxCtor, SomeControlThrowable}
 import hedgehog.*
 import hedgehog.runner.*
 
@@ -358,10 +358,11 @@ object CanHandleErrorSpec extends Properties {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: FxCtor: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IoSpec {
+    import effectie.cats.Fx.given
 
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -1285,6 +1286,7 @@ object CanHandleErrorSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 

--- a/cats-effect3/src/test/scala-3/effectie/cats/CanRecoverSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/CanRecoverSpec.scala
@@ -9,7 +9,7 @@ import cats.syntax.all.*
 import effectie.cats.Effectful.*
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.testing.types.SomeError
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, FxCtor, SomeControlThrowable}
 import hedgehog.*
 import hedgehog.runner.*
 
@@ -359,10 +359,11 @@ object CanRecoverSpec extends Properties {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: FxCtor: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IOSpec {
+    import effectie.cats.Fx.given
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
@@ -1421,6 +1422,7 @@ object CanRecoverSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala-3/effectie/cats/CatchingSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/CatchingSpec.scala
@@ -10,7 +10,7 @@ import cats.syntax.all.*
 import effectie.cats.Effectful.*
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.testing.types.SomeError
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, FxCtor, SomeControlThrowable}
 import hedgehog.*
 import hedgehog.runner.*
 
@@ -227,10 +227,11 @@ object CatchingSpec extends Properties {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: FxCtor: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IoSpec {
+    import effectie.cats.Fx.given
 
     def testCatching_IO_catchNonFatalShouldCatchNonFatal: Result = {
 
@@ -714,6 +715,7 @@ object CatchingSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testCatching_Id_catchNonFatalShouldCatchNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala-3/effectie/cats/FxCtorSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/FxCtorSpec.scala
@@ -3,7 +3,7 @@ package effectie.cats
 import cats.Id
 import cats.effect.*
 import cats.effect.unsafe.IORuntime
-import effectie.ConcurrentSupport
+import effectie.{ConcurrentSupport, FxCtor}
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import hedgehog.*
 import hedgehog.runner.*
@@ -25,6 +25,8 @@ object FxCtorSpec extends Properties {
   )
 
   object IoSpec {
+    import effectie.cats.Fx.given
+
     val compat = new CatsEffectIoCompatForFuture
 
     given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
@@ -148,6 +150,7 @@ object FxCtorSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/cats-effect3/src/test/scala-3/effectie/cats/FxSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/FxSpec.scala
@@ -10,7 +10,7 @@ import cats.{Eq, Functor, Id, Monad, Show}
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.testing.tools.*
 import effectie.testing.types.{SomeError, SomeThrowableError}
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, Fx, SomeControlThrowable}
 import hedgehog.*
 import hedgehog.runner.*
 
@@ -238,10 +238,11 @@ object FxSpec extends Properties {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
-    FxCtor[F].effectOf(a)
+  def run[F[*]: Fx: Functor, A](a: => A): F[A] =
+    Fx[F].effectOf(a)
 
   object IoSpec {
+    import effectie.cats.Fx.given
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
@@ -322,7 +323,7 @@ object FxSpec extends Properties {
       given eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      given ioFx: Fx[IO] = Fx.ioFx
+      given ioFx: Fx[IO] = effectie.cats.Fx.ioFx
 
       MonadSpec.test1_Identity[IO]
     }
@@ -335,7 +336,7 @@ object FxSpec extends Properties {
       given eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      given ioFx: Fx[IO] = Fx.ioFx
+      given ioFx: Fx[IO] = effectie.cats.Fx.ioFx
 
       MonadSpec.test2_Composition[IO]
     }
@@ -348,7 +349,7 @@ object FxSpec extends Properties {
       given eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      given ioFx: Fx[IO] = Fx.ioFx
+      given ioFx: Fx[IO] = effectie.cats.Fx.ioFx
 
       MonadSpec.test3_IdentityAp[IO]
     }
@@ -361,7 +362,7 @@ object FxSpec extends Properties {
       given eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      given ioFx: Fx[IO] = Fx.ioFx
+      given ioFx: Fx[IO] = effectie.cats.Fx.ioFx
 
       MonadSpec.test4_Homomorphism[IO]
     }
@@ -374,7 +375,7 @@ object FxSpec extends Properties {
       given eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      given ioFx: Fx[IO] = Fx.ioFx
+      given ioFx: Fx[IO] = effectie.cats.Fx.ioFx
 
       MonadSpec.test5_Interchange[IO]
     }
@@ -387,7 +388,7 @@ object FxSpec extends Properties {
       given eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      given ioFx: Fx[IO] = Fx.ioFx
+      given ioFx: Fx[IO] = effectie.cats.Fx.ioFx
 
       MonadSpec.test6_CompositionAp[IO]
     }
@@ -400,7 +401,7 @@ object FxSpec extends Properties {
       given eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      given ioFx: Fx[IO] = Fx.ioFx
+      given ioFx: Fx[IO] = effectie.cats.Fx.ioFx
 
       MonadSpec.test7_LeftIdentity[IO]
     }
@@ -413,7 +414,7 @@ object FxSpec extends Properties {
       given eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      given ioFx: Fx[IO] = Fx.ioFx
+      given ioFx: Fx[IO] = effectie.cats.Fx.ioFx
 
       MonadSpec.test8_RightIdentity[IO]
     }
@@ -426,7 +427,7 @@ object FxSpec extends Properties {
       given eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      given ioFx: Fx[IO] = Fx.ioFx
+      given ioFx: Fx[IO] = effectie.cats.Fx.ioFx
 
       MonadSpec.test9_Associativity[IO]
     }
@@ -960,6 +961,7 @@ object FxSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/cats-effect3/src/test/scala-3/effectie/cats/syntax/errorSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/syntax/errorSpec.scala
@@ -5,7 +5,7 @@ import cats.data.EitherT
 import cats.syntax.all.*
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, Fx, SomeControlThrowable}
 import effectie.cats.{CanCatch, FxCtor, testing}
 import effectie.testing.types.*
 import effectie.cats.Effectful.*
@@ -189,10 +189,11 @@ object CanCatchSyntaxSpec {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: Fx: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IoSpec {
+    import effectie.cats.Fx.given
 
     def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -571,6 +572,7 @@ object CanCatchSyntaxSpec {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -1083,10 +1085,11 @@ object CanHandleErrorSyntaxSpec {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: Fx: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IoSpec {
+    import effectie.cats.Fx.given
 
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -2000,6 +2003,7 @@ object CanHandleErrorSyntaxSpec {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -2731,10 +2735,11 @@ object CanRecoverSyntaxSpec {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[*]: Fx: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object IOSpec {
+    import effectie.cats.Fx.given
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
@@ -3761,6 +3766,7 @@ object CanRecoverSyntaxSpec {
   }
 
   object IdSpec {
+    import effectie.cats.Fx.given
 
     def testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala/effectie/cats/MonadSpec.scala
+++ b/cats-effect3/src/test/scala/effectie/cats/MonadSpec.scala
@@ -5,6 +5,9 @@ import effectie.testing.cats.{Gens, Specs}
 import hedgehog.Property
 
 object MonadSpec {
+
+  type Fx[F[_]] = effectie.Fx[F]
+
   def test1_Identity[F[_]: Fx: Monad](implicit eqF: Eq[F[Int]]): Property =
     Specs
       .MonadLaws

--- a/core/src/main/scala/effectie/CanCatch.scala
+++ b/core/src/main/scala/effectie/CanCatch.scala
@@ -4,11 +4,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait CanCatch[F[_]] {
 
-  type XorT[A, B]
-
-  protected def xorT[A, B](fab: F[Either[A, B]]): XorT[A, B]
-  protected def xorT2FEither[A, B](efab: XorT[A, B]): F[Either[A, B]]
-
   def mapFa[A, B](fa: F[A])(f: A => B): F[B]
 
   def catchNonFatalThrowable[A](fa: => F[A]): F[Either[Throwable, A]]
@@ -19,19 +14,32 @@ trait CanCatch[F[_]] {
   final def catchNonFatalEither[A, AA >: A, B](fab: => F[Either[A, B]])(f: Throwable => AA): F[Either[AA, B]] =
     mapFa(catchNonFatal(fab)(f))(_.joinRight)
 
-  final def catchNonFatalEitherT[A, AA >: A, B](fab: => XorT[A, B])(f: Throwable => AA): XorT[AA, B] =
-    xorT(catchNonFatalEither[A, AA, B](xorT2FEither(fab))(f))
-
 }
 
 object CanCatch {
   def apply[F[_]: CanCatch]: CanCatch[F] = implicitly[CanCatch[F]]
 
-  trait CanCatchFuture extends CanCatch[Future] {
-    def EC0: ExecutionContext
+  trait FutureCanCatch extends CanCatch[Future] {
+    implicit def EC0: ExecutionContext
     @inline override final def mapFa[A, B](fa: Future[A])(f: A => B): Future[B] =
       fa.map(f)(EC0)
 
+    @inline override final def catchNonFatalThrowable[A](fa: => Future[A]): Future[Either[Throwable, A]] =
+      fa.transform {
+        case scala.util.Success(a) =>
+          scala.util.Try[Either[Throwable, A]](Right(a))
+
+        case scala.util.Failure(scala.util.control.NonFatal(ex)) =>
+          scala.util.Try[Either[Throwable, A]](Left(ex))
+
+        case scala.util.Failure(ex) =>
+          throw ex
+      }
+
   }
+
+  final class CanCatchFuture(override implicit val EC0: ExecutionContext) extends FutureCanCatch
+
+  implicit def canCatchFuture(implicit EC: ExecutionContext): CanCatch[Future] = new CanCatchFuture
 
 }

--- a/core/src/main/scala/effectie/Fx.scala
+++ b/core/src/main/scala/effectie/Fx.scala
@@ -1,6 +1,20 @@
 package effectie
 
+import scala.concurrent.{ExecutionContext, Future}
+
 /** @author Kevin Lee
   * @since 2021-11-03
   */
 trait Fx[F[_]] extends FxCtor[F] with CanCatch[F]
+
+object Fx {
+
+  def apply[F[_]: Fx]: Fx[F] = implicitly[Fx[F]]
+
+  trait FxOfFuture extends Fx[Future] with FxCtor.FutureFxCtor with CanCatch.FutureCanCatch
+
+  final class FxFuture(implicit override val EC0: ExecutionContext)
+    extends FxOfFuture
+
+  implicit def fxFuture(implicit EC: ExecutionContext): Fx[Future] = new FxFuture
+}

--- a/core/src/main/scala/effectie/FxCtor.scala
+++ b/core/src/main/scala/effectie/FxCtor.scala
@@ -12,6 +12,8 @@ trait FxCtor[F[_]] {
 
 object FxCtor {
 
+  def apply[F[_]: FxCtor]: FxCtor[F] = implicitly[FxCtor[F]]
+
   trait FutureFxCtor extends FxCtor[Future] {
 
     implicit def EC0: ExecutionContext
@@ -25,4 +27,9 @@ object FxCtor {
     @inline override final def errorOf[A](throwable: Throwable): Future[A] = Future.failed[A](throwable)
 
   }
+
+  final class FxCtorFuture(override implicit val EC0: ExecutionContext) extends FutureFxCtor
+
+  implicit def fxCtorFuture(implicit EC: ExecutionContext): FxCtor[Future] = new FxCtorFuture
+
 }

--- a/effectie-monix/src/main/scala/effectie/monix/CanCatch.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/CanCatch.scala
@@ -1,28 +1,15 @@
 package effectie.monix
 
 import cats.Id
-import cats.data.EitherT
 import cats.effect.IO
 import cats.syntax.all._
 import monix.eval.Task
 
-import scala.concurrent.{ExecutionContext, Future}
-
 /** @author Kevin Lee
   * @since 2020-06-07
   */
-trait CanCatch[F[_]] extends effectie.CanCatch[F] {
-
-  override type XorT[A, B] = EitherT[F, A, B]
-
-  @inline override final protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] = EitherT(fab)
-
-  @inline override final protected def xorT2FEither[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] = efab.value
-
-}
-
 object CanCatch {
-  def apply[F[_]: CanCatch]: CanCatch[F] = implicitly[CanCatch[F]]
+  type CanCatch[F[_]] = effectie.CanCatch[F]
 
   implicit object CanCatchTask extends CanCatch[Task] {
 
@@ -39,26 +26,6 @@ object CanCatch {
 
     override def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       fa.attempt
-
-  }
-
-  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
-  implicit def canCatchFuture(implicit EC: ExecutionContext): CanCatch[Future] =
-    new effectie.CanCatch.CanCatchFuture with CanCatch[Future] {
-
-      override val EC0: ExecutionContext = EC
-
-      override def catchNonFatalThrowable[A](fa: => Future[A]): Future[Either[Throwable, A]] =
-      fa.transform {
-        case scala.util.Success(a) =>
-          scala.util.Try[Either[Throwable, A]](Right(a))
-
-        case scala.util.Failure(scala.util.control.NonFatal(ex)) =>
-          scala.util.Try[Either[Throwable, A]](Left(ex))
-
-        case scala.util.Failure(ex) =>
-          throw ex
-      }(EC0)
 
   }
 

--- a/effectie-monix/src/main/scala/effectie/monix/Catching.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/Catching.scala
@@ -7,7 +7,7 @@ import cats.data.EitherT
   */
 trait Catching {
 
-  import Catching._
+  import effectie.monix.Catching._
 
   final def catchNonFatalThrowable[F[_]]: CurriedCanCatchThrowable[F] =
     new CurriedCanCatchThrowable[F]
@@ -27,8 +27,6 @@ trait Catching {
   def catchNonFatalEitherT[F[_]]: CurriedCanCatchEitherT1[F] =
     new CurriedCanCatchEitherT1[F]
 
-//  def catchNonFatalEitherT[F[_], A, B](fab: => EitherT[F, A, B])(f: Throwable => A)(implicit CC: CanCatch[F]): EitherT[F, A, B] =
-//    CanCatch[F].catchNonFatalEitherT(fab)(f)
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -37,8 +35,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchThrowable[F[_]](
     private val dummy: Boolean = true
   ) extends AnyVal {
-    def apply[B](fb: => F[B])(implicit CC: CanCatch[F]): F[Either[Throwable, B]] =
-      CanCatch[F].catchNonFatalThrowable[B](fb)
+    def apply[B](fb: => F[B])(implicit CC: effectie.CanCatch[F]): F[Either[Throwable, B]] =
+      effectie.CanCatch[F].catchNonFatalThrowable[B](fb)
   }
 
   private[Catching] final class CurriedCanCatch1[F[_]](
@@ -51,8 +49,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatch2[F[_], B](
     private val fb: () => F[B]
   ) extends AnyVal {
-    def apply[A](f: Throwable => A)(implicit CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatal(fb())(f)
+    def apply[A](f: Throwable => A)(implicit CC: effectie.CanCatch[F]): F[Either[A, B]] =
+      effectie.CanCatch[F].catchNonFatal(fb())(f)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -66,8 +64,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchF2[F[_], B](
     private val b: () => B
   ) extends AnyVal {
-    def apply[A](f: Throwable => A)(implicit EC: FxCtor[F], CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatal(FxCtor[F].effectOf(b()))(f)
+    def apply[A](f: Throwable => A)(implicit EC: effectie.FxCtor[F], CC: effectie.CanCatch[F]): F[Either[A, B]] =
+      effectie.CanCatch[F].catchNonFatal(effectie.FxCtor[F].effectOf(b()))(f)
   }
 
   private[Catching] final class CurriedCanCatchEither1[F[_]](
@@ -80,8 +78,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchEither2[F[_], A, B](
     private val fab: () => F[Either[A, B]]
   ) extends AnyVal {
-    def apply(f: Throwable => A)(implicit CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatalEither(fab())(f)
+    def apply(f: Throwable => A)(implicit CC: effectie.CanCatch[F]): F[Either[A, B]] =
+      effectie.CanCatch[F].catchNonFatalEither(fab())(f)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -95,8 +93,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchEitherF2[F[_], A, B](
     private val ab: () => Either[A, B]
   ) extends AnyVal {
-    def apply(f: Throwable => A)(implicit EC: FxCtor[F], CC: CanCatch[F]): F[Either[A, B]] =
-      CanCatch[F].catchNonFatalEither(FxCtor[F].effectOf(ab()))(f)
+    def apply(f: Throwable => A)(implicit EC: effectie.FxCtor[F], CC: effectie.CanCatch[F]): F[Either[A, B]] =
+      effectie.CanCatch[F].catchNonFatalEither(effectie.FxCtor[F].effectOf(ab()))(f)
   }
 
   private[Catching] final class CurriedCanCatchEitherT1[F[_]](
@@ -109,8 +107,8 @@ object Catching extends Catching {
   private[Catching] final class CurriedCanCatchEitherT2[F[_], A, B](
     private val fab: () => EitherT[F, A, B]
   ) extends AnyVal {
-    def apply(f: Throwable => A)(implicit CC: CanCatch[F]): EitherT[F, A, B] =
-      CanCatch[F].catchNonFatalEitherT(fab())(f)
+    def apply(f: Throwable => A)(implicit CC: effectie.CanCatch[F]): EitherT[F, A, B] =
+      effectie.CanCatch[F].catchNonFatalEitherT(fab())(f)
   }
 
 }

--- a/effectie-monix/src/main/scala/effectie/monix/ConsoleEffect.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/ConsoleEffect.scala
@@ -11,10 +11,10 @@ object ConsoleEffect {
   def apply[F[_]: ConsoleEffect]: ConsoleEffect[F] =
     implicitly[ConsoleEffect[F]]
 
-  implicit def consoleEffectF[F[_]: FxCtor: FlatMap]: ConsoleEffect[F] =
+  implicit def consoleEffectF[F[_]: effectie.FxCtor: FlatMap]: ConsoleEffect[F] =
     new ConsoleEffectF[F]
 
-  final class ConsoleEffectF[F[_]: FxCtor: FlatMap] extends ConsoleEffectWithoutFlatMap[F] with ConsoleEffect[F] {
+  final class ConsoleEffectF[F[_]: effectie.FxCtor: FlatMap] extends ConsoleEffectWithoutFlatMap[F] with ConsoleEffect[F] {
 
     @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
     override def readYesNo(prompt: String): F[YesNo] = for {
@@ -22,9 +22,9 @@ object ConsoleEffect {
       answer <- readLn
       yesOrN <- answer match {
                   case "y" | "Y" =>
-                    FxCtor[F].effectOf(YesNo.yes)
+                    effectie.FxCtor[F].effectOf(YesNo.yes)
                   case "n" | "N" =>
-                    FxCtor[F].effectOf(YesNo.no)
+                    effectie.FxCtor[F].effectOf(YesNo.no)
                   case _         =>
                     readYesNo(prompt)
                 }

--- a/effectie-monix/src/main/scala/effectie/monix/Effectful.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/Effectful.scala
@@ -8,7 +8,7 @@ trait Effectful {
 
   def pureOf[F[_]]: CurriedEffectOfPure[F] = new CurriedEffectOfPure[F]
 
-  def unitOf[F[_]: FxCtor]: F[Unit] = FxCtor[F].unitOf
+  def unitOf[F[_]: effectie.FxCtor]: F[Unit] = effectie.FxCtor[F].unitOf
 
   def errorOf[F[_]]: CurriedErrorOf[F] = new CurriedErrorOf[F]
 
@@ -20,22 +20,22 @@ object Effectful extends Effectful {
   private[Effectful] final class CurriedEffectOf[F[_]](
     private val dummy: Boolean = true
   ) extends AnyVal {
-    def apply[A](a: => A)(implicit EF: FxCtor[F]): F[A] =
-      FxCtor[F].effectOf(a)
+    def apply[A](a: => A)(implicit EF: effectie.FxCtor[F]): F[A] =
+      effectie.FxCtor[F].effectOf(a)
   }
 
   private[Effectful] final class CurriedEffectOfPure[F[_]](
     private val dummy: Boolean = true
   ) extends AnyVal {
-    def apply[A](a: A)(implicit EF: FxCtor[F]): F[A] =
-      FxCtor[F].pureOf(a)
+    def apply[A](a: A)(implicit EF: effectie.FxCtor[F]): F[A] =
+      effectie.FxCtor[F].pureOf(a)
   }
 
   private[Effectful] final class CurriedErrorOf[F[_]](
     private val dummy: Boolean = true
   ) extends AnyVal {
-    def apply[A](throwable: Throwable)(implicit EF: FxCtor[F]): F[A] =
-      FxCtor[F].errorOf(throwable)
+    def apply[A](throwable: Throwable)(implicit EF: effectie.FxCtor[F]): F[A] =
+      effectie.FxCtor[F].errorOf(throwable)
   }
 
 }

--- a/effectie-monix/src/main/scala/effectie/monix/Fx.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/Fx.scala
@@ -4,17 +4,16 @@ import cats.effect.IO
 import cats.Id
 import monix.eval.Task
 
-import scala.concurrent.{ExecutionContext, Future}
-
 /** @author Kevin Lee
   * @since 2021-05-16
   */
-trait Fx[F[_]] extends effectie.Fx[F] with FxCtor[F] with effectie.FxCtor[F] with CanCatch[F]
-
 object Fx {
+  type Fx[F[_]] = effectie.Fx[F]
+
   def apply[F[_]: Fx]: Fx[F] = implicitly[Fx[F]]
 
   implicit object TaskFx extends Fx[Task] {
+
 
     @inline override final def effectOf[A](a: => A): Task[A] = Task(a)
 
@@ -50,18 +49,6 @@ object Fx {
       CanCatch.CanCatchIo.catchNonFatalThrowable(fa)
 
 
-  }
-
-  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
-  implicit def futureFx(implicit EC: ExecutionContext): Fx[Future] = new FutureFx
-
-  final class FutureFx(implicit override val EC0: ExecutionContext)
-      extends Fx[Future]
-      with FxCtor[Future]
-        with effectie.FxCtor.FutureFxCtor
-        with effectie.CanCatch.CanCatchFuture {
-    override def catchNonFatalThrowable[A](fa: => Future[A]): Future[Either[Throwable, A]] =
-      CanCatch.canCatchFuture.catchNonFatalThrowable(fa)
   }
 
   implicit object IdFx extends Fx[Id] {

--- a/effectie-monix/src/main/scala/effectie/monix/FxCtor.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/FxCtor.scala
@@ -4,23 +4,15 @@ import cats.Id
 import cats.effect.IO
 import monix.eval.Task
 
-import scala.concurrent.{ExecutionContext, Future}
-
 /** @author Kevin Lee
   * @since 2021-05-16
   */
-trait FxCtor[F[_]] extends effectie.FxCtor[F]
-
 object FxCtor {
-  def apply[F[_]: FxCtor]: FxCtor[F] = implicitly[FxCtor[F]]
+  type FxCtor[F[_]] = effectie.FxCtor[F]
 
   implicit final val taskFxCtor: FxCtor[Task] = Fx.TaskFx
 
   implicit final val ioFxCtor: FxCtor[IO] = Fx.IoFx
-
-  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
-  implicit def futureFxCtor(implicit EC: ExecutionContext): FxCtor[Future] =
-    Fx.futureFx
 
   implicit final val idFxCtor: FxCtor[Id] = Fx.IdFx
 

--- a/effectie-monix/src/main/scala/effectie/monix/package.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/package.scala
@@ -1,0 +1,22 @@
+package effectie
+
+import cats.data.EitherT
+
+/** @author Kevin Lee
+  * @since 2021-11-23
+  */
+package object monix {
+  implicit final class CanCatchOps[F[_]](private val canCatch: effectie.CanCatch[F]) extends AnyVal {
+
+    def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =
+      EitherT(canCatch.catchNonFatalEither[A, AA, B](fab.value)(f))
+
+  }
+
+  implicit final class FxhOps[F[_]](private val fx: Fx[F]) extends AnyVal {
+
+    def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =
+      EitherT(fx.catchNonFatalEither[A, AA, B](fab.value)(f))
+
+  }
+}

--- a/effectie-monix/src/main/scala/effectie/monix/syntax/error.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/syntax/error.scala
@@ -1,8 +1,10 @@
 package effectie.monix.syntax
 
 import cats.data.EitherT
+import effectie.CanCatch
 import effectie.monix.syntax.error.{EitherTFABErrorHandlingOps, FAErrorHandlingOps, FEitherABErrorHandlingOps}
-import effectie.monix.{CanCatch, CanHandleError, CanRecover}
+import effectie.monix.{CanHandleError, CanRecover}
+import effectie.monix.CanCatchOps
 
 /** @author Kevin Lee
  * @since 2021-10-16

--- a/effectie-monix/src/test/scala/effectie/monix/CanCatchSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/CanCatchSpec.scala
@@ -19,6 +19,10 @@ import scala.util.control.ControlThrowable
   */
 object CanCatchSpec extends Properties {
 
+  type FxCtor[F[_]] = effectie.FxCtor[F]
+  type CanCatch[F[_]] = effectie.CanCatch[F]
+  val CanCatch: effectie.CanCatch.type = effectie.CanCatch
+
   override def tests: List[Test] = List(
     /* Task */
     example(
@@ -247,6 +251,8 @@ object CanCatchSpec extends Properties {
   object TaskSpec {
     import monix.execution.Scheduler.Implicits.global
 
+    import effectie.monix.Fx.TaskFx
+
     def testCanCatch_Task_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
@@ -423,6 +429,8 @@ object CanCatchSpec extends Properties {
 
   object IoSpec {
 
+    import effectie.monix.Fx.IoFx
+
     def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
@@ -598,6 +606,7 @@ object CanCatchSpec extends Properties {
   }
 
   object FutureSpec {
+
     import java.util.concurrent.{ExecutorService, Executors}
     import scala.concurrent.duration._
     import scala.concurrent.{ExecutionContext, Future}
@@ -762,6 +771,7 @@ object CanCatchSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.monix.Fx.IdFx
 
     def testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 

--- a/effectie-monix/src/test/scala/effectie/monix/CanHandleErrorSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/CanHandleErrorSpec.scala
@@ -17,6 +17,7 @@ import scala.util.control.{ControlThrowable, NonFatal}
   * @since 2020-08-17
   */
 object CanHandleErrorSpec extends Properties {
+  type FxCtor[F[_]] = effectie.FxCtor[F]
 
   override def tests: List[Test] = List(
     /* Task */
@@ -362,6 +363,8 @@ object CanHandleErrorSpec extends Properties {
 
   object TaskSpec {
     import monix.execution.Scheduler.Implicits.global
+
+    import effectie.monix.Fx.TaskFx
 
     def testCanHandleError_Task_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -1205,6 +1208,8 @@ object CanHandleErrorSpec extends Properties {
   }
 
   object IdSpec {
+
+    import effectie.monix.Fx.IdFx
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 

--- a/effectie-monix/src/test/scala/effectie/monix/CanRecoverSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/CanRecoverSpec.scala
@@ -17,6 +17,7 @@ import scala.util.control.{ControlThrowable, NonFatal}
   * @since 2020-08-17
   */
 object CanRecoverSpec extends Properties {
+  type FxCtor[F[_]] = effectie.FxCtor[F]
 
   override def tests: List[Test] = List(
     /* Task */
@@ -362,6 +363,7 @@ object CanRecoverSpec extends Properties {
 
   object TaskSpec {
     import monix.execution.Scheduler.Implicits.global
+    import effectie.monix.Fx.TaskFx
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
@@ -1344,6 +1346,7 @@ object CanRecoverSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.monix.Fx._
 
     def testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 

--- a/effectie-monix/src/test/scala/effectie/monix/CatchingSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/CatchingSpec.scala
@@ -18,6 +18,7 @@ import scala.util.control.ControlThrowable
   * @since 2020-07-31
   */
 object CatchingSpec extends Properties {
+  type FxCtor[F[_]] = effectie.FxCtor[F]
 
   override def tests: List[Test] = List(
     /* Task */
@@ -231,6 +232,8 @@ object CatchingSpec extends Properties {
 
   object TaskSpec {
     import monix.execution.Scheduler.Implicits.global
+
+    import effectie.monix.Fx._
 
     def testCatching_Task_catchNonFatalShouldCatchNonFatal: Result = {
 
@@ -652,6 +655,7 @@ object CatchingSpec extends Properties {
   }
 
   object IdSpec {
+    import effectie.monix.Fx._
 
     def testCatching_Id_catchNonFatalShouldCatchNonFatal: Result = {
 

--- a/effectie-monix/src/test/scala/effectie/monix/FxCtorSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/FxCtorSpec.scala
@@ -25,6 +25,10 @@ object FxCtorSpec extends Properties {
   object TaskSpec {
     import monix.execution.Scheduler.Implicits.global
 
+    import effectie.FxCtor
+
+    import effectie.monix.Fx._
+
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
       after  <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_ + before).log("after")
@@ -78,6 +82,8 @@ object FxCtorSpec extends Properties {
     import java.util.concurrent.{ExecutorService, Executors}
     import scala.concurrent.duration._
     import scala.concurrent.{ExecutionContext, Future}
+
+    import effectie.FxCtor
 
     val waitFor: FiniteDuration = 1.second
 
@@ -135,6 +141,9 @@ object FxCtorSpec extends Properties {
   }
 
   object IdSpec {
+
+    import effectie.FxCtor
+    import effectie.monix.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/effectie-monix/src/test/scala/effectie/monix/FxSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/FxSpec.scala
@@ -274,6 +274,9 @@ object FxSpec extends Properties {
   object TaskSpec {
     import monix.execution.Scheduler.Implicits.global
 
+    import effectie.Fx
+    import effectie.monix.Fx._
+
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
       after  <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_ + before).log("after")
@@ -334,8 +337,6 @@ object FxSpec extends Properties {
 
       implicit val eqIo: Eq[Task[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).runSyncUnsafe()
-
-      implicit val ioFx: Fx[Task] = Fx.TaskFx
 
       MonadSpec.testMonadLaws[Task]("Task")
     }
@@ -520,6 +521,8 @@ object FxSpec extends Properties {
   }
 
   object IoSpec {
+
+    import effectie.monix.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
@@ -1019,6 +1022,8 @@ object FxSpec extends Properties {
   }
 
   object IdSpec {
+
+    import effectie.monix.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/effectie-monix/src/test/scala/effectie/monix/MonadSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/MonadSpec.scala
@@ -4,6 +4,6 @@ import cats.{Eq, Monad}
 import hedgehog.runner.Test
 
 object MonadSpec {
-  def testMonadLaws[F[_]: Fx: Monad](name: String)(implicit eqF: Eq[F[Int]]): List[Test] =
+  def testMonadLaws[F[_]: effectie.Fx: Monad](name: String)(implicit eqF: Eq[F[Int]]): List[Test] =
     effectie.testing.cats.MonadSpec.testAllLaws[F](s"Fx[$name]")
 }

--- a/effectie-monix/src/test/scala/effectie/monix/syntax/errorSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/syntax/errorSpec.scala
@@ -4,10 +4,9 @@ import cats._
 import cats.data.EitherT
 import cats.syntax.all._
 import effectie.monix.Effectful._
-import effectie.monix.FxCtor
 import effectie.monix.syntax.error._
 import effectie.testing.types._
-import effectie.{ConcurrentSupport, SomeControlThrowable}
+import effectie.{ConcurrentSupport, Fx, SomeControlThrowable}
 import hedgehog._
 import hedgehog.runner._
 import monix.eval.Task
@@ -186,10 +185,11 @@ object CanCatchSyntaxSpec {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[_]: Fx: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object TaskSpec {
+    import effectie.monix.Fx._
     import monix.execution.Scheduler.Implicits.global
 
     def testCanCatch_Task_catchNonFatalThrowableShouldCatchNonFatal: Result = {
@@ -531,6 +531,8 @@ object CanCatchSyntaxSpec {
   }
 
   object IdSpec {
+
+    import effectie.monix.Fx._
 
     def testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -1048,10 +1050,12 @@ object CanHandleErrorSyntaxSpec {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[_]: Fx: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object TaskSpec {
+
+    import effectie.monix.Fx._
     import monix.execution.Scheduler.Implicits.global
 
     def testCanHandleError_Task_handleNonFatalWithShouldHandleNonFatalWith: Result = {
@@ -1887,6 +1891,8 @@ object CanHandleErrorSyntaxSpec {
 
   object IdSpec {
 
+    import effectie.monix.Fx._
+
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
@@ -2626,10 +2632,12 @@ object CanRecoverSyntaxSpec {
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
-  def run[F[_]: FxCtor: Functor, A](a: => A): F[A] =
+  def run[F[_]: Fx: Functor, A](a: => A): F[A] =
     effectOf[F](a)
 
   object TaskSpec {
+
+    import effectie.monix.Fx._
     import monix.execution.Scheduler.Implicits.global
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
@@ -3581,6 +3589,7 @@ object CanRecoverSyntaxSpec {
   }
 
   object IdSpec {
+    import effectie.monix.Fx._
 
     def testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 


### PR DESCRIPTION
Close #320 - Remove `Fx`, `FxCtor` and `CanCatch` `trait`s from `effectie-cats-effect`, `effectie-cats-effect3` and `effectie-monix`