### PR TITLE
Upgrade: docusaurus `2.0.0-beta.14` => `2.0.0-beta.20` (can't be published until effectie v2 is released)

### DIFF
--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -14,6 +14,8 @@ jobs:
       matrix:
         scala:
           - { version: "2.13.6", binary-version: "2.13", java-version: "adopt@1.11" }
+        node:
+          - { version: "14.16.0" }
 
     steps:
       - uses: actions/checkout@v3.0.2
@@ -22,7 +24,7 @@ jobs:
           java-version: ${{ matrix.scala.java-version }}
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.4.0'
+          node-version: ${{ matrix.node.version }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Cache SBT
@@ -40,9 +42,9 @@ jobs:
         uses: actions/cache@v3.0.2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node.version }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-node-${{ matrix.node.version }}
 
       - name: Render markdown and build website
         run: |

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         scala:
           - { version: "2.13.6", binary-version: "2.13", java-version: "adopt@1.11" }
+        node:
+          - { version: "14.16.0" }
 
     steps:
       - uses: actions/checkout@v3.0.2
@@ -21,7 +23,7 @@ jobs:
           java-version: ${{ matrix.scala.java-version }}
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.4.0'
+          node-version: ${{ matrix.node.version }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Cache SBT
@@ -39,9 +41,9 @@ jobs:
         uses: actions/cache@v3.0.2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node.version }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-node-${{ matrix.node.version }}
 
       - name: Build and publish website
         env:

--- a/website/package.json
+++ b/website/package.json
@@ -14,17 +14,17 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.14",
-    "@docusaurus/preset-classic": "2.0.0-beta.14",
-    "@mdx-js/react": "^1.6.21",
+    "@docusaurus/core": "2.0.0-beta.20",
+    "@docusaurus/preset-classic": "2.0.0-beta.20",
+    "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
     "file-loader": "^6.2.0",
-    "prism-react-renderer": "^1.2.1",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "prism-react-renderer": "^1.3.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "url-loader": "^4.1.1",
-    "docusaurus-lunr-search": "2.1.14"
+    "docusaurus-lunr-search": "2.1.15"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Upgrade: docusaurus `2.0.0-beta.14` => `2.0.0-beta.20` (can't be published until effectie v2 is released)