### PR TITLE
effectie v2.0.0-beta5

### DIFF
--- a/changelogs/2.0.0-beta5.md
+++ b/changelogs/2.0.0-beta5.md
@@ -1,0 +1,28 @@
+## [2.0.0-beta5](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-12-26..2023-01-14) - 2023-01-14
+
+### New Features
+* Add `ResourceMaker` (#468)
+  ```scala
+  ResourceMaker[F].forAutoCloseable[A <: AutoCloseable](fa: F[A]): ReleasableResource[F, A]
+  ```
+  ```scala
+  import effectie.resource.ResourceMaker
+  
+  ResourceMaker.usingResourceMaker // ResourceMaker[Try]
+  ResourceMaker.futureResourceMaker(implicit ec: ExecutionContext) // ResourceMaker[Future]
+  ```
+
+  ```scala
+  import effectie.resource.Ce2ResourceMaker
+  
+  Ce2ResourceMaker.forAutoCloseable // ResourceMaker[F] where F[*]: Sync: BracketThrow
+  ```
+
+  ```scala
+  import effectie.resource.Ce3Resource
+  
+  Ce3Resource.forAutoCloseable // ResourceMaker[F] where F[*]: Sync: MonadCancelThrow
+  ```
+
+### Internal Housekeeping
+* `cats-effect` `3.3.5` => `3.3.14`

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta5"


### PR DESCRIPTION
# effectie v2.0.0-beta5
## [2.0.0-beta5](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-12-26..2023-01-14) - 2023-01-14

### New Features
* Add `ResourceMaker` (#468)
  ```scala
  ResourceMaker[F].forAutoCloseable[A <: AutoCloseable](fa: F[A]): ReleasableResource[F, A]
  ```
  ```scala
  import effectie.resource.ResourceMaker
  
  ResourceMaker.usingResourceMaker // ResourceMaker[Try]
  ResourceMaker.futureResourceMaker(implicit ec: ExecutionContext) // ResourceMaker[Future]
  ```

  ```scala
  import effectie.resource.Ce2ResourceMaker
  
  Ce2ResourceMaker.forAutoCloseable // ResourceMaker[F] where F[*]: Sync: BracketThrow
  ```

  ```scala
  import effectie.resource.Ce3Resource
  
  Ce3Resource.forAutoCloseable // ResourceMaker[F] where F[*]: Sync: MonadCancelThrow
  ```

### Internal Housekeeping
* `cats-effect` `3.3.5` => `3.3.14`
