### PR TITLE
effectie v2.0.0-beta3

### DIFF
--- a/changelogs/2.0.0-beta3.md
+++ b/changelogs/2.0.0-beta3.md
@@ -1,0 +1,85 @@
+## [2.0.0-beta3](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-09-20..2022-11-13) - 2022-11-13
+
+### Packages
+* Reorganize instances - move to `effectie.instances` (#429)
+  * `effectie.instances.future`
+  * `effectie.instances.ce2`
+  * `effectie.instances.ce3`
+  * `effectie.instances.monix3`
+  * `effectie.instances.id`
+
+### Details
+* move to `effectie.instances`: Move instances for `Future` to `effectie.instances.future`
+* Also add `@implicitNotFound` to show what to import
+* move to `effectie.instances`: Move instances for `Id` to `effectie.instances.id`
+* Remove instances for `Id` for Cats Effect 2 and 3 since they are now in the `effectie-cats`
+* Move `ConsoleEffect` instance to `effectie.instances`
+* Also `effectie.instances.future.fromFuture.FromFutureToIdTimeout` => `effectie.core.FromFuture.FromFutureToIdTimeout`
+* Remove instances for `Id` for Monix since they are now in the `effectie-cats`
+* Remove instances for `IO` for Monix since they are now in the `effectie-cats-effect2`
+* Move instances for `IO` and `Task` to `effectie.instances`
+
+***
+
+## Added
+* Add `ReleasableResource` to automatically release resource after use (#443)
+  * For `cats-effect` it should use `cats.effect.Resource` as its implementation
+  * For non-`cats-effect`, use Scala's `scala.util.Using` and `Future` with proper resource release
+
+### `ReleasableResource` with `Using` and `Try`
+
+```scala
+import effectie.resource.ReleasableResource
+
+ReleasableResource.usingResource(SomeAutoCloseable())
+  .use { resource =>
+    Try(resource.doSoemthing()) // Try[A]
+  } // Try[A]
+
+// OR
+
+val trySomeResource: Try[SomeResource] = ...
+ReleasableResource.usingResourceFromTry(trySomeResource)
+  .use { resource =>
+    Try(resource.doSoemthing()) // Try[A]
+  } // Try[A]
+
+```
+
+### `ReleasableResource` with `Future`
+
+```scala
+import effectie.resource.ReleasableResource
+val futureResource: Future[SomeResource] = ...
+
+ReleasableResource.futureResource(futureResource)
+  .use { resource =>
+    Future(doSomething(resource)) // Future[A]
+  } // Future[A]
+
+```
+
+### `ReleasableResource` with Cats Effect `IO`
+* Cats Effect 2
+  ```scala
+  import effectie.resource.Ce2Resource
+  
+  val fa: F[SomeResource] = ...
+  
+  Ce2Resource.fromAutoCloseable(fa)
+    .use { resource =>
+      Sycn[F].delay(doSomething(resource)) // F[A]
+    } // F[A]
+  ```
+
+* Cats Effect 3
+  ```scala
+  import effectie.resource.Ce3Resource
+  
+  val fa: F[SomeResource] = ...
+  
+  Ce3Resource.fromAutoCloseable(fa)
+    .use { resource =>
+      Sycn[F].delay(doSomething(resource)) // F[A]
+    } // F[A]
+  ```


### PR DESCRIPTION
# effectie v2.0.0-beta3
## [2.0.0-beta3](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-09-20..2022-11-13) - 2022-11-13

### Packages
* Reorganize instances - move to `effectie.instances` (#429)
  * `effectie.instances.future`
  * `effectie.instances.ce2`
  * `effectie.instances.ce3`
  * `effectie.instances.monix3`
  * `effectie.instances.id`

### Details
* move to `effectie.instances`: Move instances for `Future` to `effectie.instances.future`
* Also add `@implicitNotFound` to show what to import
* move to `effectie.instances`: Move instances for `Id` to `effectie.instances.id`
* Remove instances for `Id` for Cats Effect 2 and 3 since they are now in the `effectie-cats`
* Move `ConsoleEffect` instance to `effectie.instances`
* Also `effectie.instances.future.fromFuture.FromFutureToIdTimeout` => `effectie.core.FromFuture.FromFutureToIdTimeout`
* Remove instances for `Id` for Monix since they are now in the `effectie-cats`
* Remove instances for `IO` for Monix since they are now in the `effectie-cats-effect2`
* Move instances for `IO` and `Task` to `effectie.instances`

***

## Added
* Add `ReleasableResource` to automatically release resource after use (#443)
  * For `cats-effect` it should use `cats.effect.Resource` as its implementation
  * For non-`cats-effect`, use Scala's `scala.util.Using` and `Future` with proper resource release

### `ReleasableResource` with `Using` and `Try`

```scala
import effectie.resource.ReleasableResource

ReleasableResource.usingResource(SomeAutoCloseable())
  .use { resource =>
    Try(resource.doSoemthing()) // Try[A]
  } // Try[A]

// OR

val trySomeResource: Try[SomeResource] = ...
ReleasableResource.usingResourceFromTry(trySomeResource)
  .use { resource =>
    Try(resource.doSoemthing()) // Try[A]
  } // Try[A]

```

### `ReleasableResource` with `Future`

```scala
import effectie.resource.ReleasableResource
val futureResource: Future[SomeResource] = ...

ReleasableResource.futureResource(futureResource)
  .use { resource =>
    Future(doSomething(resource)) // Future[A]
  } // Future[A]

```

### `ReleasableResource` with Cats Effect `IO`
* Cats Effect 2
  ```scala
  import effectie.resource.Ce2Resource
  
  val fa: F[SomeResource] = ...
  
  Ce2Resource.fromAutoCloseable(fa)
    .use { resource =>
      Sycn[F].delay(doSomething(resource)) // F[A]
    } // F[A]
  ```

* Cats Effect 3
  ```scala
  import effectie.resource.Ce3Resource
  
  val fa: F[SomeResource] = ...
  
  Ce3Resource.fromAutoCloseable(fa)
    .use { resource =>
      Sycn[F].delay(doSomething(resource)) // F[A]
    } // F[A]
  ```
