### PR TITLE
Close #457 - Change `f` in `def catchNonFatal[A, B](fb: => F[B])(f: Throwable => A): F[Either[A, B]]` to `f: PartialFunction[Throwable, AA]`

### DIFF
--- a/modules/effectie-cats-effect2/shared/src/main/scala-2/effectie/instances/ce2/canCatch.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala-2/effectie/instances/ce2/canCatch.scala
@@ -10,9 +10,9 @@ object canCatch {
 
   implicit object canCatchIo extends CanCatch[IO] {
 
-    @inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
+    @inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 
-    @inline override def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
+    @inline override final def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       fa.attempt
 
   }

--- a/modules/effectie-cats-effect2/shared/src/main/scala-2/effectie/instances/ce2/fx.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala-2/effectie/instances/ce2/fx.scala
@@ -26,7 +26,7 @@ object fx {
 
     @inline override final def fromTry[A](tryA: Try[A]): IO[A] = fxCtor.ioFxCtor.fromTry(tryA)
 
-    @inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
+    @inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 
     @inline override final def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       canCatch.canCatchIo.catchNonFatalThrowable(fa)

--- a/modules/effectie-cats-effect2/shared/src/main/scala-3/effectie/instances/ce2/canCatch.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala-3/effectie/instances/ce2/canCatch.scala
@@ -15,9 +15,9 @@ object canCatch {
 
   given canCatchIo: CanCatch[IO] with {
 
-    inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
+    inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 
-    inline override def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
+    inline override final def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       fa.attempt
 
   }

--- a/modules/effectie-cats-effect2/shared/src/main/scala-3/effectie/instances/ce2/fx.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala-3/effectie/instances/ce2/fx.scala
@@ -28,7 +28,7 @@ object fx {
 
     inline override final def fromTry[A](tryA: Try[A]): IO[A] = fxCtor.ioFxCtor.fromTry(tryA)
 
-    inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
+    inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 
     inline override final def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       canCatch.canCatchIo.catchNonFatalThrowable(fa)

--- a/modules/effectie-cats-effect3/shared/src/main/scala-2/effectie/instances/ce3/canCatch.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala-2/effectie/instances/ce3/canCatch.scala
@@ -10,9 +10,9 @@ object canCatch {
 
   implicit object canCatchIo extends CanCatch[IO] {
 
-    @inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
+    @inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 
-    @inline override def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
+    @inline override final def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       fa.attempt
 
   }

--- a/modules/effectie-cats-effect3/shared/src/main/scala-2/effectie/instances/ce3/fx.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala-2/effectie/instances/ce3/fx.scala
@@ -26,7 +26,7 @@ object fx {
 
     @inline override final def fromTry[A](tryA: Try[A]): IO[A] = fxCtor.ioFxCtor.fromTry(tryA)
 
-    @inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
+    @inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 
     @inline override final def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       canCatch.canCatchIo.catchNonFatalThrowable(fa)

--- a/modules/effectie-cats-effect3/shared/src/main/scala-3/effectie/instances/ce3/canCatch.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala-3/effectie/instances/ce3/canCatch.scala
@@ -14,9 +14,9 @@ object canCatch {
 
   given canCatchIo: CanCatch[IO] with {
 
-    inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
+    inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 
-    inline override def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
+    inline override final def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       fa.attempt
 
   }

--- a/modules/effectie-cats-effect3/shared/src/main/scala-3/effectie/instances/ce3/fx.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala-3/effectie/instances/ce3/fx.scala
@@ -28,7 +28,7 @@ object fx {
 
     inline override final def fromTry[A](tryA: Try[A]): IO[A] = fxCtor.ioFxCtor.fromTry(tryA)
 
-    inline override final def mapFa[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
+    inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 
     inline override final def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       canCatch.canCatchIo.catchNonFatalThrowable(fa)

--- a/modules/effectie-cats/shared/src/main/scala/effectie/instances/id/canCatch.scala
+++ b/modules/effectie-cats/shared/src/main/scala/effectie/instances/id/canCatch.scala
@@ -11,9 +11,9 @@ object canCatch {
 
   implicit object canCatchId extends CanCatch[Id] {
 
-    @inline override final def mapFa[A, B](fa: Id[A])(f: A => B): Id[B] = f(fa)
+    @inline override final def flatMapFa[A, B](fa: Id[A])(f: A => Id[B]): Id[B] = f(fa)
 
-    @inline override def catchNonFatalThrowable[A](fa: => Id[A]): Id[Either[Throwable, A]] =
+    @inline override final def catchNonFatalThrowable[A](fa: => Id[A]): Id[Either[Throwable, A]] =
       scala.util.Try(fa) match {
         case scala.util.Success(a) =>
           a.asRight[Throwable]

--- a/modules/effectie-cats/shared/src/main/scala/effectie/instances/id/fx.scala
+++ b/modules/effectie-cats/shared/src/main/scala/effectie/instances/id/fx.scala
@@ -26,7 +26,7 @@ object fx {
 
     @inline override final def fromTry[A](tryA: Try[A]): Id[A] = fxCtor.idFxCtor.fromTry(tryA)
 
-    @inline override final def mapFa[A, B](fa: Id[A])(f: A => B): Id[B] = f(fa)
+    @inline override final def flatMapFa[A, B](fa: Id[A])(f: A => Id[B]): Id[B] = f(fa)
 
     @inline override final def catchNonFatalThrowable[A](fa: => Id[A]): Id[Either[Throwable, A]] =
       canCatch.canCatchId.catchNonFatalThrowable(fa)

--- a/modules/effectie-core/shared/src/main/scala/effectie/instances/future/canCatch.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/instances/future/canCatch.scala
@@ -12,8 +12,8 @@ object canCatch {
   trait FutureCanCatch extends CanCatch[Future] {
     implicit def EC0: ExecutionContext
 
-    @inline override final def mapFa[A, B](fa: Future[A])(f: A => B): Future[B] =
-      fa.map(f)(EC0)
+    @inline override final def flatMapFa[A, B](fa: Future[A])(f: A => Future[B]): Future[B] =
+      fa.flatMap(f)(EC0)
 
     @inline override final def catchNonFatalThrowable[A](fa: => Future[A]): Future[Either[Throwable, A]] =
       fa.transform {

--- a/modules/effectie-core/shared/src/test/scala/effectie/resource/ReleasableResourceSpec.scala
+++ b/modules/effectie-core/shared/src/test/scala/effectie/resource/ReleasableResourceSpec.scala
@@ -54,22 +54,23 @@ object ReleasableResourceSpec {
               _ <- useF(resource)
             } yield ()
           }
-      ) { err =>
-        Result.all(
-          List(
-            (closeStatusBefore ==== TestResource.CloseStatus.notClosed.some)
-              .log("Before: TestResource.closeStatus should be NotClosed but it is not."),
-            (contentBefore ==== Vector.empty.some)
-              .log("Before: TestResource.content should be empty but it is not."),
-            (testResource.closeStatus ==== TestResource.CloseStatus.closed)
-              .log("After: TestResource.closeStatus should Closed but it is not."),
-            (testResource.content ==== content)
-              .log("After: TestResource.content should have the expected content but it is empty."),
-            errorTest.fold(
-              Result.failure.log(s"Error was expected but no expected error was given. Error: ${err.toString}")
-            )(_(err)),
+      ) {
+        case err =>
+          Result.all(
+            List(
+              (closeStatusBefore ==== TestResource.CloseStatus.notClosed.some)
+                .log("Before: TestResource.closeStatus should be NotClosed but it is not."),
+              (contentBefore ==== Vector.empty.some)
+                .log("Before: TestResource.content should be empty but it is not."),
+              (testResource.closeStatus ==== TestResource.CloseStatus.closed)
+                .log("After: TestResource.closeStatus should Closed but it is not."),
+              (testResource.content ==== content)
+                .log("After: TestResource.content should have the expected content but it is empty."),
+              errorTest.fold(
+                Result.failure.log(s"Error was expected but no expected error was given. Error: ${err.toString}")
+              )(_(err)),
+            )
           )
-        )
       }
       .map {
         //          println(

--- a/modules/effectie-core/shared/src/test/scala/effectie/resource/UsingResourceSpec.scala
+++ b/modules/effectie-core/shared/src/test/scala/effectie/resource/UsingResourceSpec.scala
@@ -90,7 +90,7 @@ object UsingResourceSpec extends Properties {
 
     override def fromTry[A](tryA: Try[A]): Try[A] = tryA
 
-    override def mapFa[A, B](fa: Try[A])(f: A => B): Try[B] = fa.map(f)
+    override def flatMapFa[A, B](fa: Try[A])(f: A => Try[B]): Try[B] = fa.flatMap(f)
 
     override def catchNonFatalThrowable[A](fa: => Try[A]): Try[Either[Throwable, A]] =
       fa.fold(err => Try(err.asLeft[A]), a => Try(a.asRight[Throwable]))

--- a/modules/effectie-core/shared/src/test/scala/effectie/testing/types.scala
+++ b/modules/effectie-core/shared/src/test/scala/effectie/testing/types.scala
@@ -13,7 +13,9 @@ object types {
     final case class SomeThrowable(throwable: Throwable) extends SomeError
     final case class Message(message: String) extends SomeError
 
-    def someThrowable(throwable: Throwable): SomeError = SomeThrowable(throwable)
+    def someThrowable: PartialFunction[Throwable, SomeError] = {
+      case throwable => SomeThrowable(throwable)
+    }
 
     def message(message: String): SomeError = Message(message)
 

--- a/modules/effectie-monix3/shared/src/main/scala/effectie/instances/monix3/canCatch.scala
+++ b/modules/effectie-monix3/shared/src/main/scala/effectie/instances/monix3/canCatch.scala
@@ -10,7 +10,7 @@ object canCatch {
 
   implicit object canCatchTask extends CanCatch[Task] {
 
-    @inline override final def mapFa[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
+    @inline override final def flatMapFa[A, B](fa: Task[A])(f: A => Task[B]): Task[B] = fa.flatMap(f)
 
     @inline override def catchNonFatalThrowable[A](fa: => Task[A]): Task[Either[Throwable, A]] =
       fa.attempt

--- a/modules/effectie-monix3/shared/src/main/scala/effectie/instances/monix3/fx.scala
+++ b/modules/effectie-monix3/shared/src/main/scala/effectie/instances/monix3/fx.scala
@@ -30,7 +30,7 @@ object fx {
 
     @inline override final def fromTry[A](tryA: Try[A]): Task[A] = fxCtor.taskFxCtor.fromTry(tryA)
 
-    @inline override final def mapFa[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
+    @inline override final def flatMapFa[A, B](fa: Task[A])(f: A => Task[B]): Task[B] = fa.flatMap(f)
 
     @inline override final def catchNonFatalThrowable[A](fa: => Task[A]): Task[Either[Throwable, A]] =
       canCatch.canCatchTask.catchNonFatalThrowable(fa)

--- a/modules/effectie-syntax/shared/src/main/scala-2/effectie/syntax/error.scala
+++ b/modules/effectie-syntax/shared/src/main/scala-2/effectie/syntax/error.scala
@@ -1,7 +1,7 @@
 package effectie.syntax
 
 import _root_.cats.data.EitherT
-import effectie.core.{CanCatch, CanHandleError, CanRecover}
+import effectie.core.{CanCatch, CanHandleError, CanRecover, FxCtor}
 
 /** @author Kevin Lee
   * @since 2021-10-16
@@ -39,9 +39,10 @@ object error extends error {
       canCatch.catchNonFatalThrowable[B](fb())
 
     def catchNonFatal[A](
-      f: Throwable => A
+      f: PartialFunction[Throwable, A]
     )(
-      implicit canCatch: CanCatch[F]
+      implicit canCatch: CanCatch[F],
+      fxCtor: FxCtor[F],
     ): F[Either[A, B]] =
       canCatch.catchNonFatal[A, B](fb())(f)
 
@@ -73,9 +74,10 @@ object error extends error {
   final class FEitherABErrorHandlingOps[F[*], A, B](private val fab: () => F[Either[A, B]]) extends AnyVal {
 
     def catchNonFatalEither[AA >: A](
-      f: Throwable => AA
+      f: PartialFunction[Throwable, AA]
     )(
-      implicit canCatch: CanCatch[F]
+      implicit canCatch: CanCatch[F],
+      fxCtor: FxCtor[F],
     ): F[Either[AA, B]] =
       canCatch.catchNonFatalEither[A, AA, B](fab())(f)
 
@@ -111,9 +113,10 @@ object error extends error {
   final class EitherTFABErrorHandlingOps[F[*], A, B](private val efab: () => EitherT[F, A, B]) extends AnyVal {
 
     def catchNonFatalEitherT[AA >: A](
-      f: Throwable => AA
+      f: PartialFunction[Throwable, AA]
     )(
-      implicit canCatch: CanCatch[F]
+      implicit canCatch: CanCatch[F],
+      fxCtor: FxCtor[F],
     ): EitherT[F, AA, B] =
       canCatch.catchNonFatalEitherT[A, AA, B](efab())(f)
 
@@ -148,7 +151,9 @@ object error extends error {
 
   final class CanCatchOps[F[*]](private val canCatch: effectie.core.CanCatch[F]) extends AnyVal {
 
-    def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =
+    def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: PartialFunction[Throwable, AA])(
+      implicit fxCtor: FxCtor[F]
+    ): EitherT[F, AA, B] =
       EitherT(canCatch.catchNonFatalEither[A, AA, B](fab.value)(f))
 
   }
@@ -191,7 +196,9 @@ object error extends error {
 
   final class FxOps[F[*]](private val fx: effectie.core.Fx[F]) extends AnyVal {
 
-    def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(f: Throwable => AA): EitherT[F, AA, B] =
+    def catchNonFatalEitherT[A, AA >: A, B](fab: => EitherT[F, A, B])(
+      f: PartialFunction[Throwable, AA]
+    )(implicit fxCtor: FxCtor[F]): EitherT[F, AA, B] =
       EitherT(fx.catchNonFatalEither[A, AA, B](fab.value)(f))
 
   }


### PR DESCRIPTION
Close #457 - Change `f` in `def catchNonFatal[A, B](fb: => F[B])(f: Throwable => A): F[Either[A, B]]` to `f: PartialFunction[Throwable, AA]`