### PR TITLE
Issue #322 - Remove `CanHandleError` `trait` from `effectie-cats-effect`, `effectie-cats-effect3` and `effectie-monix`

### DIFF
--- a/cats-effect/src/main/scala-2/effectie/cats/CanHandleError.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/CanHandleError.scala
@@ -1,7 +1,6 @@
 package effectie.cats
 
 import cats.Id
-import cats.data.EitherT
 import cats.effect.IO
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -10,21 +9,9 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2020-08-17
   */
-trait CanHandleError[F[_]] extends effectie.CanHandleError[F] {
-
-  type XorT[A, B] = EitherT[F, A, B]
-
-  @inline override final protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] =
-    EitherT(fab)
-
-  @inline override final protected def xorT2FEither[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] =
-    efab.value
-
-}
-
 object CanHandleError {
 
-  def apply[F[_]: CanHandleError]: CanHandleError[F] = implicitly[CanHandleError[F]]
+  type CanHandleError[F[_]] = effectie.CanHandleError[F]
 
   implicit object IoCanHandleError extends CanHandleError[IO] {
 

--- a/cats-effect/src/main/scala-2/effectie/cats/package.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/package.scala
@@ -14,6 +14,24 @@ package object cats {
 
   }
 
+  implicit final class CanHandleErrorOps[F[_]](private val canHandleError: effectie.CanHandleError[F]) extends AnyVal {
+
+    def handleEitherTNonFatalWith[A, AA >: A, B, BB >: B](
+      efab: => EitherT[F, A, B]
+    )(
+      handleError: Throwable => F[Either[AA, BB]]
+    ): EitherT[F, AA, BB] =
+      EitherT(canHandleError.handleNonFatalWith[Either[A, B], Either[AA, BB]](efab.value)(handleError))
+
+    def handleEitherTNonFatal[A, AA >: A, B, BB >: B](
+      efab: => EitherT[F, A, B]
+    )(
+      handleError: Throwable => Either[AA, BB]
+    ): EitherT[F, AA, BB] =
+      EitherT(canHandleError.handleNonFatal[Either[A, B], Either[AA, BB]](efab.value)(handleError))
+
+  }
+
   implicit final class FxhOps[F[_]](private val fx: Fx[F]) extends AnyVal {
 
     def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =

--- a/cats-effect/src/main/scala-2/effectie/cats/syntax/error.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/syntax/error.scala
@@ -1,10 +1,9 @@
 package effectie.cats.syntax
 
 import cats.data.EitherT
-import effectie.CanCatch
 import effectie.cats.syntax.error.{EitherTFABErrorHandlingOps, FAErrorHandlingOps, FEitherABErrorHandlingOps}
-import effectie.cats.{CanHandleError, CanRecover}
-import effectie.cats._
+import effectie.cats.{CanCatchOps, CanHandleErrorOps, CanRecover}
+import effectie.{CanCatch, CanHandleError}
 
 /** @author Kevin Lee
   * @since 2021-10-16

--- a/cats-effect/src/main/scala-3/effectie/cats/CanHandleError.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/CanHandleError.scala
@@ -10,21 +10,9 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2020-08-17
   */
-trait CanHandleError[F[*]] extends effectie.CanHandleError[F] {
-
-  type XorT[A, B] = EitherT[F, A, B]
-
-  inline override final protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] =
-    EitherT(fab)
-
-  inline override final protected def xorT2FEither[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] =
-    efab.value
-
-}
-
 object CanHandleError {
 
-  def apply[F[*]: CanHandleError]: CanHandleError[F] = summon[CanHandleError[F]]
+  type CanHandleError[F[*]] = effectie.CanHandleError[F]
 
   given ioCanHandleError: CanHandleError[IO] with {
 

--- a/cats-effect/src/main/scala-3/effectie/cats/cats.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/cats.scala
@@ -13,6 +13,24 @@ extension [F[*]](canCatch: effectie.CanCatch[F]) {
 
 }
 
+extension [F[*]](canHandleError: effectie.CanHandleError[F]) {
+
+  def handleEitherTNonFatalWith[A, AA >: A, B, BB >: B](
+    efab: => EitherT[F, A, B]
+  )(
+    handleError: Throwable => F[Either[AA, BB]]
+  ): EitherT[F, AA, BB] =
+    EitherT(canHandleError.handleNonFatalWith[Either[A, B], Either[AA, BB]](efab.value)(handleError))
+
+  def handleEitherTNonFatal[A, AA >: A, B, BB >: B](
+    efab: => EitherT[F, A, B]
+  )(
+    handleError: Throwable => Either[AA, BB]
+  ): EitherT[F, AA, BB] =
+    EitherT(canHandleError.handleNonFatal[Either[A, B], Either[AA, BB]](efab.value)(handleError))
+
+}
+
 extension [F[*]](fx: Fx[F]) {
 
   def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =

--- a/cats-effect/src/main/scala-3/effectie/cats/syntax/error.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/syntax/error.scala
@@ -1,7 +1,7 @@
 package effectie.cats.syntax
 
 import cats.data.EitherT
-import effectie.CanCatch
+import effectie.{CanCatch, CanHandleError}
 import effectie.cats.*
 
 /** @author Kevin Lee
@@ -93,21 +93,23 @@ trait error {
     )(
       using canCatch: CanCatch[F]
     ): EitherT[F, AA, B] =
-      EitherT(canCatch.catchNonFatalEither[A, AA, B](efab.value)(f))
+      effectie.cats.catchNonFatalEitherT(canCatch)[A, AA, B](efab)(f)
+
 
     def handleEitherTNonFatalWith[AA >: A, BB >: B](
       handleError: Throwable => F[Either[AA, BB]]
     )(
       using canHandleError: CanHandleError[F]
-    ): EitherT[F, AA, BB] =
-      canHandleError.handleEitherTNonFatalWith[A, AA, B, BB](efab)(handleError)
+    ): EitherT[F, AA, BB] = {
+      effectie.cats.handleEitherTNonFatalWith(canHandleError)[A, AA, B, BB](efab)(handleError)
+    }
 
     def handleEitherTNonFatal[AA >: A, BB >: B](
       handleError: Throwable => Either[AA, BB]
     )(
       using canHandleError: CanHandleError[F]
     ): EitherT[F, AA, BB] =
-      canHandleError.handleEitherTNonFatal[A, AA, B, BB](efab)(handleError)
+      effectie.cats.handleEitherTNonFatal(canHandleError)[A, AA, B, BB](efab)(handleError)
 
     def recoverEitherTFromNonFatalWith[AA >: A, BB >: B](
       handleError: PartialFunction[Throwable, F[Either[AA, BB]]]

--- a/cats-effect/src/test/scala-2/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/CanHandleErrorSpec.scala
@@ -9,6 +9,7 @@ import effectie.cats.Effectful._
 import effectie.testing.types.SomeError
 import effectie.{ConcurrentSupport, SomeControlThrowable}
 import effectie.cats.FxCtor._
+import effectie.cats.CanHandleError._
 import hedgehog._
 import hedgehog.runner._
 
@@ -22,6 +23,8 @@ object CanHandleErrorSpec extends Properties {
   type FxCtor[F[_]] = effectie.FxCtor[F]
   val FxCtor: effectie.FxCtor.type = effectie.FxCtor
 
+  type CanHandleError[F[_]] = effectie.CanHandleError[F]
+  val CanHandleError: effectie.CanHandleError.type = effectie.CanHandleError
 
   override def tests: List[Test] = List(
     /* IO */

--- a/cats-effect/src/test/scala-2/effectie/cats/syntax/errorSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/syntax/errorSpec.scala
@@ -5,6 +5,7 @@ import cats.data.EitherT
 import cats.effect._
 import cats.syntax.all._
 import effectie.cats.Effectful._
+import effectie.cats.CanHandleError._
 import effectie.cats.Fx._
 import effectie.cats.syntax.error._
 import effectie.testing.types._

--- a/cats-effect/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
@@ -7,7 +7,8 @@ import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.cats.Effectful.*
 import effectie.testing.types.SomeError
-import effectie.{ConcurrentSupport, FxCtor, SomeControlThrowable}
+import effectie.{CanHandleError, ConcurrentSupport, FxCtor, SomeControlThrowable}
+import effectie.cats.CanHandleError.given
 import hedgehog.*
 import hedgehog.runner.*
 

--- a/cats-effect/src/test/scala-3/effectie/cats/syntax/errorSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/syntax/errorSpec.scala
@@ -1046,6 +1046,7 @@ object CanHandleErrorSyntaxSpec {
   object IoSpec {
 
     import effectie.cats.Fx.given
+    import effectie.cats.CanHandleError.ioCanHandleError
 
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -1467,6 +1468,8 @@ object CanHandleErrorSyntaxSpec {
     import scala.concurrent.duration.*
     import scala.concurrent.{ExecutionContext, Future}
 
+    import effectie.cats.CanHandleError.futureCanHandleError
+
     val waitFor: FiniteDuration = 1.second
 
     def testCanHandleError_Future_handleNonFatalWithShouldHandleNonFatalWith: Result = {
@@ -1871,6 +1874,7 @@ object CanHandleErrorSyntaxSpec {
 
   object IdSpec {
     import effectie.cats.Fx.given
+    import effectie.cats.CanHandleError.idCanHandleError
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 

--- a/cats-effect3/src/main/scala-2/effectie/cats/CanHandleError.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/CanHandleError.scala
@@ -1,7 +1,6 @@
 package effectie.cats
 
 import cats.Id
-import cats.data.EitherT
 import cats.effect.IO
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -10,21 +9,9 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2020-08-17
   */
-trait CanHandleError[F[_]] extends effectie.CanHandleError[F] {
-
-  type XorT[A, B]  = EitherT[F, A, B]
-
-  @inline override final protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] =
-    EitherT(fab)
-
-  @inline override final protected def xorT2FEither[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] =
-    efab.value
-
-}
-
 object CanHandleError {
 
-  def apply[F[_]: CanHandleError]: CanHandleError[F] = implicitly[CanHandleError[F]]
+  type CanHandleError[F[_]] = effectie.CanHandleError[F]
 
   implicit object IoCanHandleError extends CanHandleError[IO] {
 

--- a/cats-effect3/src/main/scala-2/effectie/cats/package.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/package.scala
@@ -14,6 +14,24 @@ package object cats {
 
   }
 
+  implicit final class CanHandleErrorOps[F[_]](private val canHandleError: effectie.CanHandleError[F]) extends AnyVal {
+
+    def handleEitherTNonFatalWith[A, AA >: A, B, BB >: B](
+      efab: => EitherT[F, A, B]
+    )(
+      handleError: Throwable => F[Either[AA, BB]]
+    ): EitherT[F, AA, BB] =
+      EitherT(canHandleError.handleNonFatalWith[Either[A, B], Either[AA, BB]](efab.value)(handleError))
+
+    def handleEitherTNonFatal[A, AA >: A, B, BB >: B](
+      efab: => EitherT[F, A, B]
+    )(
+      handleError: Throwable => Either[AA, BB]
+    ): EitherT[F, AA, BB] =
+      EitherT(canHandleError.handleNonFatal[Either[A, B], Either[AA, BB]](efab.value)(handleError))
+
+  }
+
   implicit final class FxhOps[F[_]](private val fx: Fx[F]) extends AnyVal {
 
     def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =

--- a/cats-effect3/src/main/scala-2/effectie/cats/syntax/error.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/syntax/error.scala
@@ -1,10 +1,9 @@
 package effectie.cats.syntax
 
 import cats.data.EitherT
-import effectie.CanCatch
 import effectie.cats.syntax.error.{EitherTFABErrorHandlingOps, FAErrorHandlingOps, FEitherABErrorHandlingOps}
-import effectie.cats.{CanHandleError, CanRecover}
-import effectie.cats.CanCatchOps
+import effectie.cats.{CanCatchOps, CanHandleErrorOps, CanRecover}
+import effectie.{CanCatch, CanHandleError}
 
 /** @author Kevin Lee
   * @since 2021-10-16

--- a/cats-effect3/src/main/scala-3/effectie/cats/CanHandleError.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/CanHandleError.scala
@@ -10,21 +10,9 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2020-08-17
   */
-trait CanHandleError[F[_]] extends effectie.CanHandleError[F] {
-
-  type XorT[A, B] = EitherT[F, A, B]
-
-  inline override final protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] =
-    EitherT(fab)
-
-  inline override final protected def xorT2FEither[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] =
-    efab.value
-
-}
-
 object CanHandleError {
 
-  def apply[F[_]: CanHandleError]: CanHandleError[F] = summon[CanHandleError[F]]
+  type CanHandleError[F[*]] = effectie.CanHandleError[F]
 
   given ioCanHandleError: CanHandleError[IO] with {
 

--- a/cats-effect3/src/main/scala-3/effectie/cats/cats.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/cats.scala
@@ -13,6 +13,24 @@ extension [F[_]](canCatch: effectie.CanCatch[F]) {
 
 }
 
+extension [F[*]](canHandleError: effectie.CanHandleError[F]) {
+
+  def handleEitherTNonFatalWith[A, AA >: A, B, BB >: B](
+    efab: => EitherT[F, A, B]
+  )(
+    handleError: Throwable => F[Either[AA, BB]]
+  ): EitherT[F, AA, BB] =
+    EitherT(canHandleError.handleNonFatalWith[Either[A, B], Either[AA, BB]](efab.value)(handleError))
+
+  def handleEitherTNonFatal[A, AA >: A, B, BB >: B](
+    efab: => EitherT[F, A, B]
+  )(
+    handleError: Throwable => Either[AA, BB]
+  ): EitherT[F, AA, BB] =
+    EitherT(canHandleError.handleNonFatal[Either[A, B], Either[AA, BB]](efab.value)(handleError))
+
+}
+
 extension [F[_]](fx: Fx[F]) {
 
   def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =

--- a/cats-effect3/src/main/scala-3/effectie/cats/syntax/error.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/syntax/error.scala
@@ -1,8 +1,8 @@
 package effectie.cats.syntax
 
 import cats.data.EitherT
-import effectie.CanCatch
 import effectie.cats.*
+import effectie.{CanCatch, CanHandleError}
 
 /** @author Kevin Lee
  * @since 2021-10-16
@@ -93,21 +93,21 @@ trait error {
     )(
       using canCatch: CanCatch[F]
     ): EitherT[F, AA, B] =
-      EitherT(canCatch.catchNonFatalEither[A, AA, B](efab.value)(f))
+      effectie.cats.catchNonFatalEitherT(canCatch)[A, AA, B](efab)(f)
 
     def handleEitherTNonFatalWith[AA >: A, BB >: B](
       handleError: Throwable => F[Either[AA, BB]]
     )(
       using canHandleError: CanHandleError[F]
     ): EitherT[F, AA, BB] =
-      canHandleError.handleEitherTNonFatalWith[A, AA, B, BB](efab)(handleError)
+      effectie.cats.handleEitherTNonFatalWith(canHandleError)[A, AA, B, BB](efab)(handleError)
 
     def handleEitherTNonFatal[AA >: A, BB >: B](
       handleError: Throwable => Either[AA, BB]
     )(
       using canHandleError: CanHandleError[F]
     ): EitherT[F, AA, BB] =
-      canHandleError.handleEitherTNonFatal[A, AA, B, BB](efab)(handleError)
+      effectie.cats.handleEitherTNonFatal(canHandleError)[A, AA, B, BB](efab)(handleError)
 
     def recoverEitherTFromNonFatalWith[AA >: A, BB >: B](
       handleError: PartialFunction[Throwable, F[Either[AA, BB]]]

--- a/cats-effect3/src/test/scala-2/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/CanHandleErrorSpec.scala
@@ -6,6 +6,7 @@ import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
+import effectie.cats.CanHandleError._
 import effectie.cats.Effectful._
 import effectie.testing.types.SomeError
 import effectie.{ConcurrentSupport, SomeControlThrowable}
@@ -20,6 +21,8 @@ import scala.util.control.{ControlThrowable, NonFatal}
   */
 object CanHandleErrorSpec extends Properties {
   type FxCtor[F[_]] = effectie.FxCtor[F]
+
+  val CanHandleError: effectie.CanHandleError.type = effectie.CanHandleError
 
   override def tests: List[Test] = List(
     /* IO */

--- a/cats-effect3/src/test/scala-2/effectie/cats/syntax/errorSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/syntax/errorSpec.scala
@@ -6,6 +6,7 @@ import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import effectie.cats.Effectful._
+import effectie.cats.CanHandleError._
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.cats.syntax.error._
 import effectie.cats.testing
@@ -26,6 +27,8 @@ object errorSpec extends Properties {
 }
 
 object CanCatchSyntaxSpec {
+
+  val CanHandleError: effectie.CanHandleError.type = effectie.CanHandleError
 
   def tests: List[Test] = List(
     /* IO */

--- a/cats-effect3/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
@@ -8,7 +8,7 @@ import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.cats.Effectful.*
 import effectie.testing.types.SomeError
-import effectie.{ConcurrentSupport, FxCtor, SomeControlThrowable}
+import effectie.{ConcurrentSupport, CanHandleError, FxCtor, SomeControlThrowable}
 import hedgehog.*
 import hedgehog.runner.*
 
@@ -363,6 +363,7 @@ object CanHandleErrorSpec extends Properties {
 
   object IoSpec {
     import effectie.cats.Fx.given
+    import effectie.cats.CanHandleError.ioCanHandleError
 
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -877,6 +878,8 @@ object CanHandleErrorSpec extends Properties {
     import scala.concurrent.duration.*
     import scala.concurrent.{ExecutionContext, Future}
 
+    import effectie.cats.CanHandleError.futureCanHandleError
+
     val waitFor: FiniteDuration = 1.second
 
     def testCanHandleError_Future_handleNonFatalWithShouldHandleNonFatalWith: Result = {
@@ -1287,6 +1290,7 @@ object CanHandleErrorSpec extends Properties {
 
   object IdSpec {
     import effectie.cats.Fx.given
+    import effectie.cats.CanHandleError.idCanHandleError
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 

--- a/cats-effect3/src/test/scala-3/effectie/cats/syntax/errorSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/syntax/errorSpec.scala
@@ -1090,6 +1090,7 @@ object CanHandleErrorSyntaxSpec {
 
   object IoSpec {
     import effectie.cats.Fx.given
+    import effectie.cats.CanHandleError.ioCanHandleError
 
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -1600,6 +1601,8 @@ object CanHandleErrorSyntaxSpec {
     import scala.concurrent.duration.*
     import scala.concurrent.{ExecutionContext, Future}
 
+    import effectie.cats.CanHandleError.futureCanHandleError
+
     val waitFor: FiniteDuration = 1.second
 
     def testCanHandleError_Future_handleNonFatalWithShouldHandleNonFatalWith: Result = {
@@ -2004,6 +2007,7 @@ object CanHandleErrorSyntaxSpec {
 
   object IdSpec {
     import effectie.cats.Fx.given
+    import effectie.cats.CanHandleError.idCanHandleError
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 

--- a/effectie-monix/src/main/scala/effectie/monix/CanHandleError.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/CanHandleError.scala
@@ -1,7 +1,6 @@
 package effectie.monix
 
 import cats.Id
-import cats.data.EitherT
 import monix.eval.Task
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -10,21 +9,9 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2020-08-17
   */
-trait CanHandleError[F[_]] extends effectie.CanHandleError[F] {
-
-  type XorT[A, B] = EitherT[F, A, B]
-
-  @inline override final protected def xorT[A, B](fab: F[Either[A, B]]): EitherT[F, A, B] =
-    EitherT(fab)
-
-  @inline override final protected def xorT2FEither[A, B](efab: EitherT[F, A, B]): F[Either[A, B]] =
-    efab.value
-
-}
-
 object CanHandleError {
 
-  def apply[F[_]: CanHandleError]: CanHandleError[F] = implicitly[CanHandleError[F]]
+  type CanHandleError[F[_]] = effectie.CanHandleError[F]
 
   implicit object IoCanHandleError extends CanHandleError[Task] {
 

--- a/effectie-monix/src/main/scala/effectie/monix/package.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/package.scala
@@ -13,6 +13,24 @@ package object monix {
 
   }
 
+  implicit final class CanHandleErrorOps[F[_]](private val canHandleError: effectie.CanHandleError[F]) extends AnyVal {
+
+    def handleEitherTNonFatalWith[A, AA >: A, B, BB >: B](
+      efab: => EitherT[F, A, B]
+    )(
+      handleError: Throwable => F[Either[AA, BB]]
+    ): EitherT[F, AA, BB] =
+      EitherT(canHandleError.handleNonFatalWith[Either[A, B], Either[AA, BB]](efab.value)(handleError))
+
+    def handleEitherTNonFatal[A, AA >: A, B, BB >: B](
+      efab: => EitherT[F, A, B]
+    )(
+      handleError: Throwable => Either[AA, BB]
+    ): EitherT[F, AA, BB] =
+      EitherT(canHandleError.handleNonFatal[Either[A, B], Either[AA, BB]](efab.value)(handleError))
+
+  }
+
   implicit final class FxhOps[F[_]](private val fx: Fx[F]) extends AnyVal {
 
     def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =

--- a/effectie-monix/src/main/scala/effectie/monix/syntax/error.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/syntax/error.scala
@@ -1,14 +1,13 @@
 package effectie.monix.syntax
 
 import cats.data.EitherT
-import effectie.CanCatch
+import effectie.monix.{CanCatchOps, CanHandleErrorOps, CanRecover}
 import effectie.monix.syntax.error.{EitherTFABErrorHandlingOps, FAErrorHandlingOps, FEitherABErrorHandlingOps}
-import effectie.monix.{CanHandleError, CanRecover}
-import effectie.monix.CanCatchOps
+import effectie.{CanCatch, CanHandleError}
 
 /** @author Kevin Lee
- * @since 2021-10-16
- */
+  * @since 2021-10-16
+  */
 trait error {
 
   implicit def fAErrorHandlingOps[F[_], B](fb: F[B]): FAErrorHandlingOps[F, B] = new FAErrorHandlingOps(fb)

--- a/effectie-monix/src/test/scala/effectie/monix/CanHandleErrorSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/CanHandleErrorSpec.scala
@@ -5,6 +5,7 @@ import cats.data.EitherT
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.monix.Effectful._
+import effectie.monix.CanHandleError._
 import effectie.testing.types.SomeError
 import effectie.{ConcurrentSupport, SomeControlThrowable}
 import hedgehog._
@@ -18,6 +19,8 @@ import scala.util.control.{ControlThrowable, NonFatal}
   */
 object CanHandleErrorSpec extends Properties {
   type FxCtor[F[_]] = effectie.FxCtor[F]
+
+  val CanHandleError: effectie.CanHandleError.type = effectie.CanHandleError
 
   override def tests: List[Test] = List(
     /* Task */

--- a/effectie-monix/src/test/scala/effectie/monix/syntax/errorSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/syntax/errorSpec.scala
@@ -4,6 +4,7 @@ import cats._
 import cats.data.EitherT
 import cats.syntax.all._
 import effectie.monix.Effectful._
+import effectie.monix.CanHandleError._
 import effectie.monix.syntax.error._
 import effectie.testing.types._
 import effectie.{ConcurrentSupport, Fx, SomeControlThrowable}


### PR DESCRIPTION
Issue #322 - Remove `CanHandleError` `trait` from `effectie-cats-effect`, `effectie-cats-effect3` and `effectie-monix`