### PR TITLE
effectie v2.0.0-beta2

### DIFF
--- a/changelogs/2.0.0-beta2.md
+++ b/changelogs/2.0.0-beta2.md
@@ -1,0 +1,42 @@
+## [2.0.0-beta2](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A%3E2022-03-28+closed%3A%3C2022-09-20) - 2022-09-20
+
+## Renaming
+Rename modules and packages (#430)
+
+### Modules
+* `effectie-cats` => `effectie-syntax`
+* `effectie-cats-effect` => `effectie-cats-effect2`
+* `effectie-cats-effect3` remains the same
+* `effectie-monix` => `effectie-monix3`
+
+### Packages
+* Cats Effect 2: `effectie.cats` => `effectie.ce2`
+* Cats Effect 3: `effectie.cats` => `effectie.ce3`
+* Monix 3: `effectie.monix` => `effectie.monix3`
+***
+
+## Project Structure Change
+* Use `effectie-cats-effect` common code for `effectie-monix` (#425)
+***
+
+## Added
+* Add `FxCtor.pureOrError(a)` and `Fx.pureOrError(a)` (#424)
+  ```scala
+  FxCtor[IO].pureOrError(1)
+  // IO[Int] = Pure(1)
+  
+  FxCtor[IO].pureOrError[Int]((throw new RuntimeException("ERROR")): Int)
+  // IO[Int] = RaiseError(java.lang.RuntimeException("ERROR"))
+  ```
+
+***
+
+## Clean up
+* Clean up syntax (#421)
+* syntax should have cats (#432)
+  * (`effectie.cats.syntax` and `effectie.syntax`) => `effectie.syntax`
+
+***
+
+## Documentation
+* Upgrade docs site to Docusaurus `2.0.0-rc.1` (#415)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta2"


### PR DESCRIPTION
# effectie v2.0.0-beta2
## [2.0.0-beta2](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A%3E2022-03-28+closed%3A%3C2022-09-20) - 2022-09-20

## Renaming
Rename modules and packages (#430)

### Modules
* `effectie-cats` => `effectie-syntax`
* `effectie-cats-effect` => `effectie-cats-effect2`
* `effectie-cats-effect3` remains the same
* `effectie-monix` => `effectie-monix3`

### Packages
* Cats Effect 2: `effectie.cats` => `effectie.ce2`
* Cats Effect 3: `effectie.cats` => `effectie.ce3`
* Monix 3: `effectie.monix` => `effectie.monix3`
***

## Project Structure Change
* Use `effectie-cats-effect` common code for `effectie-monix` (#425)
***

## Added
* Add `FxCtor.pureOrError(a)` and `Fx.pureOrError(a)` (#424)
  ```scala
  FxCtor[IO].pureOrError(1)
  // IO[Int] = Pure(1)
  
  FxCtor[IO].pureOrError[Int]((throw new RuntimeException("ERROR")): Int)
  // IO[Int] = RaiseError(java.lang.RuntimeException("ERROR"))
  ```

***

## Clean up
* Clean up syntax (#421)
* syntax should have cats (#432)
  * (`effectie.cats.syntax` and `effectie.syntax`) => `effectie.syntax`

***

## Documentation
* Upgrade docs site to Docusaurus `2.0.0-rc.1` (#415)
