### PR TITLE
Close #361 - Rename Fx and FxCtor in sub-projects to fx and fxCtor respectively

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -193,7 +193,8 @@ lazy val props =
     final val Scala3Versions = List("3.0.0")
     final val Scala3Version  = Scala3Versions.head
 
-    final val ProjectScalaVersion = Scala2Version
+//    final val ProjectScalaVersion = Scala2Version
+    final val ProjectScalaVersion = "2.12.13"
 //    final val ProjectScalaVersion = Scala3Version
 
     lazy val licenses = List("MIT" -> url("http://opensource.org/licenses/MIT"))

--- a/cats-effect/src/main/scala-2/effectie/cats/CanCatch.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/CanCatch.scala
@@ -8,7 +8,7 @@ import cats.syntax.all._
   * @since 2020-06-07
   */
 object CanCatch {
-  type CanCatch[F[_]] = effectie.core.CanCatch[F]
+  private type CanCatch[F[_]] = effectie.core.CanCatch[F]
 
   implicit object CanCatchIo extends CanCatch[IO] {
 

--- a/cats-effect/src/main/scala-2/effectie/cats/Fx.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/Fx.scala
@@ -3,18 +3,18 @@ package effectie.cats
 import cats.effect.IO
 import cats.Id
 
-object Fx {
-  type Fx[F[_]] = effectie.core.Fx[F]
+object fx {
+  private type Fx[F[_]] = effectie.core.Fx[F]
 
   implicit object IoFx extends Fx[IO] {
 
-    @inline override final def effectOf[A](a: => A): IO[A] = FxCtor.IoFxCtor.effectOf(a)
+    @inline override final def effectOf[A](a: => A): IO[A] = fxCtor.IoFxCtor.effectOf(a)
 
-    @inline override final def pureOf[A](a: A): IO[A] = FxCtor.IoFxCtor.pureOf(a)
+    @inline override final def pureOf[A](a: A): IO[A] = fxCtor.IoFxCtor.pureOf(a)
 
-    @inline override final val unitOf: IO[Unit] = FxCtor.IoFxCtor.unitOf
+    @inline override final val unitOf: IO[Unit] = fxCtor.IoFxCtor.unitOf
 
-    @inline override final def errorOf[A](throwable: Throwable): IO[A] = FxCtor.IoFxCtor.errorOf(throwable)
+    @inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.IoFxCtor.errorOf(throwable)
 
     @inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
 
@@ -40,13 +40,13 @@ object Fx {
 
   implicit object IdFx extends Fx[Id] {
 
-    @inline override final def effectOf[A](a: => A): Id[A] = FxCtor.IdFxCtor.effectOf(a)
+    @inline override final def effectOf[A](a: => A): Id[A] = fxCtor.IdFxCtor.effectOf(a)
 
-    @inline override final def pureOf[A](a: A): Id[A] = FxCtor.IdFxCtor.pureOf(a)
+    @inline override final def pureOf[A](a: A): Id[A] = fxCtor.IdFxCtor.pureOf(a)
 
-    @inline override final val unitOf: Id[Unit] = FxCtor.IdFxCtor.unitOf
+    @inline override final val unitOf: Id[Unit] = fxCtor.IdFxCtor.unitOf
 
-    @inline override final def errorOf[A](throwable: Throwable): Id[A] = FxCtor.IdFxCtor.errorOf(throwable)
+    @inline override final def errorOf[A](throwable: Throwable): Id[A] = fxCtor.IdFxCtor.errorOf(throwable)
 
     @inline override final def mapFa[A, B](fa: Id[A])(f: A => B): Id[B] = f(fa)
 

--- a/cats-effect/src/main/scala-2/effectie/cats/FxCtor.scala
+++ b/cats-effect/src/main/scala-2/effectie/cats/FxCtor.scala
@@ -3,8 +3,8 @@ package effectie.cats
 import cats.Id
 import cats.effect.IO
 
-object FxCtor {
-  type FxCtor[F[_]] = effectie.core.FxCtor[F]
+object fxCtor {
+  private type FxCtor[F[_]] = effectie.core.FxCtor[F]
 
   implicit object IoFxCtor extends FxCtor[IO] {
 

--- a/cats-effect/src/main/scala-3/effectie/cats/Fx.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/Fx.scala
@@ -2,21 +2,21 @@ package effectie.cats
 
 import cats.effect.{IO, Sync}
 import cats.{Applicative, Id, Monad}
+import effectie.core.Fx
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object Fx {
-  type Fx[F[*]] = effectie.core.Fx[F]
+object fx {
 
   given ioFx: Fx[IO] with {
 
-    inline override final def effectOf[A](a: => A): IO[A] = FxCtor.ioFxCtor.effectOf(a)
+    inline override final def effectOf[A](a: => A): IO[A] = fxCtor.ioFxCtor.effectOf(a)
 
-    inline override final def pureOf[A](a: A): IO[A] = FxCtor.ioFxCtor.pureOf(a)
+    inline override final def pureOf[A](a: A): IO[A] = fxCtor.ioFxCtor.pureOf(a)
 
-    inline override final def unitOf: IO[Unit] = FxCtor.ioFxCtor.unitOf
+    inline override final def unitOf: IO[Unit] = fxCtor.ioFxCtor.unitOf
 
-    inline override final def errorOf[A](throwable: Throwable): IO[A] = FxCtor.ioFxCtor.errorOf(throwable)
+    inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.ioFxCtor.errorOf(throwable)
 
     inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
 
@@ -29,23 +29,27 @@ object Fx {
     inline override final def handleNonFatal[A, AA >: A](fa: => IO[A])(handleError: Throwable => AA): IO[AA] =
       CanHandleError.ioCanHandleError.handleNonFatal(fa)(handleError)
 
-    inline override final def recoverFromNonFatalWith[A, AA >: A](fa: => IO[A])(handleError: PartialFunction[Throwable, IO[AA]]): IO[AA] =
+    inline override final def recoverFromNonFatalWith[A, AA >: A](fa: => IO[A])(
+      handleError: PartialFunction[Throwable, IO[AA]]
+    ): IO[AA] =
       CanRecover.ioCanRecover.recoverFromNonFatalWith(fa)(handleError)
 
-    inline override final def recoverFromNonFatal[A, AA >: A](fa: => IO[A])(handleError: PartialFunction[Throwable, AA]): IO[AA] =
+    inline override final def recoverFromNonFatal[A, AA >: A](fa: => IO[A])(
+      handleError: PartialFunction[Throwable, AA]
+    ): IO[AA] =
       CanRecover.ioCanRecover.recoverFromNonFatal(fa)(handleError)
 
   }
 
   given idFx: Fx[Id] with {
 
-    inline override final def effectOf[A](a: => A): Id[A] = FxCtor.idFxCtor.effectOf(a)
+    inline override final def effectOf[A](a: => A): Id[A] = fxCtor.idFxCtor.effectOf(a)
 
-    inline override final def pureOf[A](a: A): Id[A] = FxCtor.idFxCtor.pureOf(a)
+    inline override final def pureOf[A](a: A): Id[A] = fxCtor.idFxCtor.pureOf(a)
 
-    inline override final def unitOf: Id[Unit] = FxCtor.idFxCtor.unitOf
+    inline override final def unitOf: Id[Unit] = fxCtor.idFxCtor.unitOf
 
-    inline override final def errorOf[A](throwable: Throwable): Id[A] = FxCtor.idFxCtor.errorOf(throwable)
+    inline override final def errorOf[A](throwable: Throwable): Id[A] = fxCtor.idFxCtor.errorOf(throwable)
 
     inline override final def mapFa[A, B](fa: Id[A])(f: A => B): Id[B] = f(fa)
 
@@ -58,10 +62,14 @@ object Fx {
     inline override final def handleNonFatal[A, AA >: A](fa: => Id[A])(handleError: Throwable => AA): Id[AA] =
       CanHandleError.idCanHandleError.handleNonFatal(fa)(handleError)
 
-    inline override final def recoverFromNonFatalWith[A, AA >: A](fa: => Id[A])(handleError: PartialFunction[Throwable, Id[AA]]): Id[AA] =
+    inline override final def recoverFromNonFatalWith[A, AA >: A](fa: => Id[A])(
+      handleError: PartialFunction[Throwable, Id[AA]]
+    ): Id[AA] =
       CanRecover.idCanRecover.recoverFromNonFatalWith(fa)(handleError)
 
-    inline override final def recoverFromNonFatal[A, AA >: A](fa: => Id[A])(handleError: PartialFunction[Throwable, AA]): Id[AA] =
+    inline override final def recoverFromNonFatal[A, AA >: A](fa: => Id[A])(
+      handleError: PartialFunction[Throwable, AA]
+    ): Id[AA] =
       CanRecover.idCanRecover.recoverFromNonFatal(fa)(handleError)
 
   }

--- a/cats-effect/src/main/scala-3/effectie/cats/FxCtor.scala
+++ b/cats-effect/src/main/scala-3/effectie/cats/FxCtor.scala
@@ -2,11 +2,11 @@ package effectie.cats
 
 import cats.Id
 import cats.effect.IO
+import effectie.core.FxCtor
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object FxCtor {
-  type FxCtor[F[*]] = effectie.core.FxCtor[F]
+object fxCtor {
 
   given ioFxCtor: FxCtor[IO] with {
 

--- a/cats-effect/src/test/scala-2/effectie/cats/CanCatchSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/CanCatchSpec.scala
@@ -6,8 +6,9 @@ import cats.effect._
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.SomeControlThrowable
+import effectie.core._
 import effectie.syntax.fx._
-import effectie.cats.Fx._
+import effectie.cats.fx._
 import effectie.testing.types._
 import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
@@ -23,7 +24,6 @@ object CanCatchSpec extends Properties {
 
   private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
 
-  type FxCtor[F[_]]   = effectie.core.FxCtor[F]
   type CanCatch[F[_]] = effectie.core.CanCatch[F]
   val CanCatch: effectie.core.CanCatch.type = effectie.core.CanCatch
 

--- a/cats-effect/src/test/scala-2/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/CanHandleErrorSpec.scala
@@ -5,9 +5,10 @@ import cats.data.EitherT
 import cats.effect.IO
 import cats.instances.all._
 import cats.syntax.all._
-import effectie.cats.CanHandleError._
+import effectie.core._
 import effectie.syntax.fx._
-import effectie.cats.FxCtor._
+import effectie.cats.CanHandleError._
+import effectie.cats.fxCtor._
 import effectie.testing.types.SomeError
 import effectie.SomeControlThrowable
 import extras.concurrent.testing.ConcurrentSupport
@@ -22,9 +23,6 @@ import scala.util.control.{ControlThrowable, NonFatal}
   */
 object CanHandleErrorSpec extends Properties {
   implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
-
-  type FxCtor[F[_]] = effectie.core.FxCtor[F]
-  val FxCtor: effectie.core.FxCtor.type = effectie.core.FxCtor
 
   type CanHandleError[F[_]] = effectie.core.CanHandleError[F]
   val CanHandleError: effectie.core.CanHandleError.type = effectie.core.CanHandleError

--- a/cats-effect/src/test/scala-2/effectie/cats/CanRecoverSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/CanRecoverSpec.scala
@@ -5,8 +5,9 @@ import cats.data.EitherT
 import cats.effect.IO
 import cats.instances.all._
 import cats.syntax.all._
+import effectie.core._
 import effectie.syntax.fx._
-import effectie.cats.FxCtor._
+import effectie.cats.fxCtor._
 import effectie.testing.types.SomeError
 import effectie.SomeControlThrowable
 import extras.concurrent.testing.ConcurrentSupport
@@ -21,9 +22,6 @@ import scala.util.control.{ControlThrowable, NonFatal}
   */
 object CanRecoverSpec extends Properties {
   implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
-
-  type FxCtor[F[_]] = effectie.core.FxCtor[F]
-  val FxCtor: effectie.core.FxCtor.type = effectie.core.FxCtor
 
   val CanRecover: effectie.core.CanRecover.type = effectie.core.CanRecover
 

--- a/cats-effect/src/test/scala-2/effectie/cats/CatchingSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/CatchingSpec.scala
@@ -6,10 +6,11 @@ import cats.data.EitherT
 import cats.effect._
 import cats.instances.all._
 import cats.syntax.all._
+import effectie.core._
 import effectie.syntax.fx._
+import effectie.cats.fx._
 import effectie.testing.types.SomeError
 import effectie.SomeControlThrowable
-import effectie.cats.Fx._
 import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
 import hedgehog._
@@ -22,9 +23,6 @@ import scala.util.control.ControlThrowable
   */
 object CatchingSpec extends Properties {
   implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
-
-  type FxCtor[F[_]] = effectie.core.FxCtor[F]
-  val FxCtor: effectie.core.FxCtor.type = effectie.core.FxCtor
 
   override def tests: List[Test] = List(
     /* IO */

--- a/cats-effect/src/test/scala-2/effectie/cats/fxCtorSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/fxCtorSpec.scala
@@ -2,6 +2,8 @@ package effectie.cats
 
 import cats.Id
 import cats.effect._
+import effectie.core._
+import effectie.cats.fxCtor._
 import effectie.testing.tools
 import effectie.testing.types.SomeThrowableError
 import extras.concurrent.testing.types.ErrorLogger
@@ -11,12 +13,9 @@ import hedgehog.runner._
 /** @author Kevin Lee
   * @since 2020-12-06
   */
-object FxCtorSpec extends Properties {
+object fxCtorSpec extends Properties {
 
   implicit private val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
-
-  type FxCtor[F[_]] = effectie.core.FxCtor[F]
-  val FxCtor: effectie.core.FxCtor.type = effectie.core.FxCtor
 
   override def tests: List[Test] =
     ioSpecs ++
@@ -40,7 +39,6 @@ object FxCtorSpec extends Properties {
   )
 
   object IoSpec {
-    import effectie.cats.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
@@ -100,7 +98,6 @@ object FxCtorSpec extends Properties {
   }
 
   object IdSpec {
-    import effectie.cats.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/cats-effect/src/test/scala-2/effectie/cats/fxSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/fxSpec.scala
@@ -2,11 +2,10 @@ package effectie.cats
 
 import cats.data.EitherT
 import cats.effect._
-import cats.effect.unsafe.IORuntime
-import cats.syntax.either.catsSyntaxEitherId
+import cats.syntax.all._
 import cats.{Eq, Functor, Id, Monad}
-import effectie.cats.Fx._
-import effectie.cats.compat.CatsEffectIoCompatForFuture
+import effectie.core._
+import effectie.cats.fx._
 import effectie.testing.tools._
 import effectie.testing.types.{SomeError, SomeThrowableError}
 import effectie.SomeControlThrowable
@@ -15,17 +14,13 @@ import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
 import hedgehog._
 import hedgehog.runner._
 
-import java.util.concurrent.ExecutorService
-import scala.concurrent.Await
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
   * @since 2020-12-06
   */
-object FxSpec extends Properties {
+object fxSpec extends Properties {
   private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
-
-  type Fx[F[_]] = effectie.core.Fx[F]
 
   override def tests: List[Test] = ioSpecs ++ futureSpecs ++ idSpecs
 
@@ -35,72 +30,64 @@ object FxSpec extends Properties {
     property("test Fx[IO].pureOf", IoSpec.testPureOf),
     example("test Fx[IO].unitOf", IoSpec.testUnitOf),
     example("test Fx[IO].errorOf", IoSpec.testErrorOf),
-    property("test Fx[IO] Monad laws - Identity", IoSpec.testMonadLaws1_Identity),
-    property("test Fx[IO] Monad laws - Composition", IoSpec.testMonadLaws2_Composition),
-    property("test Fx[IO] Monad laws - IdentityAp", IoSpec.testMonadLaws3_IdentityAp),
-    property("test Fx[IO] Monad laws - Homomorphism", IoSpec.testMonadLaws4_Homomorphism),
-    property("test Fx[IO] Monad laws - Interchange", IoSpec.testMonadLaws5_Interchange),
-    property("test Fx[IO] Monad laws - CompositionAp", IoSpec.testMonadLaws6_CompositionAp),
-    property("test Fx[IO] Monad laws - LeftIdentity", IoSpec.testMonadLaws7_LeftIdentity),
-    property("test Fx[IO] Monad laws - RightIdentity", IoSpec.testMonadLaws8_RightIdentity),
-    property("test Fx[IO] Monad laws - Associativity", IoSpec.testMonadLaws9_Associativity),
   ) ++
+    IoSpec.testMonadLaws ++
     List(
       example(
-        "test CanCatch[IO]catchNonFatalThrowable should catch NonFatal",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal
+        "test Fx[IO]catchNonFatalThrowable should catch NonFatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalThrowableShouldCatchNonFatal
       ),
       example(
-        "test CanCatch[IO]catchNonFatalThrowable should not catch Fatal",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal
+        "test Fx[IO]catchNonFatalThrowable should not catch Fatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalThrowableShouldNotCatchFatal
       ),
       example(
-        "test CanCatch[IO]catchNonFatalThrowable should return the successful result",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult
+        "test Fx[IO]catchNonFatalThrowable should return the successful result",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalThrowableShouldReturnSuccessfulResult
       ),
       example(
-        "test CanCatch[IO]catchNonFatal should catch NonFatal",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalShouldCatchNonFatal
+        "test Fx[IO]catchNonFatal should catch NonFatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalShouldCatchNonFatal
       ),
       example(
-        "test CanCatch[IO]catchNonFatal should not catch Fatal",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalShouldNotCatchFatal
+        "test Fx[IO]catchNonFatal should not catch Fatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalShouldNotCatchFatal
       ),
       example(
-        "test CanCatch[IO]catchNonFatal should return the successful result",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult
+        "test Fx[IO]catchNonFatal should return the successful result",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalShouldReturnSuccessfulResult
       ),
       example(
-        "test CanCatch[IO]catchNonFatalEither should catch NonFatal",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal
+        "test Fx[IO]catchNonFatalEither should catch NonFatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherShouldCatchNonFatal
       ),
       example(
-        "test CanCatch[IO]catchNonFatalEither should not catch Fatal",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal
+        "test Fx[IO]catchNonFatalEither should not catch Fatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherShouldNotCatchFatal
       ),
       example(
-        "test CanCatch[IO]catchNonFatalEither should return the successful result",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult
+        "test Fx[IO]catchNonFatalEither should return the successful result",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherShouldReturnSuccessfulResult
       ),
       example(
-        "test CanCatch[IO]catchNonFatalEither should return the failed result",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult
+        "test Fx[IO]catchNonFatalEither should return the failed result",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherShouldReturnFailedResult
       ),
       example(
-        "test CanCatch[IO]catchNonFatalEitherT should catch NonFatal",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal
+        "test Fx[IO]catchNonFatalEitherT should catch NonFatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherTShouldCatchNonFatal
       ),
       example(
-        "test CanCatch[IO]catchNonFatalEitherT should not catch Fatal",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal
+        "test Fx[IO]catchNonFatalEitherT should not catch Fatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherTShouldNotCatchFatal
       ),
       example(
-        "test CanCatch[IO]catchNonFatalEitherT should return the successful result",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult
+        "test Fx[IO]catchNonFatalEitherT should return the successful result",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherTShouldReturnSuccessfulResult
       ),
       example(
-        "test CanCatch[IO]catchNonFatalEitherT should return the failed result",
-        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult
+        "test Fx[IO]catchNonFatalEitherT should return the failed result",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherTShouldReturnFailedResult
       ),
     ) ++
     List(
@@ -345,7 +332,7 @@ object FxSpec extends Properties {
       example(
         "test Fx[IO].recoverEitherTFromNonFatal should return the failed result",
         IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnFailedResult
-      ),
+      )
     )
 
   /* Future */
@@ -363,8 +350,7 @@ object FxSpec extends Properties {
         "test Fx[Future]catchNonFatalEitherT should return the failed result",
         FutureSpec.CanCatchSpec.testCanCatch_Future_catchNonFatalEitherTShouldReturnFailedResult
       ),
-    ) ++
-    List(
+    ) ++ List(
       example(
         "test Fx[Future].handleEitherTNonFatalWith should handle NonFatal",
         FutureSpec.CanHandleErrorSpec.testCanHandleError_Future_handleEitherTNonFatalWithShouldHandleNonFatalWith
@@ -413,7 +399,7 @@ object FxSpec extends Properties {
       example(
         "test Fx[Future].recoverEitherTFromNonFatal should return the failed result",
         FutureSpec.CanRecoverSpec.testCanRecover_Future_recoverEitherTFromNonFatalShouldReturnFailedResult
-      ),
+      )
     )
 
   /* Id */
@@ -422,17 +408,10 @@ object FxSpec extends Properties {
     property("test Fx[Id].pureOf", IdSpec.testPureOf),
     example("test Fx[Id].unitOf", IdSpec.testUnitOf),
     example("test Fx[Id].errorOf", IdSpec.testErrorOf),
-    property("test Fx[Id] Monad laws - Identity", IdSpec.testMonadLaws1_Identity),
-    property("test Fx[Id] Monad laws - Composition", IdSpec.testMonadLaws2_Composition),
-    property("test Fx[Id] Monad laws - IdentityAp", IdSpec.testMonadLaws3_IdentityAp),
-    property("test Fx[Id] Monad laws - Homomorphism", IdSpec.testMonadLaws4_Homomorphism),
-    property("test Fx[Id] Monad laws - Interchange", IdSpec.testMonadLaws5_Interchange),
-    property("test Fx[Id] Monad laws - CompositionAp", IdSpec.testMonadLaws6_CompositionAp),
-    property("test Fx[Id] Monad laws - LeftIdentity", IdSpec.testMonadLaws7_LeftIdentity),
-    property("test Fx[Id] Monad laws - RightIdentity", IdSpec.testMonadLaws8_RightIdentity),
-    property("test Fx[Id] Monad laws - Associativity", IdSpec.testMonadLaws9_Associativity),
   ) ++
+    IdSpec.testMonadLaws ++
     List(
+      /* Id */
       example(
         "test Fx[Id]catchNonFatalThrowable should catch NonFatal",
         IdSpec.CanCatchSpec.testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal
@@ -612,6 +591,7 @@ object FxSpec extends Properties {
         IdSpec.CanHandleErrorSpec.testCanHandleError_Id_handleEitherTNonFatalShouldReturnFailedResult
       )
     ) ++ List(
+      /* Id */
       example(
         "test Fx[Id].recoverFromNonFatalWith should catch NonFatal",
         IdSpec.CanRecoverSpec.testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal
@@ -734,7 +714,6 @@ object FxSpec extends Properties {
       )
     )
 
-  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
@@ -747,21 +726,15 @@ object FxSpec extends Properties {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
       after  <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_ + before).log("after")
     } yield {
-      import CatsEffectRunner._
-      implicit val ticket: Ticker = Ticker(TestContext())
-
       @SuppressWarnings(Array("org.wartremover.warts.Var"))
       var actual        = before
       val testBefore    = actual ==== before
       val io            = Fx[IO].effectOf({ actual = after; () })
       val testBeforeRun = actual ==== before
-
-      val done         = io.completeAs(())
-      val testAfterRun = actual ==== after
-
+      io.unsafeRunSync()
+      val testAfterRun  = actual ==== after
       Result.all(
         List(
-          done,
           testBefore.log("testBefore"),
           testBeforeRun.log("testBeforeRun"),
           testAfterRun.log("testAfterRun")
@@ -773,20 +746,15 @@ object FxSpec extends Properties {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
       after  <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_ + before).log("after")
     } yield {
-      import CatsEffectRunner._
-      implicit val ticket: Ticker = Ticker(TestContext())
-
       @SuppressWarnings(Array("org.wartremover.warts.Var"))
       var actual        = before
       val testBefore    = actual ==== before
       val io            = Fx[IO].pureOf({ actual = after; () })
       val testBeforeRun = actual ==== after
-
-      val done         = io.completeAs(())
-      val testAfterRun = actual ==== after
+      io.unsafeRunSync()
+      val testAfterRun  = actual ==== after
       Result.all(
         List(
-          done,
           testBefore.log("testBefore"),
           testBeforeRun.log("testBeforeRun"),
           testAfterRun.log("testAfterRun")
@@ -795,145 +763,45 @@ object FxSpec extends Properties {
     }
 
     def testUnitOf: Result = {
-      import CatsEffectRunner._
-      implicit val ticket: Ticker = Ticker(TestContext())
-      val io                      = Fx[IO].unitOf
-      val expected: Unit          = ()
-      io.completeAs(expected)
+      val io             = Fx[IO].unitOf
+      val expected: Unit = ()
+      val actual: Unit   = io.unsafeRunSync()
+      actual ==== expected
     }
 
     def testErrorOf: Result = {
       val expectedMessage = "This is a throwable test error."
       val expectedError   = SomeThrowableError.message(expectedMessage)
 
-      import CatsEffectRunner._
-      implicit val ticket: Ticker = Ticker(TestContext())
-
-      val io = Fx[IO].errorOf[Unit](expectedError)
-      io.expectError(expectedError)
+      val io = Fx[IO].errorOf(expectedError)
+      expectThrowable(io.unsafeRunSync(), expectedError)
     }
 
-    def testMonadLaws1_Identity: Property = {
-      import CatsEffectRunner._
+    def testMonadLaws: List[Test] = {
       import cats.syntax.eq._
-      implicit val ticket: Ticker = Ticker(TestContext())
 
       implicit val eqIo: Eq[IO[Int]] =
-        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).unsafeRunSync()
 
-      MonadSpec.test1_Identity[IO]
-    }
+      implicit val ioFx: Fx[IO] = effectie.cats.fx.IoFx
 
-    def testMonadLaws2_Composition: Property = {
-      import CatsEffectRunner._
-      import cats.syntax.eq._
-      implicit val ticket: Ticker = Ticker(TestContext())
-
-      implicit val eqIo: Eq[IO[Int]] =
-        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
-
-      MonadSpec.test2_Composition[IO]
-    }
-
-    def testMonadLaws3_IdentityAp: Property = {
-      import CatsEffectRunner._
-      import cats.syntax.eq._
-      implicit val ticket: Ticker = Ticker(TestContext())
-
-      implicit val eqIo: Eq[IO[Int]] =
-        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
-
-      MonadSpec.test3_IdentityAp[IO]
-    }
-
-    def testMonadLaws4_Homomorphism: Property = {
-      import CatsEffectRunner._
-      import cats.syntax.eq._
-      implicit val ticket: Ticker = Ticker(TestContext())
-
-      implicit val eqIo: Eq[IO[Int]] =
-        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
-
-      MonadSpec.test4_Homomorphism[IO]
-    }
-
-    def testMonadLaws5_Interchange: Property = {
-      import CatsEffectRunner._
-      import cats.syntax.eq._
-      implicit val ticket: Ticker = Ticker(TestContext())
-
-      implicit val eqIo: Eq[IO[Int]] =
-        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
-
-      MonadSpec.test5_Interchange[IO]
-    }
-
-    def testMonadLaws6_CompositionAp: Property = {
-      import CatsEffectRunner._
-      import cats.syntax.eq._
-      implicit val ticket: Ticker = Ticker(TestContext())
-
-      implicit val eqIo: Eq[IO[Int]] =
-        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
-
-      MonadSpec.test6_CompositionAp[IO]
-    }
-
-    def testMonadLaws7_LeftIdentity: Property = {
-      import CatsEffectRunner._
-      import cats.syntax.eq._
-      implicit val ticket: Ticker = Ticker(TestContext())
-
-      implicit val eqIo: Eq[IO[Int]] =
-        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
-
-      MonadSpec.test7_LeftIdentity[IO]
-    }
-
-    def testMonadLaws8_RightIdentity: Property = {
-      import CatsEffectRunner._
-      import cats.syntax.eq._
-      implicit val ticket: Ticker = Ticker(TestContext())
-
-      implicit val eqIo: Eq[IO[Int]] =
-        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
-
-      MonadSpec.test8_RightIdentity[IO]
-    }
-
-    def testMonadLaws9_Associativity: Property = {
-      import CatsEffectRunner._
-      import cats.syntax.eq._
-      implicit val ticket: Ticker = Ticker(TestContext())
-
-      implicit val eqIo: Eq[IO[Int]] =
-        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
-
-//      implicit val ioFx: Fx[IO] = Fx.IoFx
-
-      MonadSpec.test9_Associativity[IO]
+      MonadSpec.testMonadLaws[IO]("IO")
     }
 
     object CanCatchSpec {
 
-      def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
+      def testFx_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
         val expected          = expectedExpcetion.asLeft[Int]
-        val actual            = Fx[IO].catchNonFatalThrowable(fa)
+        val actual            = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      def testFx_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -951,36 +819,27 @@ object FxSpec extends Properties {
 
       }
 
-      def testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult: Result = {
+      def testFx_IO_catchNonFatalThrowableShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
+        val fa       = run[IO, Int](1)
+        val expected = 1.asRight[Throwable]
+        val actual   = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
 
-        val fa: IO[Int] = run[IO, Int](1)
-        val expected    = 1.asRight[Throwable]
-        val actual      = Fx[IO].catchNonFatalThrowable(fa)
-
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
-      def testCanCatch_IO_catchNonFatalShouldCatchNonFatal: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
+      def testFx_IO_catchNonFatalShouldCatchNonFatal: Result = {
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
         val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actual            = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable)
+        val actual            = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      def testFx_IO_catchNonFatalShouldNotCatchFatal: Result = {
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -998,36 +857,27 @@ object FxSpec extends Properties {
 
       }
 
-      def testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult: Result = {
+      def testFx_IO_catchNonFatalShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
+        val fa       = run[IO, Int](1)
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
 
-        val fa: IO[Int] = run[IO, Int](1)
-        val expected    = 1.asRight[SomeError]
-        val actual      = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable)
-
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
-      def testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
+      def testFx_IO_catchNonFatalEitherShouldCatchNonFatal: Result = {
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa       = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
         val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actual   = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable)
+        val actual   = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      def testFx_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1045,49 +895,39 @@ object FxSpec extends Properties {
 
       }
 
-      def testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
+      def testFx_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable)
+        val actual   = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
-      def testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
+      def testFx_IO_catchNonFatalEitherShouldReturnFailedResult: Result = {
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
         val expected        = expectedFailure.asLeft[Int]
-        val actual          = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable)
+        val actual          = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
-      def testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal: Result = {
+      def testFx_IO_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
+        val expectedExpcetion               = new RuntimeException("Something's wrong")
+        val fa: EitherT[IO, SomeError, Int] = EitherT(
+          run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        )
+        val expected                        = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actual = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
 
-        val expectedExpcetion = new RuntimeException("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-        val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actual   = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
-
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      def testFx_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -1105,29 +945,23 @@ object FxSpec extends Properties {
 
       }
 
-      def testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
+      def testFx_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
 
         val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
+        val actual   = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
-      def testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
+      def testFx_IO_catchNonFatalEitherTShouldReturnFailedResult: Result = {
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
         val expected        = expectedFailure.asLeft[Int]
-        val actual          = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
+        val actual          = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
     }
@@ -1135,9 +969,6 @@ object FxSpec extends Properties {
     object CanHandleErrorSpec {
 
       def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
@@ -1147,15 +978,13 @@ object FxSpec extends Properties {
             case NonFatal(`expectedExpcetion`) =>
               IO.pure(expected)
           }
+          .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -1175,39 +1004,30 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = run[IO, Int](1)
         val expected = 1
-        val actual   = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(999))
+        val actual   = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(999)).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
         val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
         val actualFailedResult   =
-          Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(expectedFailedResult))
+          Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(expectedFailedResult)).unsafeRunSync()
 
         val expectedSuccessResult = 1.asRight[SomeError]
         val actualSuccessResult   =
-          Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(1.asRight[SomeError]))
+          Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(1.asRight[SomeError])).unsafeRunSync()
 
-        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1227,52 +1047,40 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].handleNonFatalWith(fa)(_ => IO(999.asRight[SomeError]))
+        val actual   = Fx[IO].handleNonFatalWith(fa)(_ => IO(999.asRight[SomeError])).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
         val expected        = expectedFailure.asLeft[Int]
-        val actual          = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
+        val actual          = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleEitherNonFatalWithShouldHandleNonFatalWith: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult   = Fx[IO]
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    = Fx[IO]
           .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-
+          .unsafeRunSync()
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   =
-          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
+          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
 
-        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1295,55 +1103,43 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
         val actual   =
-          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
+          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnFailedResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
         val expected        = expectedFailure.asLeft[Int]
         val actual          =
-          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
+          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult   = Fx[IO]
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    = Fx[IO]
           .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
           .value
-
+          .unsafeRunSync()
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   =
-          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value
+          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
 
-        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -1367,35 +1163,26 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
         val expected = 1.asRight[SomeError]
         val actual   =
-          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value
+          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
         val expected        = expectedFailure.asLeft[Int]
         val actual          =
-          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value
+          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleNonFatalShouldHandleNonFatal: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
@@ -1405,15 +1192,13 @@ object FxSpec extends Properties {
             case NonFatal(`expectedExpcetion`) =>
               expected
           }
+          .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -1433,37 +1218,28 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = run[IO, Int](1)
         val expected = 1
-        val actual   = Fx[IO].handleNonFatal(fa)(_ => 999)
+        val actual   = Fx[IO].handleNonFatal(fa)(_ => 999).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
         val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
-        val actualFailedResult   = Fx[IO].handleNonFatal(fa)(_ => expectedFailedResult)
+        val actualFailedResult   = Fx[IO].handleNonFatal(fa)(_ => expectedFailedResult).unsafeRunSync()
 
         val expectedSuccessResult = 1.asRight[SomeError]
-        val actualSuccessResult   = Fx[IO].handleNonFatal(fa)(_ => 1.asRight[SomeError])
+        val actualSuccessResult   = Fx[IO].handleNonFatal(fa)(_ => 1.asRight[SomeError]).unsafeRunSync()
 
-        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1483,52 +1259,40 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].handleNonFatal(fa)(_ => 999.asRight[SomeError])
+        val actual   = Fx[IO].handleNonFatal(fa)(_ => 999.asRight[SomeError]).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
         val expected        = expectedFailure.asLeft[Int]
-        val actual          = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError])
+        val actual          = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleEitherNonFatalShouldHandleNonFatal: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult   = Fx[IO]
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    = Fx[IO]
           .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-
+          .unsafeRunSync()
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   =
-          Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError])
+          Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
 
-        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1551,54 +1315,42 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError])
+        val actual   = Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleEitherNonFatalShouldReturnFailedResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
         val expected        = expectedFailure.asLeft[Int]
         val actual          =
-          Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError])
+          Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult   = Fx[IO]
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    = Fx[IO]
           .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
           .value
-
+          .unsafeRunSync()
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   =
-          Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value
+          Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
 
-        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -1622,28 +1374,22 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value
+        val actual   = Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
         val expected        = expectedFailure.asLeft[Int]
         val actual          =
-          Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value
+          Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
     }
@@ -1652,25 +1398,21 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
         val expected          = 123
-        val actual            = Fx[IO].recoverFromNonFatalWith(fa) {
-          case NonFatal(`expectedExpcetion`) =>
-            IO.pure(expected)
-        }
-        actual.completeAs(expected)
+        val actual            = Fx[IO]
+          .recoverFromNonFatalWith(fa) {
+            case NonFatal(`expectedExpcetion`) =>
+              IO.pure(expected)
+          }
+          .unsafeRunSync()
 
+        actual ==== expected
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
-
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
@@ -1691,22 +1433,18 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
+        val fa       = run[IO, Int](1)
         val expected = 1
-        val fa       = run[IO, Int](expected)
         val actual   = Fx[IO]
           .recoverFromNonFatalWith(fa) {
             case NonFatal(_) => IO.pure(999)
           }
+          .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal: Result = {
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
@@ -1715,21 +1453,20 @@ object FxSpec extends Properties {
           .recoverFromNonFatalWith(fa) {
             case NonFatal(`expectedExpcetion`) => IO.pure(expectedFailedResult)
           }
+          .unsafeRunSync()
 
         val expectedSuccessResult = 1.asRight[SomeError]
         val actualSuccessResult   = Fx[IO]
           .recoverFromNonFatalWith(fa) {
             case NonFatal(`expectedExpcetion`) => IO.pure(1.asRight[SomeError])
           }
+          .unsafeRunSync()
 
-        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
-
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
@@ -1752,23 +1489,18 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
         val actual   = Fx[IO]
           .recoverFromNonFatalWith(fa) {
             case NonFatal(_) => IO(999.asRight[SomeError])
           }
+          .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnFailedResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
@@ -1777,37 +1509,33 @@ object FxSpec extends Properties {
           .recoverFromNonFatalWith(fa) {
             case NonFatal(_) => IO.pure(123.asRight[SomeError])
           }
+          .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult   = Fx[IO]
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    = Fx[IO]
           .recoverEitherFromNonFatalWith(fa) {
             case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
           }
-
+          .unsafeRunSync()
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   = Fx[IO]
           .recoverEitherFromNonFatalWith(fa) {
             case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
           }
+          .unsafeRunSync()
 
-        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
-
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
@@ -1830,23 +1558,18 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
         val actual   = Fx[IO]
           .recoverEitherFromNonFatalWith(fa) {
             case NonFatal(_) => IO.pure(123.asRight[SomeError])
           }
+          .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnFailedResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
@@ -1856,39 +1579,35 @@ object FxSpec extends Properties {
             .recoverEitherFromNonFatalWith(fa) {
               case NonFatal(_) => IO.pure(123.asRight[SomeError])
             }
+            .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult   = Fx[IO]
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    = Fx[IO]
           .recoverEitherTFromNonFatalWith(fa) {
             case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
           }
           .value
-
+          .unsafeRunSync()
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   = Fx[IO]
           .recoverEitherTFromNonFatalWith(fa) {
             case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
           }
           .value
+          .unsafeRunSync()
 
-        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
-
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
@@ -1911,9 +1630,6 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
         val expected = 1.asRight[SomeError]
         val actual   = Fx[IO]
@@ -1921,14 +1637,12 @@ object FxSpec extends Properties {
             case NonFatal(_) => IO.pure(123.asRight[SomeError])
           }
           .value
+          .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnFailedResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
@@ -1939,16 +1653,14 @@ object FxSpec extends Properties {
               case NonFatal(_) => IO.pure(123.asRight[SomeError])
             }
             .value
+            .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       // /
 
       def testCanRecover_IO_recoverFromNonFatalShouldRecoverFromNonFatal: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
@@ -1958,15 +1670,13 @@ object FxSpec extends Properties {
             case NonFatal(`expectedExpcetion`) =>
               expected
           }
+          .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
-
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
@@ -1987,39 +1697,32 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = run[IO, Int](1)
         val expected = 1
-        val actual   = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999 }
+        val actual   = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999 }.unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanRecover_IO_recoverFromNonFatalEitherShouldRecoverFromNonFatal: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
         val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
         val actualFailedResult   = Fx[IO]
           .recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => expectedFailedResult }
+          .unsafeRunSync()
 
         val expectedSuccessResult = 1.asRight[SomeError]
         val actualSuccessResult   = Fx[IO]
           .recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 1.asRight[SomeError] }
+          .unsafeRunSync()
 
-        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
-
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
@@ -2040,56 +1743,45 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999.asRight[SomeError] }
+        val actual   = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999.asRight[SomeError] }.unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnFailedResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
         val expected        = expectedFailure.asLeft[Int]
-        val actual          = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+        val actual = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }.unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanRecover_IO_recoverEitherFromNonFatalShouldRecoverFromNonFatal: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult   =
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    =
           Fx[IO]
             .recoverEitherFromNonFatal(fa) {
               case err => SomeError.someThrowable(err).asLeft[Int]
             }
-
+            .unsafeRunSync()
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   =
           Fx[IO]
             .recoverEitherFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+            .unsafeRunSync()
 
-        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
-
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
@@ -2113,22 +1805,17 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
         val actual   =
           Fx[IO]
             .recoverEitherFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+            .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnFailedResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
@@ -2136,39 +1823,35 @@ object FxSpec extends Properties {
         val actual          =
           Fx[IO]
             .recoverEitherFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+            .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldRecoverFromNonFatal: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult   =
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    =
           Fx[IO]
             .recoverEitherTFromNonFatal(fa) {
               case err => SomeError.someThrowable(err).asLeft[Int]
             }
             .value
-
+            .unsafeRunSync()
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   =
           Fx[IO]
             .recoverEitherTFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
             .value
+            .unsafeRunSync()
 
-        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
-
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
@@ -2192,23 +1875,18 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult: Result = {
 
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
-
         val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
         val expected = 1.asRight[SomeError]
         val actual   =
           Fx[IO]
             .recoverEitherTFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
             .value
+            .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnFailedResult: Result = {
-
-        import CatsEffectRunner._
-        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
@@ -2217,26 +1895,23 @@ object FxSpec extends Properties {
           Fx[IO]
             .recoverEitherTFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
             .value
+            .unsafeRunSync()
 
-        actual.completeAs(expected)
+        actual ==== expected
       }
 
     }
+
   }
 
   object FutureSpec {
-    import java.util.concurrent.{ExecutorService, Executors}
     import scala.concurrent.duration._
-    import scala.concurrent.{ExecutionContext, Future}
 
     val waitFor = WaitFor(1.second)
 
-    implicit def futureEqual[A: Eq](
-      implicit ec: scala.concurrent.ExecutionContext
-    ): Eq[Future[A]] =
-      (x: Future[A], y: Future[A]) => Await.result(x.flatMap(a => y.map(b => Eq[A].eqv(a, b))), waitFor.waitFor)
-
     object CanCatchSpec {
+      import java.util.concurrent.{ExecutorService, Executors}
+      import scala.concurrent.{ExecutionContext, Future}
 
       def testCanCatch_Future_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
@@ -2288,6 +1963,7 @@ object FxSpec extends Properties {
         actual ==== expected
       }
     }
+
     object CanHandleErrorSpec {
       import java.util.concurrent.{ExecutorService, Executors}
       import scala.concurrent.{ExecutionContext, Future}
@@ -2445,11 +2121,12 @@ object FxSpec extends Properties {
           waitFor
         )
 
-        val fa2      = EitherT(
+        val expected = 1.asRight[SomeError]
+
+        val fa2    = EitherT(
           run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
         )
-        val expected = 1.asRight[SomeError]
-        val actual   =
+        val actual =
           ConcurrentSupport.futureToValueAndTerminate(
             executorService,
             waitFor
@@ -2631,34 +2308,10 @@ object FxSpec extends Properties {
       expectThrowable(actual, expectedError)
     }
 
-    implicit val idInstance: Monad[Id] = cats.catsInstancesForId
-
-    def testMonadLaws1_Identity: Property =
-      MonadSpec.test1_Identity[Id]
-
-    def testMonadLaws2_Composition: Property =
-      MonadSpec.test2_Composition[Id]
-
-    def testMonadLaws3_IdentityAp: Property =
-      MonadSpec.test3_IdentityAp[Id]
-
-    def testMonadLaws4_Homomorphism: Property =
-      MonadSpec.test4_Homomorphism[Id]
-
-    def testMonadLaws5_Interchange: Property =
-      MonadSpec.test5_Interchange[Id]
-
-    def testMonadLaws6_CompositionAp: Property =
-      MonadSpec.test6_CompositionAp[Id]
-
-    def testMonadLaws7_LeftIdentity: Property =
-      MonadSpec.test7_LeftIdentity[Id]
-
-    def testMonadLaws8_RightIdentity: Property =
-      MonadSpec.test8_RightIdentity[Id]
-
-    def testMonadLaws9_Associativity: Property =
-      MonadSpec.test9_Associativity[Id]
+    def testMonadLaws: List[Test] = {
+      val idInstance: Monad[Id] = cats.catsInstancesForId
+      MonadSpec.testMonadLaws[Id]("Id")
+    }
 
     object CanCatchSpec {
 
@@ -3600,6 +3253,7 @@ object FxSpec extends Properties {
         try {
           val actual = Fx[Id]
             .recoverEitherFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 1.asRight[SomeError] }
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>

--- a/cats-effect/src/test/scala-2/effectie/cats/syntax/errorSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/cats/syntax/errorSpec.scala
@@ -4,7 +4,7 @@ import cats._
 import cats.data.EitherT
 import cats.effect._
 import cats.syntax.all._
-import effectie.cats.Fx._
+import effectie.cats.fx._
 import effectie.cats.syntax.error._
 import effectie.syntax.error._
 import effectie.syntax.fx._

--- a/cats-effect/src/test/scala-2/effectie/syntax/fxSpec.scala
+++ b/cats-effect/src/test/scala-2/effectie/syntax/fxSpec.scala
@@ -2,7 +2,7 @@ package effectie.syntax
 
 import cats.Id
 import cats.effect.IO
-import effectie.cats.Fx._
+import effectie.cats.fx._
 import effectie.syntax.fx._
 import effectie.testing.tools.{dropResult, expectThrowable}
 import effectie.testing.types.SomeThrowableError

--- a/cats-effect/src/test/scala-3/effectie/cats/CanCatchSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CanCatchSpec.scala
@@ -6,7 +6,7 @@ import cats.effect.*
 import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.cats.CanCatch as *
-import effectie.cats.Fx.given
+import effectie.cats.fx.given
 import effectie.syntax.fx.*
 import effectie.testing.types.SomeError
 import effectie.core.{CanCatch, Fx}

--- a/cats-effect/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
@@ -7,7 +7,7 @@ import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.cats.CanHandleError.given
 import effectie.syntax.fx.*
-import effectie.cats.Fx.given
+import effectie.cats.fx.given
 import effectie.testing.types.SomeError
 import effectie.core.{CanHandleError, FxCtor}
 import effectie.SomeControlThrowable

--- a/cats-effect/src/test/scala-3/effectie/cats/CanRecoverSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CanRecoverSpec.scala
@@ -5,8 +5,9 @@ import cats.data.EitherT
 import cats.effect.IO
 import cats.instances.all.*
 import cats.syntax.all.*
+import effectie.core.{Fx, CanRecover}
 import effectie.cats.CanRecover.given
-import effectie.cats.Fx.given
+import effectie.cats.fx.given
 import effectie.syntax.fx.*
 import effectie.testing.types.SomeError
 import effectie.core.FxCtor
@@ -22,7 +23,6 @@ import scala.util.control.{ControlThrowable, NonFatal}
   * @since 2020-08-17
   */
 object CanRecoverSpec extends Properties {
-  val CanRecover: effectie.core.CanRecover.type = effectie.core.CanRecover
 
   override def tests: List[Test] = ioSpecs ++ futureSpecs ++ idSpecs
 

--- a/cats-effect/src/test/scala-3/effectie/cats/CatchingSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/CatchingSpec.scala
@@ -6,7 +6,7 @@ import cats.data.EitherT
 import cats.effect.*
 import cats.instances.all.*
 import cats.syntax.all.*
-import effectie.cats.Fx.given
+import effectie.cats.fx.given
 import effectie.syntax.fx.*
 import effectie.testing.types.SomeError
 import effectie.core.FxCtor

--- a/cats-effect/src/test/scala-3/effectie/cats/FxCtorSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/FxCtorSpec.scala
@@ -34,7 +34,7 @@ object FxCtorSpec extends Properties {
 
   object IoSpec {
 
-    import effectie.cats.FxCtor.given
+    import effectie.cats.fxCtor.given
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
@@ -92,7 +92,7 @@ object FxCtorSpec extends Properties {
 
   object IdSpec {
 
-    import effectie.cats.FxCtor.given
+    import effectie.cats.fxCtor.given
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/cats-effect/src/test/scala-3/effectie/cats/FxSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/FxSpec.scala
@@ -5,7 +5,7 @@ import cats.effect.*
 import cats.syntax.all.*
 import cats.{Eq, Functor, Id, Monad}
 import effectie.testing.tools.*
-import effectie.cats.Fx.given
+import effectie.cats.fx.given
 import effectie.testing.types.{SomeError, SomeThrowableError}
 import effectie.core.Fx
 import effectie.SomeControlThrowable
@@ -778,7 +778,7 @@ object FxSpec extends Properties {
       given eqIo: Eq[IO[Int]] =
         (x, y) => x.flatMap(xx => y.map(_ === xx)).unsafeRunSync()
 
-      given ioFx: Fx[IO] = effectie.cats.Fx.ioFx
+      given ioFx: Fx[IO] = effectie.cats.fx.ioFx
 
       MonadSpec.testMonadLaws[IO]("IO")
     }

--- a/cats-effect/src/test/scala-3/effectie/cats/syntax/errorSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/cats/syntax/errorSpec.scala
@@ -2,14 +2,13 @@ package effectie.cats.syntax
 
 import cats.*
 import cats.data.EitherT
-import cats.syntax.all.*
 import cats.effect.*
-import effectie.cats.FxCtor
-import effectie.core.Fx
+import cats.syntax.all.*
 import effectie.SomeControlThrowable
-import effectie.syntax.fx.*
-import effectie.syntax.error.*
 import effectie.cats.syntax.error.*
+import effectie.core.{Fx, FxCtor}
+import effectie.syntax.error.*
+import effectie.syntax.fx.*
 import effectie.testing.types.SomeError
 import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
@@ -193,7 +192,7 @@ object CanCatchSyntaxSpec {
     effectOf[F](a)
 
   object IoSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -319,9 +318,9 @@ object CanCatchSyntaxSpec {
     def testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa                = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual            = fa.catchNonFatalEitherT(SomeError.someThrowable).value.unsafeRunSync()
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual   = fa.catchNonFatalEitherT(SomeError.someThrowable).value.unsafeRunSync()
 
       actual ==== expected
     }
@@ -329,7 +328,7 @@ object CanCatchSyntaxSpec {
     def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual = fa.catchNonFatalEitherT(SomeError.someThrowable).value.unsafeRunSync()
@@ -377,7 +376,8 @@ object CanCatchSyntaxSpec {
     def testCanCatch_Future_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
       val fa                = run[Future, Int](throwThrowable[Int](expectedExpcetion))
@@ -393,7 +393,8 @@ object CanCatchSyntaxSpec {
     def testCanCatch_Future_catchNonFatalThrowableShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Int](1)
       val expected = 1.asRight[SomeError]
@@ -408,7 +409,8 @@ object CanCatchSyntaxSpec {
     def testCanCatch_Future_catchNonFatalShouldCatchNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
       val fa                = run[Future, Int](throwThrowable[Int](expectedExpcetion))
@@ -424,7 +426,8 @@ object CanCatchSyntaxSpec {
     def testCanCatch_Future_catchNonFatalShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Int](1)
       val expected = 1.asRight[SomeError]
@@ -439,12 +442,13 @@ object CanCatchSyntaxSpec {
     def testCanCatch_Future_catchNonFatalEitherShouldCatchNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa                = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual            = ConcurrentSupport.futureToValueAndTerminate(
+      val fa       = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         executorService,
         waitFor
       )(fa.catchNonFatalEither(SomeError.someThrowable))
@@ -455,7 +459,8 @@ object CanCatchSyntaxSpec {
     def testCanCatch_Future_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
@@ -470,7 +475,8 @@ object CanCatchSyntaxSpec {
     def testCanCatch_Future_catchNonFatalEitherShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
@@ -486,12 +492,13 @@ object CanCatchSyntaxSpec {
     def testCanCatch_Future_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      val fa                = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual            = ConcurrentSupport.futureToValueAndTerminate(
+      val fa = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
         executorService,
         waitFor
       )(fa.catchNonFatalEitherT(SomeError.someThrowable).value)
@@ -502,7 +509,8 @@ object CanCatchSyntaxSpec {
     def testCanCatch_Future_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
@@ -517,7 +525,8 @@ object CanCatchSyntaxSpec {
     def testCanCatch_Future_catchNonFatalEitherTShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
@@ -533,7 +542,7 @@ object CanCatchSyntaxSpec {
 
   object IdSpec {
 
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -659,9 +668,9 @@ object CanCatchSyntaxSpec {
     def testCanCatch_Id_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
-      lazy val fa           = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-      val actual            = fa.catchNonFatalEitherT(SomeError.someThrowable).value
+      lazy val fa  = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual   = fa.catchNonFatalEitherT(SomeError.someThrowable).value
 
       actual ==== expected
     }
@@ -669,7 +678,7 @@ object CanCatchSyntaxSpec {
     def testCanCatch_Id_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      lazy val fa        = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual = fa.catchNonFatalEitherT(SomeError.someThrowable).value
@@ -1051,8 +1060,8 @@ object CanHandleErrorSyntaxSpec {
 
   object IoSpec {
 
-    import effectie.cats.Fx.given
     import effectie.cats.CanHandleError.ioCanHandleError
+    import effectie.cats.fx.given
 
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -1098,8 +1107,8 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
       val actualFailedResult   =
         fa.handleNonFatalWith(_ => IO.pure(expectedFailedResult)).unsafeRunSync()
@@ -1150,8 +1159,8 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleEitherNonFatalWithShouldHandleNonFatalWith: Result = {
 
-      val expectedExpcetion     = new RuntimeException("Something's wrong")
-      val fa                    = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult    = fa
         .handleEitherNonFatalWith(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
@@ -1206,8 +1215,8 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = {
 
-      val expectedExpcetion     = new RuntimeException("Something's wrong")
-      val fa                    = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult    = fa
         .handleEitherTNonFatalWith(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
@@ -1223,7 +1232,7 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual =
@@ -1306,8 +1315,8 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
       val actualFailedResult   = fa.handleNonFatal(_ => expectedFailedResult).unsafeRunSync()
 
@@ -1356,8 +1365,8 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleEitherNonFatalShouldHandleNonFatal: Result = {
 
-      val expectedExpcetion     = new RuntimeException("Something's wrong")
-      val fa                    = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult    = fa
         .handleEitherNonFatal(err => SomeError.someThrowable(err).asLeft[Int])
@@ -1412,8 +1421,8 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal: Result = {
 
-      val expectedExpcetion     = new RuntimeException("Something's wrong")
-      val fa                    = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult    = fa
         .handleEitherTNonFatal(err => SomeError.someThrowable(err).asLeft[Int])
@@ -1429,7 +1438,7 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual =
@@ -1481,7 +1490,8 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
       val fa                = run[Future, Int](throwThrowable[Int](expectedExpcetion))
@@ -1497,7 +1507,8 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleNonFatalWithShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Int](1)
       val expected = 1
@@ -1512,10 +1523,11 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         ConcurrentSupport.futureToValue(
@@ -1536,15 +1548,16 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.handleNonFatalWith(err => Future(SomeError.someThrowable(err).asLeft[Int])))
+          executorService,
+          waitFor
+        )(fa.handleNonFatalWith(err => Future(SomeError.someThrowable(err).asLeft[Int])))
 
       actual ==== expected
     }
@@ -1552,7 +1565,8 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleNonFatalWithEitherShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
@@ -1568,10 +1582,11 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleEitherNonFatalWithShouldHandleNonFatalWith: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   = ConcurrentSupport.futureToValue(
         fa.handleEitherNonFatalWith(err => Future(SomeError.someThrowable(err).asLeft[Int])),
@@ -1582,9 +1597,9 @@ object CanHandleErrorSyntaxSpec {
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa2.handleEitherNonFatalWith(err => Future(expected)))
+          executorService,
+          waitFor
+        )(fa2.handleEitherNonFatalWith(err => Future(expected)))
 
       actualFailedResult ==== expectedFailedResult and actual ==== expected
     }
@@ -1592,7 +1607,8 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
@@ -1607,16 +1623,17 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleEitherNonFatalWithShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
       val expected        = expectedFailure.asLeft[Int]
       val actual          =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.handleEitherNonFatalWith(_ => Future(expected)))
+          executorService,
+          waitFor
+        )(fa.handleEitherNonFatalWith(_ => Future(expected)))
 
       actual ==== expected
     }
@@ -1624,23 +1641,24 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   = ConcurrentSupport.futureToValue(
         fa.handleEitherTNonFatalWith(err => Future(SomeError.someThrowable(err).asLeft[Int])).value,
         waitFor
       )
 
-      val fa2      = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val fa2 = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa2.handleEitherTNonFatalWith(err => Future(expected)).value)
+          executorService,
+          waitFor
+        )(fa2.handleEitherTNonFatalWith(err => Future(expected)).value)
 
       actualFailedResult ==== expectedFailedResult and actual ==== expected
     }
@@ -1648,7 +1666,8 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
@@ -1663,16 +1682,17 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleEitherTNonFatalWithShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
       val expected        = expectedFailure.asLeft[Int]
       val actual          =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.handleEitherTNonFatalWith(_ => Future(expected)).value)
+          executorService,
+          waitFor
+        )(fa.handleEitherTNonFatalWith(_ => Future(expected)).value)
 
       actual ==== expected
     }
@@ -1680,7 +1700,8 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleNonFatalShouldHandleNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
       val fa                = run[Future, Int](throwThrowable[Int](expectedExpcetion))
@@ -1696,7 +1717,8 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleNonFatalShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Int](1)
       val expected = 1
@@ -1711,10 +1733,11 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleNonFatalEitherShouldHandleNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         ConcurrentSupport.futureToValue(
@@ -1735,15 +1758,16 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.handleNonFatal(err => SomeError.someThrowable(err).asLeft[Int]))
+          executorService,
+          waitFor
+        )(fa.handleNonFatal(err => SomeError.someThrowable(err).asLeft[Int]))
 
       actual ==== expected
     }
@@ -1751,7 +1775,8 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleNonFatalEitherShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
@@ -1767,10 +1792,11 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleEitherNonFatalShouldHandleNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   = ConcurrentSupport.futureToValue(
         fa.handleEitherNonFatal(err => SomeError.someThrowable(err).asLeft[Int]),
@@ -1781,9 +1807,9 @@ object CanHandleErrorSyntaxSpec {
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa2.handleEitherNonFatal(err => expected))
+          executorService,
+          waitFor
+        )(fa2.handleEitherNonFatal(err => expected))
 
       actualFailedResult ==== expectedFailedResult and actual ==== expected
     }
@@ -1791,7 +1817,8 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleEitherNonFatalShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
@@ -1806,16 +1833,17 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleEitherNonFatalShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
       val expected        = expectedFailure.asLeft[Int]
       val actual          =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.handleEitherTNonFatal(_ => expected).value)
+          executorService,
+          waitFor
+        )(fa.handleEitherTNonFatal(_ => expected).value)
 
       actual ==== expected
     }
@@ -1823,23 +1851,24 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleEitherTNonFatalShouldHandleNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   = ConcurrentSupport.futureToValue(
         fa.handleEitherTNonFatal(err => SomeError.someThrowable(err).asLeft[Int]).value,
         waitFor
       )
 
-      val fa2      = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val fa2 = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa2.handleEitherTNonFatal(err => expected).value)
+          executorService,
+          waitFor
+        )(fa2.handleEitherTNonFatal(err => expected).value)
 
       actualFailedResult ==== expectedFailedResult and actual ==== expected
     }
@@ -1847,7 +1876,8 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
@@ -1862,16 +1892,17 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Future_handleEitherTNonFatalShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
       val expected        = expectedFailure.asLeft[Int]
       val actual          =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.handleEitherTNonFatal(_ => expected).value)
+          executorService,
+          waitFor
+        )(fa.handleEitherTNonFatal(_ => expected).value)
 
       actual ==== expected
     }
@@ -1879,8 +1910,8 @@ object CanHandleErrorSyntaxSpec {
   }
 
   object IdSpec {
-    import effectie.cats.Fx.given
     import effectie.cats.CanHandleError.idCanHandleError
+    import effectie.cats.fx.given
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -1921,8 +1952,8 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_Id_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      lazy val fa              = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         fa.handleNonFatalWith(err => SomeError.someThrowable(err).asLeft[Int]: Id[Either[SomeError, Int]])
@@ -1973,8 +2004,8 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_Id_handleEitherNonFatalWithShouldHandleNonFatalWith: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      lazy val fa              = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         fa.handleEitherNonFatalWith(err => SomeError.someThrowable(err).asLeft[Int]: Id[Either[SomeError, Int]])
@@ -2026,8 +2057,8 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_Id_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      lazy val fa              = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         fa.handleEitherTNonFatalWith(err => SomeError.someThrowable(err).asLeft[Int]).value
@@ -2042,7 +2073,7 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Id_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      lazy val fa        = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual = fa.handleEitherTNonFatalWith(_ => 1.asRight[SomeError]).value
@@ -2116,8 +2147,8 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_Id_handleNonFatalEitherShouldHandleNonFatal: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      lazy val fa              = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   = fa.handleNonFatal(err => SomeError.someThrowable(err).asLeft[Int])
 
@@ -2167,8 +2198,8 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_Id_handleEitherNonFatalShouldHandleNonFatal: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      lazy val fa              = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         fa.handleEitherNonFatal(err => SomeError.someThrowable(err).asLeft[Int])
@@ -2219,8 +2250,8 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_Id_handleEitherTNonFatalShouldHandleNonFatal: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      lazy val fa              = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         fa.handleEitherTNonFatal(err => SomeError.someThrowable(err).asLeft[Int]).value
@@ -2235,7 +2266,7 @@ object CanHandleErrorSyntaxSpec {
     def testCanHandleError_Id_handleEitherTNonFatalShouldNotHandleFatal: Result = {
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      lazy val fa        = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
       try {
         val actual = fa.handleEitherTNonFatal(_ => 1.asRight[SomeError]).value
@@ -2616,8 +2647,8 @@ object CanRecoverSyntaxSpec {
     effectOf[F](a)
 
   object IOSpec {
-    import effectie.cats.Fx.given
     import effectie.cats.CanRecover.given
+    import effectie.cats.fx.given
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
@@ -2668,8 +2699,8 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
       val actualFailedResult   = fa
         .recoverFromNonFatalWith {
@@ -2737,8 +2768,8 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
-      val expectedExpcetion     = new RuntimeException("Something's wrong")
-      val fa                    = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult    = fa
         .recoverEitherFromNonFatalWith {
@@ -2804,8 +2835,8 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
-      val expectedExpcetion     = new RuntimeException("Something's wrong")
-      val fa                    = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult    = fa
         .recoverEitherTFromNonFatalWith {
@@ -2827,7 +2858,7 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
 
       val expectedExpcetion = SomeControlThrowable("Something's wrong")
-      val fa                = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
 
       val io = fa.recoverEitherTFromNonFatalWith {
         case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
@@ -2873,7 +2904,7 @@ object CanRecoverSyntaxSpec {
       actual ==== expected
     }
 
-    ///
+    // /
 
     def testCanRecover_IO_recoverFromNonFatalShouldRecoverFromNonFatal: Result = {
 
@@ -2920,8 +2951,8 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverFromNonFatalEitherShouldRecoverFromNonFatal: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
       val actualFailedResult   = fa
         .recoverFromNonFatal { case NonFatal(`expectedExpcetion`) => expectedFailedResult }
@@ -2975,8 +3006,8 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverEitherFromNonFatalShouldRecoverFromNonFatal: Result = {
 
-      val expectedExpcetion     = new RuntimeException("Something's wrong")
-      val fa                    = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult    =
         fa.recoverEitherFromNonFatal {
@@ -3037,8 +3068,8 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverEitherTFromNonFatalShouldRecoverFromNonFatal: Result = {
 
-      val expectedExpcetion     = new RuntimeException("Something's wrong")
-      val fa                    = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult    =
         fa.recoverEitherTFromNonFatal {
@@ -3057,7 +3088,7 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
 
       val expectedExpcetion = SomeControlThrowable("Something's wrong")
-      val fa                = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
 
       val io =
         fa.recoverEitherTFromNonFatal {
@@ -3116,7 +3147,8 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
       val fa                = run[Future, Int](throwThrowable[Int](expectedExpcetion))
@@ -3125,8 +3157,8 @@ object CanRecoverSyntaxSpec {
         executorService,
         waitFor
       )(fa.recoverFromNonFatalWith {
-          case NonFatal(`expectedExpcetion`) => Future(expected)
-        })
+        case NonFatal(`expectedExpcetion`) => Future(expected)
+      })
 
       actual ==== expected
     }
@@ -3134,7 +3166,8 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverFromNonFatalWithShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Int](1)
       val expected = 1
@@ -3142,8 +3175,8 @@ object CanRecoverSyntaxSpec {
         executorService,
         waitFor
       )(fa.recoverFromNonFatalWith {
-          case NonFatal(_) => Future(123)
-        })
+        case NonFatal(_) => Future(123)
+      })
 
       actual ==== expected
     }
@@ -3151,10 +3184,11 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         ConcurrentSupport.futureToValue(
@@ -3168,11 +3202,11 @@ object CanRecoverSyntaxSpec {
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa2.recoverFromNonFatalWith {
-            case NonFatal(`expectedExpcetion`) => Future(expected)
-          })
+          executorService,
+          waitFor
+        )(fa2.recoverFromNonFatalWith {
+          case NonFatal(`expectedExpcetion`) => Future(expected)
+        })
 
       expectedFailedResult ==== actualFailedResult and actual ==== expected
     }
@@ -3180,17 +3214,18 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.recoverFromNonFatalWith {
-            case err => Future(SomeError.someThrowable(err).asLeft[Int])
-          })
+          executorService,
+          waitFor
+        )(fa.recoverFromNonFatalWith {
+          case err => Future(SomeError.someThrowable(err).asLeft[Int])
+        })
 
       actual ==== expected
     }
@@ -3198,18 +3233,19 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverFromNonFatalWithEitherShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
       val expected        = expectedFailure.asLeft[Int]
       val actual          =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.recoverFromNonFatalWith {
-            case NonFatal(_) => Future(1.asRight[SomeError])
-          })
+          executorService,
+          waitFor
+        )(fa.recoverFromNonFatalWith {
+          case NonFatal(_) => Future(1.asRight[SomeError])
+        })
 
       actual ==== expected
     }
@@ -3217,10 +3253,11 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   = ConcurrentSupport.futureToValue(
         fa.recoverEitherFromNonFatalWith {
@@ -3233,11 +3270,11 @@ object CanRecoverSyntaxSpec {
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa2.recoverEitherFromNonFatalWith {
-            case err => Future(expected)
-          })
+          executorService,
+          waitFor
+        )(fa2.recoverEitherFromNonFatalWith {
+          case err => Future(expected)
+        })
 
       actualFailedResult ==== expectedFailedResult and actual ==== expected
     }
@@ -3245,7 +3282,8 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
@@ -3253,8 +3291,8 @@ object CanRecoverSyntaxSpec {
         executorService,
         waitFor
       )(fa.recoverEitherFromNonFatalWith {
-          case err => Future(SomeError.someThrowable(err).asLeft[Int])
-        })
+        case err => Future(SomeError.someThrowable(err).asLeft[Int])
+      })
 
       actual ==== expected
     }
@@ -3262,18 +3300,19 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverEitherFromNonFatalWithShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
       val expected        = expectedFailure.asLeft[Int]
       val actual          =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.recoverEitherFromNonFatalWith {
-            case NonFatal(_) => Future(expected)
-          })
+          executorService,
+          waitFor
+        )(fa.recoverEitherFromNonFatalWith {
+          case NonFatal(_) => Future(expected)
+        })
 
       actual ==== expected
     }
@@ -3281,10 +3320,11 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   = ConcurrentSupport.futureToValue(
         fa.recoverEitherTFromNonFatalWith {
@@ -3293,15 +3333,15 @@ object CanRecoverSyntaxSpec {
         waitFor
       )
 
-      val fa2      = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val fa2 = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa2.recoverEitherTFromNonFatalWith {
-            case err => Future(expected)
-          }.value)
+          executorService,
+          waitFor
+        )(fa2.recoverEitherTFromNonFatalWith {
+          case err => Future(expected)
+        }.value)
 
       actualFailedResult ==== expectedFailedResult and actual ==== expected
     }
@@ -3309,7 +3349,8 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
@@ -3317,8 +3358,8 @@ object CanRecoverSyntaxSpec {
         executorService,
         waitFor
       )(fa.recoverEitherTFromNonFatalWith {
-          case err => Future(SomeError.someThrowable(err).asLeft[Int])
-        }.value)
+        case err => Future(SomeError.someThrowable(err).asLeft[Int])
+      }.value)
 
       actual ==== expected
     }
@@ -3326,28 +3367,30 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverEitherTFromNonFatalWithShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
       val expected        = expectedFailure.asLeft[Int]
       val actual          =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.recoverEitherTFromNonFatalWith {
-            case NonFatal(_) => Future(expected)
-          }.value)
+          executorService,
+          waitFor
+        )(fa.recoverEitherTFromNonFatalWith {
+          case NonFatal(_) => Future(expected)
+        }.value)
 
       actual ==== expected
     }
 
-    ///
+    // /
 
     def testCanRecover_Future_recoverFromNonFatalShouldRecoverFromNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
       val fa                = run[Future, Int](throwThrowable[Int](expectedExpcetion))
@@ -3363,7 +3406,8 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverFromNonFatalShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Int](1)
       val expected = 1
@@ -3378,10 +3422,11 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverFromNonFatalEitherShouldRecoverFromNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         ConcurrentSupport.futureToValue(
@@ -3404,17 +3449,18 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverFromNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.recoverFromNonFatal {
-            case err => SomeError.someThrowable(err).asLeft[Int]
-          })
+          executorService,
+          waitFor
+        )(fa.recoverFromNonFatal {
+          case err => SomeError.someThrowable(err).asLeft[Int]
+        })
 
       actual ==== expected
     }
@@ -3422,7 +3468,8 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverFromNonFatalEitherShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
@@ -3438,10 +3485,11 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverEitherFromNonFatalShouldRecoverFromNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   = ConcurrentSupport.futureToValue(
         fa.recoverEitherFromNonFatal {
@@ -3454,9 +3502,9 @@ object CanRecoverSyntaxSpec {
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa2.recoverEitherFromNonFatal { case err => expected })
+          executorService,
+          waitFor
+        )(fa2.recoverEitherFromNonFatal { case err => expected })
 
       actualFailedResult ==== expectedFailedResult and actual ==== expected
     }
@@ -3464,7 +3512,8 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverEitherFromNonFatalShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
       val expected = 1.asRight[SomeError]
@@ -3472,8 +3521,8 @@ object CanRecoverSyntaxSpec {
         executorService,
         waitFor
       )(fa.recoverEitherFromNonFatal {
-          case err => SomeError.someThrowable(err).asLeft[Int]
-        })
+        case err => SomeError.someThrowable(err).asLeft[Int]
+      })
 
       actual ==== expected
     }
@@ -3481,16 +3530,17 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverEitherFromNonFatalShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
       val expected        = expectedFailure.asLeft[Int]
       val actual          =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.recoverEitherFromNonFatal { case NonFatal(_) => expected })
+          executorService,
+          waitFor
+        )(fa.recoverEitherFromNonFatal { case NonFatal(_) => expected })
 
       actual ==== expected
     }
@@ -3498,10 +3548,11 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverEitherTFromNonFatalShouldRecoverFromNonFatal: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      val fa                   = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   = ConcurrentSupport.futureToValue(
         fa.recoverEitherTFromNonFatal {
@@ -3510,13 +3561,13 @@ object CanRecoverSyntaxSpec {
         waitFor
       )
 
-      val fa2      = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val fa2 = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expected = 1.asRight[SomeError]
       val actual   =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa2.recoverEitherTFromNonFatal { case err => expected }.value)
+          executorService,
+          waitFor
+        )(fa2.recoverEitherTFromNonFatal { case err => expected }.value)
 
       actualFailedResult ==== expectedFailedResult and actual ==== expected
     }
@@ -3524,7 +3575,8 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverEitherTFromNonFatalShouldReturnSuccessfulResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val fa       = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
       val expected = 1.asRight[SomeError]
@@ -3532,8 +3584,8 @@ object CanRecoverSyntaxSpec {
         executorService,
         waitFor
       )(fa.recoverEitherTFromNonFatal {
-          case err => SomeError.someThrowable(err).asLeft[Int]
-        }.value)
+        case err => SomeError.someThrowable(err).asLeft[Int]
+      }.value)
 
       actual ==== expected
     }
@@ -3541,16 +3593,17 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Future_recoverEitherTFromNonFatalShouldReturnFailedResult: Result = {
 
       given executorService: ExecutorService = Executors.newFixedThreadPool(1)
-      given ec: ExecutionContext             = ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+      given ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expectedFailure = SomeError.message("Failed")
       val fa              = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
       val expected        = expectedFailure.asLeft[Int]
       val actual          =
         ConcurrentSupport.futureToValueAndTerminate(
-        executorService,
-        waitFor
-      )(fa.recoverEitherTFromNonFatal { case NonFatal(_) => expected }.value)
+          executorService,
+          waitFor
+        )(fa.recoverEitherTFromNonFatal { case NonFatal(_) => expected }.value)
 
       actual ==== expected
     }
@@ -3558,8 +3611,8 @@ object CanRecoverSyntaxSpec {
   }
 
   object IdSpec {
-    import effectie.cats.Fx.given
     import effectie.cats.CanRecover.given
+    import effectie.cats.fx.given
 
     def testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
@@ -3602,8 +3655,8 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_Id_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      lazy val fa              = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   = fa.recoverFromNonFatalWith {
         case err => SomeError.someThrowable(err).asLeft[Int]: Id[Either[SomeError, Int]]
@@ -3654,15 +3707,15 @@ object CanRecoverSyntaxSpec {
       val expectedFailure = SomeError.message("Failed")
       val fa              = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
       val expected        = expectedFailure.asLeft[Int]
-      val actual          = fa.recoverFromNonFatalWith { case NonFatal(_) => 1.asRight[SomeError]: Id[Either[SomeError, Int]] }
+      val actual = fa.recoverFromNonFatalWith { case NonFatal(_) => 1.asRight[SomeError]: Id[Either[SomeError, Int]] }
 
       actual ==== expected
     }
 
     def testCanRecover_Id_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      lazy val fa              = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         fa.recoverEitherFromNonFatalWith {
@@ -3721,8 +3774,8 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_Id_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      lazy val fa              = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         fa.recoverEitherTFromNonFatalWith {
@@ -3739,7 +3792,7 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Id_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
 
       val expectedExpcetion = SomeControlThrowable("Something's wrong")
-      lazy val fa           = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
 
       try {
         val actual = fa.recoverEitherTFromNonFatalWith {
@@ -3778,7 +3831,7 @@ object CanRecoverSyntaxSpec {
       actual ==== expected
     }
 
-    ///
+    // /
 
     def testCanRecover_Id_recoverFromNonFatalShouldRecoverFromNonFatal: Result = {
 
@@ -3819,8 +3872,8 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_Id_recoverFromNonFatalEitherShouldRecoverFromNonFatal: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      lazy val fa              = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         fa.recoverFromNonFatal {
@@ -3877,8 +3930,8 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_Id_recoverEitherFromNonFatalShouldRecoverFromNonFatal: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      lazy val fa              = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         fa.recoverEitherFromNonFatal {
@@ -3934,8 +3987,8 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_Id_recoverEitherTFromNonFatalShouldRecoverFromNonFatal: Result = {
 
-      val expectedExpcetion    = new RuntimeException("Something's wrong")
-      lazy val fa              = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
       val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
       val actualFailedResult   =
         fa.recoverEitherTFromNonFatal {
@@ -3952,7 +4005,7 @@ object CanRecoverSyntaxSpec {
     def testCanRecover_Id_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
 
       val expectedExpcetion = SomeControlThrowable("Something's wrong")
-      lazy val fa           = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
 
       try {
         val actual = fa.recoverEitherTFromNonFatal { case NonFatal(`expectedExpcetion`) => 1.asRight[SomeError] }.value

--- a/cats-effect/src/test/scala-3/effectie/syntax/fxSpec.scala
+++ b/cats-effect/src/test/scala-3/effectie/syntax/fxSpec.scala
@@ -2,7 +2,7 @@ package effectie.syntax
 
 import cats.Id
 import cats.effect.IO
-import effectie.cats.Fx.given
+import effectie.cats.fx.given
 import effectie.syntax.fx.*
 import effectie.testing.tools.*
 import effectie.testing.types.SomeThrowableError

--- a/cats-effect3/src/main/scala-2/effectie/cats/CanCatch.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/CanCatch.scala
@@ -8,7 +8,7 @@ import cats.syntax.all._
   * @since 2020-06-07
   */
 object CanCatch {
-  type CanCatch[F[_]] = effectie.core.CanCatch[F]
+  private type CanCatch[F[_]] = effectie.core.CanCatch[F]
 
   implicit object CanCatchIo extends CanCatch[IO] {
 

--- a/cats-effect3/src/main/scala-2/effectie/cats/CanHandleError.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/CanHandleError.scala
@@ -10,7 +10,7 @@ import scala.util.control.NonFatal
   */
 object CanHandleError {
 
-  type CanHandleError[F[_]] = effectie.core.CanHandleError[F]
+  private type CanHandleError[F[_]] = effectie.core.CanHandleError[F]
 
   implicit object IoCanHandleError extends CanHandleError[IO] {
 

--- a/cats-effect3/src/main/scala-2/effectie/cats/CanRecover.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/CanRecover.scala
@@ -10,7 +10,7 @@ import scala.util.control.NonFatal
   */
 object CanRecover {
 
-  type CanRecover[F[_]] = effectie.core.CanRecover[F]
+  private type CanRecover[F[_]] = effectie.core.CanRecover[F]
 
   implicit object IoCanRecover extends CanRecover[IO] {
 

--- a/cats-effect3/src/main/scala-2/effectie/cats/Catching.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/Catching.scala
@@ -1,5 +1,6 @@
 package effectie.cats
 
+import effectie.core._
 import cats.data.EitherT
 
 /** @author Kevin Lee

--- a/cats-effect3/src/main/scala-2/effectie/cats/Fx.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/Fx.scala
@@ -3,20 +3,18 @@ package effectie.cats
 import cats.effect.IO
 import cats.Id
 
-object Fx {
-  type Fx[F[_]] = effectie.core.Fx[F]
-
-  def apply[F[_]: Fx]: Fx[F] = implicitly[Fx[F]]
+object fx {
+  private type Fx[F[_]] = effectie.core.Fx[F]
 
   implicit object IoFx extends Fx[IO] {
 
-    @inline override final def effectOf[A](a: => A): IO[A] = FxCtor.IoFxCtor.effectOf(a)
+    @inline override final def effectOf[A](a: => A): IO[A] = fxCtor.IoFxCtor.effectOf(a)
 
-    @inline override final def pureOf[A](a: A): IO[A] = FxCtor.IoFxCtor.pureOf(a)
+    @inline override final def pureOf[A](a: A): IO[A] = fxCtor.IoFxCtor.pureOf(a)
 
-    @inline override final val unitOf: IO[Unit] = FxCtor.IoFxCtor.unitOf
+    @inline override final val unitOf: IO[Unit] = fxCtor.IoFxCtor.unitOf
 
-    @inline override final def errorOf[A](throwable: Throwable): IO[A] = FxCtor.IoFxCtor.errorOf(throwable)
+    @inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.IoFxCtor.errorOf(throwable)
 
     @inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
 
@@ -42,13 +40,13 @@ object Fx {
 
   implicit object IdFx extends Fx[Id] {
 
-    @inline override final def effectOf[A](a: => A): Id[A] = FxCtor.IdFxCtor.effectOf(a)
+    @inline override final def effectOf[A](a: => A): Id[A] = fxCtor.IdFxCtor.effectOf(a)
 
-    @inline override final def pureOf[A](a: A): Id[A] = FxCtor.IdFxCtor.pureOf(a)
+    @inline override final def pureOf[A](a: A): Id[A] = fxCtor.IdFxCtor.pureOf(a)
 
-    @inline override final val unitOf: Id[Unit] = FxCtor.IdFxCtor.unitOf
+    @inline override final val unitOf: Id[Unit] = fxCtor.IdFxCtor.unitOf
 
-    @inline override final def errorOf[A](throwable: Throwable): Id[A] = FxCtor.IdFxCtor.errorOf(throwable)
+    @inline override final def errorOf[A](throwable: Throwable): Id[A] = fxCtor.IdFxCtor.errorOf(throwable)
 
     @inline override final def mapFa[A, B](fa: Id[A])(f: A => B): Id[B] = f(fa)
 

--- a/cats-effect3/src/main/scala-2/effectie/cats/FxCtor.scala
+++ b/cats-effect3/src/main/scala-2/effectie/cats/FxCtor.scala
@@ -3,10 +3,8 @@ package effectie.cats
 import cats.Id
 import cats.effect.IO
 
-object FxCtor {
-  type FxCtor[F[_]] = effectie.core.FxCtor[F]
-
-  def apply[F[_]: FxCtor]: FxCtor[F] = implicitly[FxCtor[F]]
+object fxCtor {
+  private type FxCtor[F[_]] = effectie.core.FxCtor[F]
 
   implicit object IoFxCtor extends FxCtor[IO] {
 

--- a/cats-effect3/src/main/scala-3/effectie/cats/Fx.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/Fx.scala
@@ -2,24 +2,21 @@ package effectie.cats
 
 import cats.effect.{IO, Sync}
 import cats.{Applicative, Id, Monad}
+import effectie.core.Fx
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object Fx {
-
-  type Fx[F[*]] = effectie.core.Fx[F]
-
-  def apply[F[_]: Fx]: Fx[F] = summon[Fx[F]]
+object fx {
 
   given ioFx: Fx[IO] with {
 
-    inline override final def effectOf[A](a: => A): IO[A] = FxCtor.ioFxCtor.effectOf(a)
+    inline override final def effectOf[A](a: => A): IO[A] = fxCtor.ioFxCtor.effectOf(a)
 
-    inline override final def pureOf[A](a: A): IO[A] = FxCtor.ioFxCtor.pureOf(a)
+    inline override final def pureOf[A](a: A): IO[A] = fxCtor.ioFxCtor.pureOf(a)
 
-    inline override final def unitOf: IO[Unit] = FxCtor.ioFxCtor.unitOf
+    inline override final def unitOf: IO[Unit] = fxCtor.ioFxCtor.unitOf
 
-    inline override final def errorOf[A](throwable: Throwable): IO[A] = FxCtor.ioFxCtor.errorOf(throwable)
+    inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.ioFxCtor.errorOf(throwable)
 
     inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
 
@@ -42,13 +39,13 @@ object Fx {
 
   given idFx: Fx[Id] with {
 
-    inline override final def effectOf[A](a: => A): Id[A] = FxCtor.idFxCtor.effectOf(a)
+    inline override final def effectOf[A](a: => A): Id[A] = fxCtor.idFxCtor.effectOf(a)
 
-    inline override final def pureOf[A](a: A): Id[A] = FxCtor.idFxCtor.pureOf(a)
+    inline override final def pureOf[A](a: A): Id[A] = fxCtor.idFxCtor.pureOf(a)
 
-    inline override final def unitOf: Id[Unit] = FxCtor.idFxCtor.unitOf
+    inline override final def unitOf: Id[Unit] = fxCtor.idFxCtor.unitOf
 
-    inline override final def errorOf[A](throwable: Throwable): Id[A] = FxCtor.idFxCtor.errorOf(throwable)
+    inline override final def errorOf[A](throwable: Throwable): Id[A] = fxCtor.idFxCtor.errorOf(throwable)
 
     inline override final def mapFa[A, B](fa: Id[A])(f: A => B): Id[B] = f(fa)
 

--- a/cats-effect3/src/main/scala-3/effectie/cats/FxCtor.scala
+++ b/cats-effect3/src/main/scala-3/effectie/cats/FxCtor.scala
@@ -2,11 +2,11 @@ package effectie.cats
 
 import cats.Id
 import cats.effect.IO
+import effectie.core.FxCtor
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object FxCtor {
-  type FxCtor[F[*]] = effectie.core.FxCtor[F]
+object fxCtor {
 
   given ioFxCtor: FxCtor[IO] with {
 

--- a/cats-effect3/src/test/scala-2/effectie/cats/CanCatchSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/CanCatchSpec.scala
@@ -7,6 +7,8 @@ import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.SomeControlThrowable
+import effectie.core._
+import effectie.cats.fx._
 import effectie.syntax.fx._
 import effectie.testing.types._
 import extras.concurrent.testing.ConcurrentSupport
@@ -24,7 +26,6 @@ object CanCatchSpec extends Properties {
 
   implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
 
-  type FxCtor[F[_]]   = effectie.core.FxCtor[F]
   type CanCatch[F[_]] = effectie.core.CanCatch[F]
   val CanCatch: effectie.core.CanCatch.type = effectie.core.CanCatch
 
@@ -174,8 +175,6 @@ object CanCatchSpec extends Properties {
     effectOf[F](a)
 
   object IoSpec {
-
-    import effectie.cats.Fx.IoFx
 
     def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -569,8 +568,6 @@ object CanCatchSpec extends Properties {
   }
 
   object IdSpec {
-
-    import effectie.cats.Fx.IdFx
 
     def testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala-2/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/CanHandleErrorSpec.scala
@@ -6,9 +6,10 @@ import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
+import effectie.core._
+import effectie.cats.fxCtor._
 import effectie.cats.CanHandleError._
 import effectie.syntax.fx._
-import effectie.cats.FxCtor._
 import effectie.testing.types.SomeError
 import effectie.SomeControlThrowable
 import extras.concurrent.testing.ConcurrentSupport
@@ -25,8 +26,6 @@ import scala.util.control.{ControlThrowable, NonFatal}
 object CanHandleErrorSpec extends Properties {
 
   implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
-
-  type FxCtor[F[_]] = effectie.core.FxCtor[F]
 
   val CanHandleError: effectie.core.CanHandleError.type = effectie.core.CanHandleError
 

--- a/cats-effect3/src/test/scala-2/effectie/cats/CanRecoverSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/CanRecoverSpec.scala
@@ -7,7 +7,7 @@ import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.cats.CanRecover._
-import effectie.cats.FxCtor._
+import effectie.cats.fxCtor._
 import effectie.syntax.fx._
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.testing.types.SomeError

--- a/cats-effect3/src/test/scala-2/effectie/cats/CatchingSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/CatchingSpec.scala
@@ -7,6 +7,8 @@ import cats.effect._
 import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
+import effectie.core._
+import effectie.cats.fx._
 import effectie.syntax.fx._
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.testing.types.SomeError
@@ -23,9 +25,6 @@ import scala.util.control.ControlThrowable
   */
 object CatchingSpec extends Properties {
   private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
-
-  type Fx[F[_]]     = effectie.core.Fx[F]
-  type FxCtor[F[_]] = effectie.core.FxCtor[F]
 
   override def tests: List[Test] = List(
     /* IO */
@@ -238,8 +237,6 @@ object CatchingSpec extends Properties {
     effectOf[F](a)
 
   object IoSpec {
-
-    import effectie.cats.Fx._
 
     def testCatching_IO_catchNonFatalShouldCatchNonFatal: Result = {
 
@@ -741,8 +738,6 @@ object CatchingSpec extends Properties {
   }
 
   object IdSpec {
-
-    import effectie.cats.Fx._
 
     def testCatching_Id_catchNonFatalShouldCatchNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala-2/effectie/cats/fxCtorSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/fxCtorSpec.scala
@@ -2,6 +2,8 @@ package effectie.cats
 
 import cats.Id
 import cats.effect._
+import effectie.core._
+import effectie.cats.fxCtor._
 import effectie.testing.tools
 import effectie.testing.types.SomeThrowableError
 import extras.concurrent.testing.types.ErrorLogger
@@ -11,7 +13,7 @@ import hedgehog.runner._
 /** @author Kevin Lee
   * @since 2020-12-06
   */
-object FxCtorSpec extends Properties {
+object fxCtorSpec extends Properties {
   private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
 
   override def tests: List[Test] = ioSpecs ++ futureSpecs ++ idSpecs
@@ -33,7 +35,6 @@ object FxCtorSpec extends Properties {
   )
 
   object IoSpec {
-    import effectie.cats.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
@@ -107,8 +108,6 @@ object FxCtorSpec extends Properties {
   }
 
   object IdSpec {
-
-    import effectie.cats.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/cats-effect3/src/test/scala-2/effectie/cats/fxSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/fxSpec.scala
@@ -2,9 +2,12 @@ package effectie.cats
 
 import cats.data.EitherT
 import cats.effect._
-import cats.syntax.all._
+import cats.effect.unsafe.IORuntime
+import cats.syntax.either.catsSyntaxEitherId
 import cats.{Eq, Functor, Id, Monad}
-import effectie.cats.Fx._
+import effectie.core._
+import effectie.cats.fx._
+import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.testing.tools._
 import effectie.testing.types.{SomeError, SomeThrowableError}
 import effectie.SomeControlThrowable
@@ -13,16 +16,15 @@ import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
 import hedgehog._
 import hedgehog.runner._
 
+import java.util.concurrent.ExecutorService
+import scala.concurrent.Await
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
   * @since 2020-12-06
   */
-object FxSpec extends Properties {
+object fxSpec extends Properties {
   private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
-
-  type Fx[F[_]] = effectie.core.Fx[F]
-  val Fx: effectie.core.Fx.type = effectie.core.Fx
 
   override def tests: List[Test] = ioSpecs ++ futureSpecs ++ idSpecs
 
@@ -32,64 +34,72 @@ object FxSpec extends Properties {
     property("test Fx[IO].pureOf", IoSpec.testPureOf),
     example("test Fx[IO].unitOf", IoSpec.testUnitOf),
     example("test Fx[IO].errorOf", IoSpec.testErrorOf),
+    property("test Fx[IO] Monad laws - Identity", IoSpec.testMonadLaws1_Identity),
+    property("test Fx[IO] Monad laws - Composition", IoSpec.testMonadLaws2_Composition),
+    property("test Fx[IO] Monad laws - IdentityAp", IoSpec.testMonadLaws3_IdentityAp),
+    property("test Fx[IO] Monad laws - Homomorphism", IoSpec.testMonadLaws4_Homomorphism),
+    property("test Fx[IO] Monad laws - Interchange", IoSpec.testMonadLaws5_Interchange),
+    property("test Fx[IO] Monad laws - CompositionAp", IoSpec.testMonadLaws6_CompositionAp),
+    property("test Fx[IO] Monad laws - LeftIdentity", IoSpec.testMonadLaws7_LeftIdentity),
+    property("test Fx[IO] Monad laws - RightIdentity", IoSpec.testMonadLaws8_RightIdentity),
+    property("test Fx[IO] Monad laws - Associativity", IoSpec.testMonadLaws9_Associativity),
   ) ++
-    IoSpec.testMonadLaws ++
     List(
       example(
-        "test Fx[IO]catchNonFatalThrowable should catch NonFatal",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalThrowableShouldCatchNonFatal
+        "test CanCatch[IO]catchNonFatalThrowable should catch NonFatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal
       ),
       example(
-        "test Fx[IO]catchNonFatalThrowable should not catch Fatal",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalThrowableShouldNotCatchFatal
+        "test CanCatch[IO]catchNonFatalThrowable should not catch Fatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal
       ),
       example(
-        "test Fx[IO]catchNonFatalThrowable should return the successful result",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalThrowableShouldReturnSuccessfulResult
+        "test CanCatch[IO]catchNonFatalThrowable should return the successful result",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult
       ),
       example(
-        "test Fx[IO]catchNonFatal should catch NonFatal",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalShouldCatchNonFatal
+        "test CanCatch[IO]catchNonFatal should catch NonFatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalShouldCatchNonFatal
       ),
       example(
-        "test Fx[IO]catchNonFatal should not catch Fatal",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalShouldNotCatchFatal
+        "test CanCatch[IO]catchNonFatal should not catch Fatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalShouldNotCatchFatal
       ),
       example(
-        "test Fx[IO]catchNonFatal should return the successful result",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalShouldReturnSuccessfulResult
+        "test CanCatch[IO]catchNonFatal should return the successful result",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult
       ),
       example(
-        "test Fx[IO]catchNonFatalEither should catch NonFatal",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherShouldCatchNonFatal
+        "test CanCatch[IO]catchNonFatalEither should catch NonFatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal
       ),
       example(
-        "test Fx[IO]catchNonFatalEither should not catch Fatal",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherShouldNotCatchFatal
+        "test CanCatch[IO]catchNonFatalEither should not catch Fatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal
       ),
       example(
-        "test Fx[IO]catchNonFatalEither should return the successful result",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherShouldReturnSuccessfulResult
+        "test CanCatch[IO]catchNonFatalEither should return the successful result",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult
       ),
       example(
-        "test Fx[IO]catchNonFatalEither should return the failed result",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherShouldReturnFailedResult
+        "test CanCatch[IO]catchNonFatalEither should return the failed result",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult
       ),
       example(
-        "test Fx[IO]catchNonFatalEitherT should catch NonFatal",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherTShouldCatchNonFatal
+        "test CanCatch[IO]catchNonFatalEitherT should catch NonFatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal
       ),
       example(
-        "test Fx[IO]catchNonFatalEitherT should not catch Fatal",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherTShouldNotCatchFatal
+        "test CanCatch[IO]catchNonFatalEitherT should not catch Fatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal
       ),
       example(
-        "test Fx[IO]catchNonFatalEitherT should return the successful result",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherTShouldReturnSuccessfulResult
+        "test CanCatch[IO]catchNonFatalEitherT should return the successful result",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult
       ),
       example(
-        "test Fx[IO]catchNonFatalEitherT should return the failed result",
-        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherTShouldReturnFailedResult
+        "test CanCatch[IO]catchNonFatalEitherT should return the failed result",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult
       ),
     ) ++
     List(
@@ -334,7 +344,7 @@ object FxSpec extends Properties {
       example(
         "test Fx[IO].recoverEitherTFromNonFatal should return the failed result",
         IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnFailedResult
-      )
+      ),
     )
 
   /* Future */
@@ -352,7 +362,8 @@ object FxSpec extends Properties {
         "test Fx[Future]catchNonFatalEitherT should return the failed result",
         FutureSpec.CanCatchSpec.testCanCatch_Future_catchNonFatalEitherTShouldReturnFailedResult
       ),
-    ) ++ List(
+    ) ++
+    List(
       example(
         "test Fx[Future].handleEitherTNonFatalWith should handle NonFatal",
         FutureSpec.CanHandleErrorSpec.testCanHandleError_Future_handleEitherTNonFatalWithShouldHandleNonFatalWith
@@ -401,7 +412,7 @@ object FxSpec extends Properties {
       example(
         "test Fx[Future].recoverEitherTFromNonFatal should return the failed result",
         FutureSpec.CanRecoverSpec.testCanRecover_Future_recoverEitherTFromNonFatalShouldReturnFailedResult
-      )
+      ),
     )
 
   /* Id */
@@ -410,10 +421,17 @@ object FxSpec extends Properties {
     property("test Fx[Id].pureOf", IdSpec.testPureOf),
     example("test Fx[Id].unitOf", IdSpec.testUnitOf),
     example("test Fx[Id].errorOf", IdSpec.testErrorOf),
+    property("test Fx[Id] Monad laws - Identity", IdSpec.testMonadLaws1_Identity),
+    property("test Fx[Id] Monad laws - Composition", IdSpec.testMonadLaws2_Composition),
+    property("test Fx[Id] Monad laws - IdentityAp", IdSpec.testMonadLaws3_IdentityAp),
+    property("test Fx[Id] Monad laws - Homomorphism", IdSpec.testMonadLaws4_Homomorphism),
+    property("test Fx[Id] Monad laws - Interchange", IdSpec.testMonadLaws5_Interchange),
+    property("test Fx[Id] Monad laws - CompositionAp", IdSpec.testMonadLaws6_CompositionAp),
+    property("test Fx[Id] Monad laws - LeftIdentity", IdSpec.testMonadLaws7_LeftIdentity),
+    property("test Fx[Id] Monad laws - RightIdentity", IdSpec.testMonadLaws8_RightIdentity),
+    property("test Fx[Id] Monad laws - Associativity", IdSpec.testMonadLaws9_Associativity),
   ) ++
-    IdSpec.testMonadLaws ++
     List(
-      /* Id */
       example(
         "test Fx[Id]catchNonFatalThrowable should catch NonFatal",
         IdSpec.CanCatchSpec.testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal
@@ -593,7 +611,6 @@ object FxSpec extends Properties {
         IdSpec.CanHandleErrorSpec.testCanHandleError_Id_handleEitherTNonFatalShouldReturnFailedResult
       )
     ) ++ List(
-      /* Id */
       example(
         "test Fx[Id].recoverFromNonFatalWith should catch NonFatal",
         IdSpec.CanRecoverSpec.testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal
@@ -716,6 +733,7 @@ object FxSpec extends Properties {
       )
     )
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def throwThrowable[A](throwable: => Throwable): A =
     throw throwable
 
@@ -728,15 +746,21 @@ object FxSpec extends Properties {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
       after  <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_ + before).log("after")
     } yield {
+      import CatsEffectRunner._
+      implicit val ticket: Ticker = Ticker(TestContext())
+
       @SuppressWarnings(Array("org.wartremover.warts.Var"))
       var actual        = before
       val testBefore    = actual ==== before
       val io            = Fx[IO].effectOf({ actual = after; () })
       val testBeforeRun = actual ==== before
-      io.unsafeRunSync()
-      val testAfterRun  = actual ==== after
+
+      val done         = io.completeAs(())
+      val testAfterRun = actual ==== after
+
       Result.all(
         List(
+          done,
           testBefore.log("testBefore"),
           testBeforeRun.log("testBeforeRun"),
           testAfterRun.log("testAfterRun")
@@ -748,15 +772,20 @@ object FxSpec extends Properties {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
       after  <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_ + before).log("after")
     } yield {
+      import CatsEffectRunner._
+      implicit val ticket: Ticker = Ticker(TestContext())
+
       @SuppressWarnings(Array("org.wartremover.warts.Var"))
       var actual        = before
       val testBefore    = actual ==== before
       val io            = Fx[IO].pureOf({ actual = after; () })
       val testBeforeRun = actual ==== after
-      io.unsafeRunSync()
-      val testAfterRun  = actual ==== after
+
+      val done         = io.completeAs(())
+      val testAfterRun = actual ==== after
       Result.all(
         List(
+          done,
           testBefore.log("testBefore"),
           testBeforeRun.log("testBeforeRun"),
           testAfterRun.log("testAfterRun")
@@ -765,45 +794,145 @@ object FxSpec extends Properties {
     }
 
     def testUnitOf: Result = {
-      val io             = Fx[IO].unitOf
-      val expected: Unit = ()
-      val actual: Unit   = io.unsafeRunSync()
-      actual ==== expected
+      import CatsEffectRunner._
+      implicit val ticket: Ticker = Ticker(TestContext())
+      val io                      = Fx[IO].unitOf
+      val expected: Unit          = ()
+      io.completeAs(expected)
     }
 
     def testErrorOf: Result = {
       val expectedMessage = "This is a throwable test error."
       val expectedError   = SomeThrowableError.message(expectedMessage)
 
-      val io = Fx[IO].errorOf(expectedError)
-      expectThrowable(io.unsafeRunSync(), expectedError)
+      import CatsEffectRunner._
+      implicit val ticket: Ticker = Ticker(TestContext())
+
+      val io = Fx[IO].errorOf[Unit](expectedError)
+      io.expectError(expectedError)
     }
 
-    def testMonadLaws: List[Test] = {
+    def testMonadLaws1_Identity: Property = {
+      import CatsEffectRunner._
       import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker(TestContext())
 
       implicit val eqIo: Eq[IO[Int]] =
-        (x, y) => x.flatMap(xx => y.map(_ === xx)).unsafeRunSync()
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
 
-      implicit val ioFx: Fx[IO] = effectie.cats.Fx.IoFx
+      MonadSpec.test1_Identity[IO]
+    }
 
-      MonadSpec.testMonadLaws[IO]("IO")
+    def testMonadLaws2_Composition: Property = {
+      import CatsEffectRunner._
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker(TestContext())
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test2_Composition[IO]
+    }
+
+    def testMonadLaws3_IdentityAp: Property = {
+      import CatsEffectRunner._
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker(TestContext())
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test3_IdentityAp[IO]
+    }
+
+    def testMonadLaws4_Homomorphism: Property = {
+      import CatsEffectRunner._
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker(TestContext())
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test4_Homomorphism[IO]
+    }
+
+    def testMonadLaws5_Interchange: Property = {
+      import CatsEffectRunner._
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker(TestContext())
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test5_Interchange[IO]
+    }
+
+    def testMonadLaws6_CompositionAp: Property = {
+      import CatsEffectRunner._
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker(TestContext())
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test6_CompositionAp[IO]
+    }
+
+    def testMonadLaws7_LeftIdentity: Property = {
+      import CatsEffectRunner._
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker(TestContext())
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test7_LeftIdentity[IO]
+    }
+
+    def testMonadLaws8_RightIdentity: Property = {
+      import CatsEffectRunner._
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker(TestContext())
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test8_RightIdentity[IO]
+    }
+
+    def testMonadLaws9_Associativity: Property = {
+      import CatsEffectRunner._
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker(TestContext())
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+//      implicit val ioFx: Fx[IO] = Fx.IoFx
+
+      MonadSpec.test9_Associativity[IO]
     }
 
     object CanCatchSpec {
 
-      def testFx_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
+      def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
         val expected          = expectedExpcetion.asLeft[Int]
-        val actual            = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+        val actual            = Fx[IO].catchNonFatalThrowable(fa)
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testFx_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
+      def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -821,27 +950,36 @@ object FxSpec extends Properties {
 
       }
 
-      def testFx_IO_catchNonFatalThrowableShouldReturnSuccessfulResult: Result = {
+      def testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult: Result = {
 
-        val fa       = run[IO, Int](1)
-        val expected = 1.asRight[Throwable]
-        val actual   = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
-        actual ==== expected
+        val fa: IO[Int] = run[IO, Int](1)
+        val expected    = 1.asRight[Throwable]
+        val actual      = Fx[IO].catchNonFatalThrowable(fa)
+
+        actual.completeAs(expected)
       }
 
-      def testFx_IO_catchNonFatalShouldCatchNonFatal: Result = {
+      def testCanCatch_IO_catchNonFatalShouldCatchNonFatal: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
         val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actual            = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+        val actual            = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable)
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testFx_IO_catchNonFatalShouldNotCatchFatal: Result = {
+      def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -859,27 +997,36 @@ object FxSpec extends Properties {
 
       }
 
-      def testFx_IO_catchNonFatalShouldReturnSuccessfulResult: Result = {
+      def testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult: Result = {
 
-        val fa       = run[IO, Int](1)
-        val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
-        actual ==== expected
+        val fa: IO[Int] = run[IO, Int](1)
+        val expected    = 1.asRight[SomeError]
+        val actual      = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable)
+
+        actual.completeAs(expected)
       }
 
-      def testFx_IO_catchNonFatalEitherShouldCatchNonFatal: Result = {
+      def testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa       = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
         val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actual   = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+        val actual   = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable)
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testFx_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
+      def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -897,39 +1044,49 @@ object FxSpec extends Properties {
 
       }
 
-      def testFx_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
+      def testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+        val actual   = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable)
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
-      def testFx_IO_catchNonFatalEitherShouldReturnFailedResult: Result = {
+      def testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
         val expected        = expectedFailure.asLeft[Int]
-        val actual          = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+        val actual          = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable)
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
-      def testFx_IO_catchNonFatalEitherTShouldCatchNonFatal: Result = {
+      def testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
-        val expectedExpcetion               = new RuntimeException("Something's wrong")
-        val fa: EitherT[IO, SomeError, Int] = EitherT(
-          run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-        )
-        val expected                        = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actual = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
-        actual ==== expected
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+        val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actual   = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
+
+        actual.completeAs(expected)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testFx_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
+      def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -947,23 +1104,29 @@ object FxSpec extends Properties {
 
       }
 
-      def testFx_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
+      def testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+        val actual   = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
-      def testFx_IO_catchNonFatalEitherTShouldReturnFailedResult: Result = {
+      def testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
         val expected        = expectedFailure.asLeft[Int]
-        val actual          = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+        val actual          = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
     }
@@ -971,6 +1134,9 @@ object FxSpec extends Properties {
     object CanHandleErrorSpec {
 
       def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
@@ -980,13 +1146,15 @@ object FxSpec extends Properties {
             case NonFatal(`expectedExpcetion`) =>
               IO.pure(expected)
           }
-          .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -1006,30 +1174,39 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = run[IO, Int](1)
         val expected = 1
-        val actual   = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(999)).unsafeRunSync()
+        val actual   = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(999))
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
         val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
         val actualFailedResult   =
-          Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(expectedFailedResult)).unsafeRunSync()
+          Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(expectedFailedResult))
 
         val expectedSuccessResult = 1.asRight[SomeError]
         val actualSuccessResult   =
-          Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(1.asRight[SomeError])).unsafeRunSync()
+          Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(1.asRight[SomeError]))
 
-        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1049,40 +1226,52 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].handleNonFatalWith(fa)(_ => IO(999.asRight[SomeError])).unsafeRunSync()
+        val actual   = Fx[IO].handleNonFatalWith(fa)(_ => IO(999.asRight[SomeError]))
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
         val expected        = expectedFailure.asLeft[Int]
-        val actual          = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+        val actual          = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleEitherNonFatalWithShouldHandleNonFatalWith: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult    = Fx[IO]
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   = Fx[IO]
           .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-          .unsafeRunSync()
+
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   =
-          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
 
-        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1105,43 +1294,55 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
         val actual   =
-          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnFailedResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
         val expected        = expectedFailure.asLeft[Int]
         val actual          =
-          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult    = Fx[IO]
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   = Fx[IO]
           .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
           .value
-          .unsafeRunSync()
+
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   =
-          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
+          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value
 
-        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -1165,26 +1366,35 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
         val expected = 1.asRight[SomeError]
         val actual   =
-          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
+          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
         val expected        = expectedFailure.asLeft[Int]
         val actual          =
-          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
+          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleNonFatalShouldHandleNonFatal: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
@@ -1194,13 +1404,15 @@ object FxSpec extends Properties {
             case NonFatal(`expectedExpcetion`) =>
               expected
           }
-          .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -1220,28 +1432,37 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = run[IO, Int](1)
         val expected = 1
-        val actual   = Fx[IO].handleNonFatal(fa)(_ => 999).unsafeRunSync()
+        val actual   = Fx[IO].handleNonFatal(fa)(_ => 999)
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
         val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
-        val actualFailedResult   = Fx[IO].handleNonFatal(fa)(_ => expectedFailedResult).unsafeRunSync()
+        val actualFailedResult   = Fx[IO].handleNonFatal(fa)(_ => expectedFailedResult)
 
         val expectedSuccessResult = 1.asRight[SomeError]
-        val actualSuccessResult   = Fx[IO].handleNonFatal(fa)(_ => 1.asRight[SomeError]).unsafeRunSync()
+        val actualSuccessResult   = Fx[IO].handleNonFatal(fa)(_ => 1.asRight[SomeError])
 
-        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1261,40 +1482,52 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].handleNonFatal(fa)(_ => 999.asRight[SomeError]).unsafeRunSync()
+        val actual   = Fx[IO].handleNonFatal(fa)(_ => 999.asRight[SomeError])
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
         val expected        = expectedFailure.asLeft[Int]
-        val actual          = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+        val actual          = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError])
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleEitherNonFatalShouldHandleNonFatal: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult    = Fx[IO]
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   = Fx[IO]
           .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-          .unsafeRunSync()
+
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   =
-          Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+          Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError])
 
-        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1317,42 +1550,54 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+        val actual   = Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError])
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleEitherNonFatalShouldReturnFailedResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
         val expected        = expectedFailure.asLeft[Int]
         val actual          =
-          Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+          Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError])
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult    = Fx[IO]
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   = Fx[IO]
           .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
           .value
-          .unsafeRunSync()
+
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   =
-          Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
+          Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value
 
-        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -1376,22 +1621,28 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
+        val actual   = Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
         val expected        = expectedFailure.asLeft[Int]
         val actual          =
-          Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
+          Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
     }
@@ -1400,21 +1651,25 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
         val expected          = 123
-        val actual            = Fx[IO]
-          .recoverFromNonFatalWith(fa) {
-            case NonFatal(`expectedExpcetion`) =>
-              IO.pure(expected)
-          }
-          .unsafeRunSync()
+        val actual            = Fx[IO].recoverFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) =>
+            IO.pure(expected)
+        }
+        actual.completeAs(expected)
 
-        actual ==== expected
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
@@ -1435,18 +1690,22 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult: Result = {
 
-        val fa       = run[IO, Int](1)
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expected = 1
+        val fa       = run[IO, Int](expected)
         val actual   = Fx[IO]
           .recoverFromNonFatalWith(fa) {
             case NonFatal(_) => IO.pure(999)
           }
-          .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal: Result = {
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
@@ -1455,20 +1714,21 @@ object FxSpec extends Properties {
           .recoverFromNonFatalWith(fa) {
             case NonFatal(`expectedExpcetion`) => IO.pure(expectedFailedResult)
           }
-          .unsafeRunSync()
 
         val expectedSuccessResult = 1.asRight[SomeError]
         val actualSuccessResult   = Fx[IO]
           .recoverFromNonFatalWith(fa) {
             case NonFatal(`expectedExpcetion`) => IO.pure(1.asRight[SomeError])
           }
-          .unsafeRunSync()
 
-        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
@@ -1491,18 +1751,23 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
         val actual   = Fx[IO]
           .recoverFromNonFatalWith(fa) {
             case NonFatal(_) => IO(999.asRight[SomeError])
           }
-          .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnFailedResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
@@ -1511,33 +1776,37 @@ object FxSpec extends Properties {
           .recoverFromNonFatalWith(fa) {
             case NonFatal(_) => IO.pure(123.asRight[SomeError])
           }
-          .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult    = Fx[IO]
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   = Fx[IO]
           .recoverEitherFromNonFatalWith(fa) {
             case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
           }
-          .unsafeRunSync()
+
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   = Fx[IO]
           .recoverEitherFromNonFatalWith(fa) {
             case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
           }
-          .unsafeRunSync()
 
-        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
@@ -1560,18 +1829,23 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
         val actual   = Fx[IO]
           .recoverEitherFromNonFatalWith(fa) {
             case NonFatal(_) => IO.pure(123.asRight[SomeError])
           }
-          .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnFailedResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
@@ -1581,35 +1855,39 @@ object FxSpec extends Properties {
             .recoverEitherFromNonFatalWith(fa) {
               case NonFatal(_) => IO.pure(123.asRight[SomeError])
             }
-            .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult    = Fx[IO]
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   = Fx[IO]
           .recoverEitherTFromNonFatalWith(fa) {
             case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
           }
           .value
-          .unsafeRunSync()
+
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   = Fx[IO]
           .recoverEitherTFromNonFatalWith(fa) {
             case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
           }
           .value
-          .unsafeRunSync()
 
-        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
@@ -1632,6 +1910,9 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
         val expected = 1.asRight[SomeError]
         val actual   = Fx[IO]
@@ -1639,12 +1920,14 @@ object FxSpec extends Properties {
             case NonFatal(_) => IO.pure(123.asRight[SomeError])
           }
           .value
-          .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnFailedResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
@@ -1655,14 +1938,16 @@ object FxSpec extends Properties {
               case NonFatal(_) => IO.pure(123.asRight[SomeError])
             }
             .value
-            .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       // /
 
       def testCanRecover_IO_recoverFromNonFatalShouldRecoverFromNonFatal: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
@@ -1672,13 +1957,15 @@ object FxSpec extends Properties {
             case NonFatal(`expectedExpcetion`) =>
               expected
           }
-          .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
@@ -1699,32 +1986,39 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = run[IO, Int](1)
         val expected = 1
-        val actual   = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999 }.unsafeRunSync()
+        val actual   = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999 }
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanRecover_IO_recoverFromNonFatalEitherShouldRecoverFromNonFatal: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
         val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
         val actualFailedResult   = Fx[IO]
           .recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => expectedFailedResult }
-          .unsafeRunSync()
 
         val expectedSuccessResult = 1.asRight[SomeError]
         val actualSuccessResult   = Fx[IO]
           .recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 1.asRight[SomeError] }
-          .unsafeRunSync()
 
-        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
@@ -1745,45 +2039,56 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
-        val actual   = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999.asRight[SomeError] }.unsafeRunSync()
+        val actual   = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999.asRight[SomeError] }
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnFailedResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
         val expected        = expectedFailure.asLeft[Int]
-        val actual = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }.unsafeRunSync()
+        val actual          = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanRecover_IO_recoverEitherFromNonFatalShouldRecoverFromNonFatal: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
-        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult    =
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   =
           Fx[IO]
             .recoverEitherFromNonFatal(fa) {
               case err => SomeError.someThrowable(err).asLeft[Int]
             }
-            .unsafeRunSync()
+
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   =
           Fx[IO]
             .recoverEitherFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
-            .unsafeRunSync()
 
-        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
@@ -1807,17 +2112,22 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
         val expected = 1.asRight[SomeError]
         val actual   =
           Fx[IO]
             .recoverEitherFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
-            .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnFailedResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
@@ -1825,35 +2135,39 @@ object FxSpec extends Properties {
         val actual          =
           Fx[IO]
             .recoverEitherFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
-            .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldRecoverFromNonFatal: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val expectedExpcetion = new RuntimeException("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
-        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
-        val actualFailedResult    =
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   =
           Fx[IO]
             .recoverEitherTFromNonFatal(fa) {
               case err => SomeError.someThrowable(err).asLeft[Int]
             }
             .value
-            .unsafeRunSync()
+
         val expectedSuccessResult = 123.asRight[SomeError]
         val actualSuccessResult   =
           Fx[IO]
             .recoverEitherTFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
             .value
-            .unsafeRunSync()
 
-        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
         val expectedExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
@@ -1877,18 +2191,23 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult: Result = {
 
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
+
         val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
         val expected = 1.asRight[SomeError]
         val actual   =
           Fx[IO]
             .recoverEitherTFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
             .value
-            .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnFailedResult: Result = {
+
+        import CatsEffectRunner._
+        implicit val ticket: Ticker = Ticker(TestContext())
 
         val expectedFailure = SomeError.message("Failed")
         val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
@@ -1897,23 +2216,26 @@ object FxSpec extends Properties {
           Fx[IO]
             .recoverEitherTFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
             .value
-            .unsafeRunSync()
 
-        actual ==== expected
+        actual.completeAs(expected)
       }
 
     }
-
   }
 
   object FutureSpec {
+    import java.util.concurrent.{ExecutorService, Executors}
     import scala.concurrent.duration._
+    import scala.concurrent.{ExecutionContext, Future}
 
     val waitFor = WaitFor(1.second)
 
+    implicit def futureEqual[A: Eq](
+      implicit ec: scala.concurrent.ExecutionContext
+    ): Eq[Future[A]] =
+      (x: Future[A], y: Future[A]) => Await.result(x.flatMap(a => y.map(b => Eq[A].eqv(a, b))), waitFor.waitFor)
+
     object CanCatchSpec {
-      import java.util.concurrent.{ExecutorService, Executors}
-      import scala.concurrent.{ExecutionContext, Future}
 
       def testCanCatch_Future_catchNonFatalEitherTShouldCatchNonFatal: Result = {
 
@@ -1965,7 +2287,6 @@ object FxSpec extends Properties {
         actual ==== expected
       }
     }
-
     object CanHandleErrorSpec {
       import java.util.concurrent.{ExecutorService, Executors}
       import scala.concurrent.{ExecutionContext, Future}
@@ -2123,12 +2444,11 @@ object FxSpec extends Properties {
           waitFor
         )
 
-        val expected = 1.asRight[SomeError]
-
-        val fa2    = EitherT(
+        val fa2      = EitherT(
           run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
         )
-        val actual =
+        val expected = 1.asRight[SomeError]
+        val actual   =
           ConcurrentSupport.futureToValueAndTerminate(
             executorService,
             waitFor
@@ -2310,10 +2630,34 @@ object FxSpec extends Properties {
       expectThrowable(actual, expectedError)
     }
 
-    def testMonadLaws: List[Test] = {
-      val idInstance: Monad[Id] = cats.catsInstancesForId
-      MonadSpec.testMonadLaws[Id]("Id")
-    }
+    implicit val idInstance: Monad[Id] = cats.catsInstancesForId
+
+    def testMonadLaws1_Identity: Property =
+      MonadSpec.test1_Identity[Id]
+
+    def testMonadLaws2_Composition: Property =
+      MonadSpec.test2_Composition[Id]
+
+    def testMonadLaws3_IdentityAp: Property =
+      MonadSpec.test3_IdentityAp[Id]
+
+    def testMonadLaws4_Homomorphism: Property =
+      MonadSpec.test4_Homomorphism[Id]
+
+    def testMonadLaws5_Interchange: Property =
+      MonadSpec.test5_Interchange[Id]
+
+    def testMonadLaws6_CompositionAp: Property =
+      MonadSpec.test6_CompositionAp[Id]
+
+    def testMonadLaws7_LeftIdentity: Property =
+      MonadSpec.test7_LeftIdentity[Id]
+
+    def testMonadLaws8_RightIdentity: Property =
+      MonadSpec.test8_RightIdentity[Id]
+
+    def testMonadLaws9_Associativity: Property =
+      MonadSpec.test9_Associativity[Id]
 
     object CanCatchSpec {
 
@@ -3255,7 +3599,6 @@ object FxSpec extends Properties {
         try {
           val actual = Fx[Id]
             .recoverEitherFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 1.asRight[SomeError] }
-
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>

--- a/cats-effect3/src/test/scala-2/effectie/cats/syntax/errorSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/cats/syntax/errorSpec.scala
@@ -5,7 +5,7 @@ import cats.data.EitherT
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
-import effectie.cats.Fx._
+import effectie.cats.fx._
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.cats.syntax.error._
 import effectie.cats.testing

--- a/cats-effect3/src/test/scala-2/effectie/syntax/fxSpec.scala
+++ b/cats-effect3/src/test/scala-2/effectie/syntax/fxSpec.scala
@@ -3,7 +3,7 @@ package effectie.syntax
 import cats.Id
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
-import effectie.cats.Fx._
+import effectie.cats.fx._
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.cats.{CatsEffectRunner, testing}
 import effectie.syntax.fx._

--- a/cats-effect3/src/test/scala-3/effectie/cats/CanCatchSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/CanCatchSpec.scala
@@ -170,7 +170,7 @@ object CanCatchSpec extends Properties {
     effectOf[F](a)
 
   object IoSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -442,7 +442,7 @@ object CanCatchSpec extends Properties {
   }
 
   object IdSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/CanHandleErrorSpec.scala
@@ -309,7 +309,7 @@ object CanHandleErrorSpec extends Properties {
     effectOf[F](a)
 
   object IoSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
     import effectie.cats.CanHandleError.ioCanHandleError
 
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
@@ -947,7 +947,7 @@ object CanHandleErrorSpec extends Properties {
   }
 
   object IdSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
     import effectie.cats.CanHandleError.idCanHandleError
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {

--- a/cats-effect3/src/test/scala-3/effectie/cats/CanRecoverSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/CanRecoverSpec.scala
@@ -7,6 +7,7 @@ import effectie.cats.CatsEffectRunner.TestContext
 import cats.effect.unsafe.IORuntime
 import cats.instances.all.*
 import cats.syntax.all.*
+import effectie.core.CanRecover
 import effectie.syntax.fx.*
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.testing.types.SomeError
@@ -23,8 +24,6 @@ import scala.util.control.{ControlThrowable, NonFatal}
   * @since 2020-08-17
   */
 object CanRecoverSpec extends Properties {
-
-  val CanRecover: effectie.core.CanRecover.type = effectie.core.CanRecover
 
   override def tests: List[Test] = ioSpecs ++ futureSpecs ++ idSpecs
 
@@ -311,7 +310,7 @@ object CanRecoverSpec extends Properties {
     effectOf[F](a)
 
   object IoSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
     import effectie.cats.CanRecover.given
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
@@ -1046,7 +1045,7 @@ object CanRecoverSpec extends Properties {
   }
 
   object IdSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
     import effectie.cats.CanRecover.given
 
     def testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {

--- a/cats-effect3/src/test/scala-3/effectie/cats/CatchingSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/CatchingSpec.scala
@@ -242,7 +242,7 @@ object CatchingSpec extends Properties {
     effectOf[F](a)
 
   object IoSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testCatching_IO_catchNonFatalShouldCatchNonFatal: Result = {
 
@@ -727,7 +727,7 @@ object CatchingSpec extends Properties {
   }
 
   object IdSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testCatching_Id_catchNonFatalShouldCatchNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala-3/effectie/cats/FxCtorSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/FxCtorSpec.scala
@@ -35,7 +35,7 @@ object FxCtorSpec extends Properties {
   )
 
   object IoSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
@@ -116,7 +116,7 @@ object FxCtorSpec extends Properties {
   }
 
   object IdSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/cats-effect3/src/test/scala-3/effectie/cats/FxSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/FxSpec.scala
@@ -8,7 +8,7 @@ import cats.instances.either.*
 import cats.syntax.all.*
 import cats.{Eq, Functor, Id, Monad, Show}
 import effectie.cats.compat.CatsEffectIoCompatForFuture
-import effectie.cats.Fx.given
+import effectie.cats.fx.given
 import effectie.testing.tools.*
 import effectie.testing.types.{SomeError, SomeThrowableError}
 import effectie.core.Fx
@@ -26,8 +26,6 @@ import scala.util.control.{ControlThrowable, NonFatal}
   * @since 2020-12-06
   */
 object FxSpec extends Properties {
-
-  val Fx: effectie.core.Fx.type = effectie.core.Fx
 
   given eqSomeError: Eq[SomeError]     = Eq.fromUniversalEquals[SomeError]
   given shosSomeError: Show[SomeError] = Show.fromToString

--- a/cats-effect3/src/test/scala-3/effectie/cats/syntax/errorSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/cats/syntax/errorSpec.scala
@@ -8,7 +8,8 @@ import cats.{Functor, Id}
 import effectie.cats.CatsEffectRunner.TestContext
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.cats.syntax.error.*
-import effectie.cats.{CanCatch, FxCtor, testing}
+import effectie.core.FxCtor
+import effectie.cats.{CanCatch, testing}
 import effectie.syntax.error.*
 import effectie.syntax.fx.*
 import effectie.testing.types.*
@@ -205,7 +206,7 @@ object CanCatchSyntaxSpec {
     effectOf[F](a)
 
   object IoSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -586,7 +587,7 @@ object CanCatchSyntaxSpec {
   }
 
   object IdSpec {
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -1112,7 +1113,7 @@ object CanHandleErrorSyntaxSpec {
 
   object IoSpec {
     import effectie.cats.CanHandleError.ioCanHandleError
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -2027,7 +2028,7 @@ object CanHandleErrorSyntaxSpec {
 
   object IdSpec {
     import effectie.cats.CanHandleError.idCanHandleError
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
 
@@ -2772,7 +2773,7 @@ object CanRecoverSyntaxSpec {
 
   object IOSpec {
     import effectie.cats.CanRecover.given
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 
@@ -3783,7 +3784,7 @@ object CanRecoverSyntaxSpec {
 
   object IdSpec {
     import effectie.cats.CanRecover.given
-    import effectie.cats.Fx.given
+    import effectie.cats.fx.given
 
     def testCanRecover_Id_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
 

--- a/cats-effect3/src/test/scala-3/effectie/syntax/fxSpec.scala
+++ b/cats-effect3/src/test/scala-3/effectie/syntax/fxSpec.scala
@@ -4,7 +4,7 @@ import cats.*
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import effectie.cats.CatsEffectRunner.{TestContext, Ticker}
-import effectie.cats.Fx.given
+import effectie.cats.fx.given
 import effectie.cats.compat.CatsEffectIoCompatForFuture
 import effectie.cats.{CatsEffectRunner, testing}
 import effectie.syntax.fx.*

--- a/effectie-monix/src/main/scala/effectie/monix/CanCatch.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/CanCatch.scala
@@ -9,7 +9,7 @@ import monix.eval.Task
   * @since 2020-06-07
   */
 object CanCatch {
-  type CanCatch[F[_]] = effectie.core.CanCatch[F]
+  private type CanCatch[F[_]] = effectie.core.CanCatch[F]
 
   implicit object CanCatchTask extends CanCatch[Task] {
 

--- a/effectie-monix/src/main/scala/effectie/monix/Fx.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/Fx.scala
@@ -7,18 +7,18 @@ import monix.eval.Task
 /** @author Kevin Lee
   * @since 2021-05-16
   */
-object Fx {
-  type Fx[F[_]] = effectie.core.Fx[F]
+object fx {
+  private type Fx[F[_]] = effectie.core.Fx[F]
 
   implicit object TaskFx extends Fx[Task] {
 
-    @inline override final def effectOf[A](a: => A): Task[A] = FxCtor.TaskFxCtor.effectOf(a)
+    @inline override final def effectOf[A](a: => A): Task[A] = fxCtor.TaskFxCtor.effectOf(a)
 
-    @inline override final def pureOf[A](a: A): Task[A] = FxCtor.TaskFxCtor.pureOf(a)
+    @inline override final def pureOf[A](a: A): Task[A] = fxCtor.TaskFxCtor.pureOf(a)
 
-    @inline override final val unitOf: Task[Unit] = FxCtor.TaskFxCtor.unitOf
+    @inline override final val unitOf: Task[Unit] = fxCtor.TaskFxCtor.unitOf
 
-    @inline override final def errorOf[A](throwable: Throwable): Task[A] = FxCtor.TaskFxCtor.errorOf(throwable)
+    @inline override final def errorOf[A](throwable: Throwable): Task[A] = fxCtor.TaskFxCtor.errorOf(throwable)
 
     @inline override final def mapFa[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
 
@@ -46,13 +46,13 @@ object Fx {
 
   implicit object IoFx extends Fx[IO] {
 
-    @inline override final def effectOf[A](a: => A): IO[A] = FxCtor.IoFxCtor.effectOf(a)
+    @inline override final def effectOf[A](a: => A): IO[A] = fxCtor.IoFxCtor.effectOf(a)
 
-    @inline override final def pureOf[A](a: A): IO[A] = FxCtor.IoFxCtor.pureOf(a)
+    @inline override final def pureOf[A](a: A): IO[A] = fxCtor.IoFxCtor.pureOf(a)
 
-    @inline override final val unitOf: IO[Unit] = FxCtor.IoFxCtor.unitOf
+    @inline override final val unitOf: IO[Unit] = fxCtor.IoFxCtor.unitOf
 
-    @inline override final def errorOf[A](throwable: Throwable): IO[A] = FxCtor.IoFxCtor.errorOf(throwable)
+    @inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.IoFxCtor.errorOf(throwable)
 
     @inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
 
@@ -78,13 +78,13 @@ object Fx {
 
   implicit object IdFx extends Fx[Id] {
 
-    @inline override final def effectOf[A](a: => A): Id[A] = FxCtor.IdFxCtor.effectOf(a)
+    @inline override final def effectOf[A](a: => A): Id[A] = fxCtor.IdFxCtor.effectOf(a)
 
-    @inline override final def pureOf[A](a: A): Id[A] = FxCtor.IdFxCtor.pureOf(a)
+    @inline override final def pureOf[A](a: A): Id[A] = fxCtor.IdFxCtor.pureOf(a)
 
-    @inline override final val unitOf: Id[Unit] = FxCtor.IdFxCtor.unitOf
+    @inline override final val unitOf: Id[Unit] = fxCtor.IdFxCtor.unitOf
 
-    @inline override final def errorOf[A](throwable: Throwable): Id[A] = FxCtor.IdFxCtor.errorOf(throwable)
+    @inline override final def errorOf[A](throwable: Throwable): Id[A] = fxCtor.IdFxCtor.errorOf(throwable)
 
     @inline override final def mapFa[A, B](fa: Id[A])(f: A => B): Id[B] = f(fa)
 

--- a/effectie-monix/src/main/scala/effectie/monix/FxCtor.scala
+++ b/effectie-monix/src/main/scala/effectie/monix/FxCtor.scala
@@ -7,8 +7,8 @@ import monix.eval.Task
 /** @author Kevin Lee
   * @since 2021-05-16
   */
-object FxCtor {
-  type FxCtor[F[_]] = effectie.core.FxCtor[F]
+object fxCtor {
+  private type FxCtor[F[_]] = effectie.core.FxCtor[F]
 
   implicit object TaskFxCtor extends FxCtor[Task] {
 

--- a/effectie-monix/src/test/scala/effectie/monix/CanCatchSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/CanCatchSpec.scala
@@ -6,6 +6,8 @@ import cats.effect.IO
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.SomeControlThrowable
+import effectie.core._
+import effectie.monix.fx._
 import effectie.syntax.fx._
 import effectie.testing.types.SomeError
 import extras.concurrent.testing.ConcurrentSupport
@@ -23,7 +25,6 @@ object CanCatchSpec extends Properties {
 
   implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
 
-  type FxCtor[F[_]]   = effectie.core.FxCtor[F]
   type CanCatch[F[_]] = effectie.core.CanCatch[F]
   val CanCatch: effectie.core.CanCatch.type = effectie.core.CanCatch
 
@@ -236,7 +237,6 @@ object CanCatchSpec extends Properties {
     effectOf[F](a)
 
   object TaskSpec {
-    import effectie.monix.Fx.TaskFx
     import monix.execution.Scheduler.Implicits.global
 
     def testCanCatch_Task_catchNonFatalThrowableShouldCatchNonFatal: Result = {
@@ -414,8 +414,6 @@ object CanCatchSpec extends Properties {
   }
 
   object IoSpec {
-
-    import effectie.monix.Fx.IoFx
 
     def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 
@@ -760,7 +758,6 @@ object CanCatchSpec extends Properties {
   }
 
   object IdSpec {
-    import effectie.monix.Fx.IdFx
 
     def testCanCatch_Id_catchNonFatalThrowableShouldCatchNonFatal: Result = {
 

--- a/effectie-monix/src/test/scala/effectie/monix/CanHandleErrorSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/CanHandleErrorSpec.scala
@@ -7,7 +7,8 @@ import cats.instances.all._
 import cats.syntax.all._
 import effectie.SomeControlThrowable
 import effectie.monix.CanHandleError._
-import effectie.monix.FxCtor._
+import effectie.core._
+import effectie.monix.fxCtor._
 import effectie.syntax.fx._
 import effectie.testing.types.SomeError
 import extras.concurrent.testing.ConcurrentSupport
@@ -23,8 +24,6 @@ import scala.util.control.{ControlThrowable, NonFatal}
   */
 object CanHandleErrorSpec extends Properties {
   implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
-
-  type FxCtor[F[_]] = effectie.core.FxCtor[F]
 
   val CanHandleError: effectie.core.CanHandleError.type = effectie.core.CanHandleError
 

--- a/effectie-monix/src/test/scala/effectie/monix/CanRecoverSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/CanRecoverSpec.scala
@@ -6,7 +6,8 @@ import cats.effect.IO
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.syntax.fx._
-import effectie.monix.FxCtor._
+import effectie.core._
+import effectie.monix.fxCtor._
 import effectie.monix.CanRecover._
 import effectie.testing.types.SomeError
 import effectie.SomeControlThrowable
@@ -24,7 +25,6 @@ import scala.util.control.{ControlThrowable, NonFatal}
 object CanRecoverSpec extends Properties {
   implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
 
-  type FxCtor[F[_]] = effectie.core.FxCtor[F]
   val CanRecover: effectie.core.CanRecover.type = effectie.core.CanRecover
 
   override def tests: List[Test] = taskSpecs ++ ioSpecs ++ futureSpecs ++ idSpecs

--- a/effectie-monix/src/test/scala/effectie/monix/CatchingSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/CatchingSpec.scala
@@ -6,6 +6,8 @@ import cats.data.EitherT
 import cats.effect.IO
 import cats.instances.all._
 import cats.syntax.all._
+import effectie.core._
+import effectie.monix.fx._
 import effectie.syntax.fx._
 import effectie.testing.types.SomeError
 import effectie.SomeControlThrowable
@@ -22,8 +24,6 @@ import scala.util.control.ControlThrowable
   */
 object CatchingSpec extends Properties {
   private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
-
-  type FxCtor[F[_]] = effectie.core.FxCtor[F]
 
   override def tests: List[Test] = taskSpecs ++ ioSpecs ++ futureSpecs ++ idSpecs
 
@@ -321,8 +321,6 @@ object CatchingSpec extends Properties {
   object TaskSpec {
     import monix.execution.Scheduler.Implicits.global
 
-    import effectie.monix.Fx._
-
     def testCatching_Task_catchNonFatalShouldCatchNonFatal: Result = {
 
       val expectedExpcetion = new RuntimeException("Something's wrong")
@@ -545,8 +543,6 @@ object CatchingSpec extends Properties {
   }
 
   object IoSpec {
-
-    import effectie.monix.Fx._
 
     def testCatching_IO_catchNonFatalShouldCatchNonFatal: Result = {
 
@@ -999,7 +995,6 @@ object CatchingSpec extends Properties {
   }
 
   object IdSpec {
-    import effectie.monix.Fx._
 
     def testCatching_Id_catchNonFatalShouldCatchNonFatal: Result = {
 

--- a/effectie-monix/src/test/scala/effectie/monix/fxCtorSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/fxCtorSpec.scala
@@ -2,6 +2,8 @@ package effectie.monix
 
 import cats.Id
 import cats.effect.IO
+import effectie.core._
+import effectie.monix.fxCtor._
 import effectie.testing.tools
 import effectie.testing.types.SomeThrowableError
 import extras.concurrent.testing.types.ErrorLogger
@@ -12,7 +14,7 @@ import monix.eval.Task
 /** @author Kevin Lee
   * @since 2020-12-06
   */
-object FxCtorSpec extends Properties {
+object fxCtorSpec extends Properties {
   private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
 
   override def tests: List[Test] = ioSpecs ++ futureSpecs ++ idSpecs
@@ -38,8 +40,6 @@ object FxCtorSpec extends Properties {
   )
 
   object TaskSpec {
-    import effectie.core.FxCtor
-    import effectie.monix.Fx._
     import monix.execution.Scheduler.Implicits.global
 
     def testEffectOf: Property = for {
@@ -101,9 +101,6 @@ object FxCtorSpec extends Properties {
 
   object IoSpec {
 
-    import effectie.core.FxCtor
-    import effectie.monix.Fx._
-
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")
       after  <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_ + before).log("after")
@@ -163,9 +160,6 @@ object FxCtorSpec extends Properties {
   }
 
   object IdSpec {
-
-    import effectie.core.FxCtor
-    import effectie.monix.Fx._
 
     def testEffectOf: Property = for {
       before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/effectie-monix/src/test/scala/effectie/monix/fxSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/fxSpec.scala
@@ -5,7 +5,8 @@ import cats.effect.IO
 import cats.syntax.all._
 import cats.{Eq, Id, Monad}
 import effectie.monix.CanCatchSpec.{run, throwThrowable}
-import effectie.monix.Fx._
+import effectie.core._
+import effectie.monix.fx._
 import effectie.testing.tools._
 import effectie.testing.types.{SomeError, SomeThrowableError}
 import effectie.SomeControlThrowable
@@ -20,11 +21,9 @@ import scala.util.control.{ControlThrowable, NonFatal}
 /** @author Kevin Lee
   * @since 2020-12-06
   */
-object FxSpec extends Properties {
+object fxSpec extends Properties {
 
   private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
-
-  val Fx: effectie.core.Fx.type = effectie.core.Fx
 
   override def tests: List[Test] = taskSpecs ++ ioSpecs ++ futureSpecs ++ idSpecs
 

--- a/effectie-monix/src/test/scala/effectie/monix/syntax/errorSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/monix/syntax/errorSpec.scala
@@ -6,7 +6,7 @@ import cats.effect.IO
 import cats.syntax.all._
 import effectie.syntax.fx._
 import effectie.syntax.error._
-import effectie.monix.Fx._
+import effectie.monix.fx._
 import effectie.monix.syntax.error._
 import effectie.testing.types._
 import effectie.core.Fx
@@ -28,7 +28,6 @@ object errorSpec extends Properties {
 }
 
 object CanCatchSyntaxSpec {
-  val CanRecover: effectie.core.CanRecover.type = effectie.core.CanRecover
 
   def tests: List[Test] = taskSpecs ++ ioSpecs ++ futureSpecs ++ idSpecs
 

--- a/effectie-monix/src/test/scala/effectie/syntax/fxSpec.scala
+++ b/effectie-monix/src/test/scala/effectie/syntax/fxSpec.scala
@@ -1,7 +1,7 @@
 package effectie.syntax
 
 import cats._
-import effectie.monix.Fx._
+import effectie.monix.fx._
 import effectie.syntax.fx._
 import effectie.testing.tools.{dropResult, expectThrowable}
 import effectie.testing.types.SomeThrowableError
@@ -181,7 +181,6 @@ object fxSpec extends Properties {
 
   object IoSpec {
     import cats.effect.IO
-    import effectie.monix.Fx._
 
     @SuppressWarnings(Array("org.wartremover.warts.Any", "org.wartremover.warts.Nothing"))
     def testAll: Property = for {


### PR DESCRIPTION
Close #361 - Rename `Fx` and `FxCtor` in sub-projects to `fx` and `fxCtor` respectively