### PR TITLE
effectie v2.0.0-beta4

### DIFF
--- a/changelogs/2.0.0-beta4.md
+++ b/changelogs/2.0.0-beta4.md
@@ -1,0 +1,21 @@
+## [2.0.0-beta4](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-11-14..2022-12-25) - 2022-12-25 🎄
+
+### Changes
+* Update missing implicit instance messages for Scala 3 (#454)
+  e.g.)
+  ```scala
+  import effectie.instances.ce2.fx.*
+  ```
+  to
+  ```scala
+  import effectie.instances.ce2.fx.given
+  ```
+* Change `f` in `def catchNonFatal[A, B](fb: => F[B])(f: Throwable => A): F[Either[A, B]]` to `f: PartialFunction[Throwable, AA]` (#457)
+  ```scala
+  CanCatch[F].catchNonFatal(fa) {
+    case FooException(err) =>
+      FooError(err)
+  }
+  // If fa throws FooException, the result is F[Either[FooError, A]]
+  // If fa throws some other exception, the result is F[Either[FooError, A]] but it's actually the same as errorOf[Either[FooError, A]](theException) so the exception is not caught in Either.
+  ```

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta4"


### PR DESCRIPTION
# effectie v2.0.0-beta4
## [2.0.0-beta4](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-11-14..2022-12-25) - 2022-12-25 🎄

### Changes
* Update missing implicit instance messages for Scala 3 (#454)
  e.g.)
  ```scala
  import effectie.instances.ce2.fx.*
  ```
  to
  ```scala
  import effectie.instances.ce2.fx.given
  ```
* Change `f` in `def catchNonFatal[A, B](fb: => F[B])(f: Throwable => A): F[Either[A, B]]` to `f: PartialFunction[Throwable, AA]` (#457)
  ```scala
  CanCatch[F].catchNonFatal(fa) {
    case FooException(err) =>
      FooError(err)
  }
  // If fa throws FooException, the result is F[Either[FooError, A]]
  // If fa throws some other exception, the result is F[Either[FooError, A]] but it's actually the same as errorOf[Either[FooError, A]](theException) so the exception is not caught in Either.
  ```
