### PR TITLE
Close #480 - Remove implicit fxCtor: FxCtor[F] param from the catch methods in CanCatch

### DIFF
--- a/modules/effectie-cats-effect2/shared/src/main/scala-2/effectie/instances/ce2/canCatch.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala-2/effectie/instances/ce2/canCatch.scala
@@ -1,7 +1,7 @@
 package effectie.instances.ce2
 
 import cats.effect.IO
-import effectie.core.CanCatch
+import effectie.core.{CanCatch, FxCtor}
 
 /** @author Kevin Lee
   * @since 2020-06-07
@@ -10,11 +10,12 @@ object canCatch {
 
   implicit object canCatchIo extends CanCatch[IO] {
 
+    override implicit protected val fxCtor: FxCtor[IO] = effectie.instances.ce2.fxCtor.ioFxCtor
+
     @inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 
     @inline override final def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       fa.attempt
-
   }
 
 }

--- a/modules/effectie-cats-effect2/shared/src/main/scala-2/effectie/instances/ce2/fx.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala-2/effectie/instances/ce2/fx.scala
@@ -1,7 +1,7 @@
 package effectie.instances.ce2
 
 import cats.effect.IO
-import effectie.core.Fx
+import effectie.core.{Fx, FxCtor}
 
 import scala.util.Try
 
@@ -9,22 +9,24 @@ object fx {
 
   implicit object ioFx extends Fx[IO] {
 
-    @inline override final def effectOf[A](a: => A): IO[A] = fxCtor.ioFxCtor.effectOf(a)
+    override implicit protected val fxCtor: FxCtor[IO] = effectie.instances.ce2.fxCtor.ioFxCtor
 
-    @inline override final def pureOf[A](a: A): IO[A] = fxCtor.ioFxCtor.pureOf(a)
+    @inline override final def effectOf[A](a: => A): IO[A] = fxCtor.effectOf(a)
 
-    @inline override val unitOf: IO[Unit] = fxCtor.ioFxCtor.unitOf
+    @inline override final def pureOf[A](a: A): IO[A] = fxCtor.pureOf(a)
 
-    @inline override final def pureOrError[A](a: => A): IO[A] = fxCtor.ioFxCtor.pureOrError(a)
+    @inline override val unitOf: IO[Unit] = fxCtor.unitOf
 
-    @inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.ioFxCtor.errorOf(throwable)
+    @inline override final def pureOrError[A](a: => A): IO[A] = fxCtor.pureOrError(a)
 
-    @inline override final def fromEither[A](either: Either[Throwable, A]): IO[A] = fxCtor.ioFxCtor.fromEither(either)
+    @inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.errorOf(throwable)
+
+    @inline override final def fromEither[A](either: Either[Throwable, A]): IO[A] = fxCtor.fromEither(either)
 
     @inline override final def fromOption[A](option: Option[A])(orElse: => Throwable): IO[A] =
-      fxCtor.ioFxCtor.fromOption(option)(orElse)
+      fxCtor.fromOption(option)(orElse)
 
-    @inline override final def fromTry[A](tryA: Try[A]): IO[A] = fxCtor.ioFxCtor.fromTry(tryA)
+    @inline override final def fromTry[A](tryA: Try[A]): IO[A] = fxCtor.fromTry(tryA)
 
     @inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 

--- a/modules/effectie-cats-effect2/shared/src/main/scala-3/effectie/instances/ce2/canCatch.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala-3/effectie/instances/ce2/canCatch.scala
@@ -4,7 +4,7 @@ import cats.Id
 import cats.data.EitherT
 import cats.effect.IO
 import cats.syntax.all.*
-import effectie.core.CanCatch
+import effectie.core.{CanCatch, FxCtor}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -15,11 +15,12 @@ object canCatch {
 
   given canCatchIo: CanCatch[IO] with {
 
+    override implicit protected val fxCtor: FxCtor[IO] = effectie.instances.ce2.fxCtor.ioFxCtor
+
     inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 
     inline override final def catchNonFatalThrowable[A](fa: => IO[A]): IO[Either[Throwable, A]] =
       fa.attempt
-
   }
 
 }

--- a/modules/effectie-cats-effect2/shared/src/main/scala-3/effectie/instances/ce2/fx.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala-3/effectie/instances/ce2/fx.scala
@@ -2,7 +2,7 @@ package effectie.instances.ce2
 
 import cats.effect.{IO, Sync}
 import cats.{Applicative, Id, Monad}
-import effectie.core.Fx
+import effectie.core.{Fx, FxCtor}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -11,22 +11,24 @@ object fx {
 
   given ioFx: Fx[IO] with {
 
-    inline override final def effectOf[A](a: => A): IO[A] = fxCtor.ioFxCtor.effectOf(a)
+    override implicit protected val fxCtor: FxCtor[IO] = effectie.instances.ce2.fxCtor.ioFxCtor
 
-    inline override final def pureOf[A](a: A): IO[A] = fxCtor.ioFxCtor.pureOf(a)
+    inline override final def effectOf[A](a: => A): IO[A] = fxCtor.effectOf(a)
 
-    inline override final def pureOrError[A](a: => A): IO[A] = fxCtor.ioFxCtor.pureOrError(a)
+    inline override final def pureOf[A](a: A): IO[A] = fxCtor.pureOf(a)
 
-    inline override final def unitOf: IO[Unit] = fxCtor.ioFxCtor.unitOf
+    inline override final def pureOrError[A](a: => A): IO[A] = fxCtor.pureOrError(a)
 
-    inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.ioFxCtor.errorOf(throwable)
+    inline override final def unitOf: IO[Unit] = fxCtor.unitOf
 
-    inline override final def fromEither[A](either: Either[Throwable, A]): IO[A] = fxCtor.ioFxCtor.fromEither(either)
+    inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.errorOf(throwable)
+
+    inline override final def fromEither[A](either: Either[Throwable, A]): IO[A] = fxCtor.fromEither(either)
 
     inline override final def fromOption[A](option: Option[A])(orElse: => Throwable): IO[A] =
-      fxCtor.ioFxCtor.fromOption(option)(orElse)
+      fxCtor.fromOption(option)(orElse)
 
-    inline override final def fromTry[A](tryA: Try[A]): IO[A] = fxCtor.ioFxCtor.fromTry(tryA)
+    inline override final def fromTry[A](tryA: Try[A]): IO[A] = fxCtor.fromTry(tryA)
 
     inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 

--- a/modules/effectie-cats-effect3/shared/src/main/scala-2/effectie/instances/ce3/canCatch.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala-2/effectie/instances/ce3/canCatch.scala
@@ -1,7 +1,7 @@
 package effectie.instances.ce3
 
 import cats.effect.IO
-import effectie.core.CanCatch
+import effectie.core.{CanCatch, FxCtor}
 
 /** @author Kevin Lee
   * @since 2020-06-07
@@ -9,6 +9,8 @@ import effectie.core.CanCatch
 object canCatch {
 
   implicit object canCatchIo extends CanCatch[IO] {
+
+    override implicit protected val fxCtor: FxCtor[IO] = effectie.instances.ce3.fxCtor.ioFxCtor
 
     @inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 

--- a/modules/effectie-cats-effect3/shared/src/main/scala-2/effectie/instances/ce3/fx.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala-2/effectie/instances/ce3/fx.scala
@@ -1,7 +1,7 @@
 package effectie.instances.ce3
 
 import cats.effect.IO
-import effectie.core.Fx
+import effectie.core.{Fx, FxCtor}
 
 import scala.util.Try
 
@@ -9,22 +9,24 @@ object fx {
 
   implicit object ioFx extends Fx[IO] {
 
-    @inline override final def effectOf[A](a: => A): IO[A] = fxCtor.ioFxCtor.effectOf(a)
+    override implicit protected val fxCtor: FxCtor[IO] = effectie.instances.ce3.fxCtor.ioFxCtor
 
-    @inline override final def pureOf[A](a: A): IO[A] = fxCtor.ioFxCtor.pureOf(a)
+    @inline override final def effectOf[A](a: => A): IO[A] = fxCtor.effectOf(a)
 
-    @inline override final def pureOrError[A](a: => A): IO[A] = fxCtor.ioFxCtor.pureOrError(a)
+    @inline override final def pureOf[A](a: A): IO[A] = fxCtor.pureOf(a)
 
-    @inline override val unitOf: IO[Unit] = fxCtor.ioFxCtor.unitOf
+    @inline override final def pureOrError[A](a: => A): IO[A] = fxCtor.pureOrError(a)
 
-    @inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.ioFxCtor.errorOf(throwable)
+    @inline override val unitOf: IO[Unit] = fxCtor.unitOf
 
-    @inline override final def fromEither[A](either: Either[Throwable, A]): IO[A] = fxCtor.ioFxCtor.fromEither(either)
+    @inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.errorOf(throwable)
+
+    @inline override final def fromEither[A](either: Either[Throwable, A]): IO[A] = fxCtor.fromEither(either)
 
     @inline override final def fromOption[A](option: Option[A])(orElse: => Throwable): IO[A] =
-      fxCtor.ioFxCtor.fromOption(option)(orElse)
+      fxCtor.fromOption(option)(orElse)
 
-    @inline override final def fromTry[A](tryA: Try[A]): IO[A] = fxCtor.ioFxCtor.fromTry(tryA)
+    @inline override final def fromTry[A](tryA: Try[A]): IO[A] = fxCtor.fromTry(tryA)
 
     @inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 

--- a/modules/effectie-cats-effect3/shared/src/main/scala-3/effectie/instances/ce3/canCatch.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala-3/effectie/instances/ce3/canCatch.scala
@@ -3,7 +3,7 @@ package effectie.instances.ce3
 import cats.data.EitherT
 import cats.effect.IO
 import cats.syntax.all.*
-import effectie.core.CanCatch
+import effectie.core.{CanCatch, FxCtor}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -13,6 +13,8 @@ import scala.concurrent.{ExecutionContext, Future}
 object canCatch {
 
   given canCatchIo: CanCatch[IO] with {
+
+    override implicit protected val fxCtor: FxCtor[IO] = effectie.instances.ce3.fxCtor.ioFxCtor
 
     inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 

--- a/modules/effectie-cats-effect3/shared/src/main/scala-3/effectie/instances/ce3/fx.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala-3/effectie/instances/ce3/fx.scala
@@ -2,7 +2,7 @@ package effectie.instances.ce3
 
 import cats.effect.{IO, Sync}
 import cats.{Applicative, Monad, MonadThrow}
-import effectie.core.Fx
+import effectie.core.{Fx, FxCtor}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -11,22 +11,24 @@ object fx {
 
   given ioFx: Fx[IO] with {
 
-    inline override final def effectOf[A](a: => A): IO[A] = fxCtor.ioFxCtor.effectOf(a)
+    override implicit protected val fxCtor: FxCtor[IO] = effectie.instances.ce3.fxCtor.ioFxCtor
 
-    inline override final def pureOf[A](a: A): IO[A] = fxCtor.ioFxCtor.pureOf(a)
+    inline override final def effectOf[A](a: => A): IO[A] = fxCtor.effectOf(a)
 
-    inline override final def pureOrError[A](a: => A): IO[A] = fxCtor.ioFxCtor.pureOrError(a)
+    inline override final def pureOf[A](a: A): IO[A] = fxCtor.pureOf(a)
 
-    inline override final def unitOf: IO[Unit] = fxCtor.ioFxCtor.unitOf
+    inline override final def pureOrError[A](a: => A): IO[A] = fxCtor.pureOrError(a)
 
-    inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.ioFxCtor.errorOf(throwable)
+    inline override final def unitOf: IO[Unit] = fxCtor.unitOf
 
-    inline override final def fromEither[A](either: Either[Throwable, A]): IO[A] = fxCtor.ioFxCtor.fromEither(either)
+    inline override final def errorOf[A](throwable: Throwable): IO[A] = fxCtor.errorOf(throwable)
+
+    inline override final def fromEither[A](either: Either[Throwable, A]): IO[A] = fxCtor.fromEither(either)
 
     inline override final def fromOption[A](option: Option[A])(orElse: => Throwable): IO[A] =
-      fxCtor.ioFxCtor.fromOption(option)(orElse)
+      fxCtor.fromOption(option)(orElse)
 
-    inline override final def fromTry[A](tryA: Try[A]): IO[A] = fxCtor.ioFxCtor.fromTry(tryA)
+    inline override final def fromTry[A](tryA: Try[A]): IO[A] = fxCtor.fromTry(tryA)
 
     inline override final def flatMapFa[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa.flatMap(f)
 

--- a/modules/effectie-cats/shared/src/main/scala/effectie/instances/id/canCatch.scala
+++ b/modules/effectie-cats/shared/src/main/scala/effectie/instances/id/canCatch.scala
@@ -2,7 +2,7 @@ package effectie.instances.id
 
 import cats.Id
 import cats.syntax.all._
-import effectie.core.CanCatch
+import effectie.core.{CanCatch, FxCtor}
 
 /** @author Kevin Lee
   * @since 2020-06-07
@@ -10,6 +10,8 @@ import effectie.core.CanCatch
 object canCatch {
 
   implicit object canCatchId extends CanCatch[Id] {
+
+    override implicit protected val fxCtor: FxCtor[Id] = effectie.instances.id.fxCtor.idFxCtor
 
     @inline override final def flatMapFa[A, B](fa: Id[A])(f: A => Id[B]): Id[B] = f(fa)
 
@@ -24,7 +26,6 @@ object canCatch {
         case scala.util.Failure(ex) =>
           throw ex // scalafix:ok DisableSyntax.throw
       }
-
   }
 
 }

--- a/modules/effectie-cats/shared/src/main/scala/effectie/instances/id/fx.scala
+++ b/modules/effectie-cats/shared/src/main/scala/effectie/instances/id/fx.scala
@@ -1,7 +1,7 @@
 package effectie.instances.id
 
 import cats.Id
-import effectie.core.Fx
+import effectie.core.{Fx, FxCtor}
 
 import scala.util.Try
 
@@ -9,22 +9,24 @@ object fx {
 
   implicit object idFx extends Fx[Id] {
 
-    @inline override final def effectOf[A](a: => A): Id[A] = fxCtor.idFxCtor.effectOf(a)
+    override implicit protected val fxCtor: FxCtor[Id] = effectie.instances.id.fxCtor.idFxCtor
 
-    @inline override final def pureOf[A](a: A): Id[A] = fxCtor.idFxCtor.pureOf(a)
+    @inline override final def effectOf[A](a: => A): Id[A] = fxCtor.effectOf(a)
 
-    @inline override final def pureOrError[A](a: => A): Id[A] = fxCtor.idFxCtor.pureOrError(a)
+    @inline override final def pureOf[A](a: A): Id[A] = fxCtor.pureOf(a)
 
-    @inline override val unitOf: Id[Unit] = fxCtor.idFxCtor.unitOf
+    @inline override final def pureOrError[A](a: => A): Id[A] = fxCtor.pureOrError(a)
 
-    @inline override final def errorOf[A](throwable: Throwable): Id[A] = fxCtor.idFxCtor.errorOf(throwable)
+    @inline override val unitOf: Id[Unit] = fxCtor.unitOf
 
-    @inline override final def fromEither[A](either: Either[Throwable, A]): Id[A] = fxCtor.idFxCtor.fromEither(either)
+    @inline override final def errorOf[A](throwable: Throwable): Id[A] = fxCtor.errorOf(throwable)
+
+    @inline override final def fromEither[A](either: Either[Throwable, A]): Id[A] = fxCtor.fromEither(either)
 
     @inline override final def fromOption[A](option: Option[A])(orElse: => Throwable): Id[A] =
-      fxCtor.idFxCtor.fromOption(option)(orElse)
+      fxCtor.fromOption(option)(orElse)
 
-    @inline override final def fromTry[A](tryA: Try[A]): Id[A] = fxCtor.idFxCtor.fromTry(tryA)
+    @inline override final def fromTry[A](tryA: Try[A]): Id[A] = fxCtor.fromTry(tryA)
 
     @inline override final def flatMapFa[A, B](fa: Id[A])(f: A => Id[B]): Id[B] = f(fa)
 

--- a/modules/effectie-core/shared/src/main/scala/effectie/instances/future/canCatch.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/instances/future/canCatch.scala
@@ -1,6 +1,6 @@
 package effectie.instances.future
 
-import effectie.core.CanCatch
+import effectie.core.{CanCatch, FxCtor}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -10,7 +10,10 @@ import scala.concurrent.{ExecutionContext, Future}
 object canCatch {
 
   trait FutureCanCatch extends CanCatch[Future] {
+
     implicit def EC0: ExecutionContext
+
+    override implicit protected val fxCtor: FxCtor[Future] = effectie.instances.future.fxCtor.fxCtorFuture
 
     @inline override final def flatMapFa[A, B](fa: Future[A])(f: A => Future[B]): Future[B] =
       fa.flatMap(f)(EC0)

--- a/modules/effectie-core/shared/src/test/scala/effectie/resource/UsingResourceMakerSpec.scala
+++ b/modules/effectie-core/shared/src/test/scala/effectie/resource/UsingResourceMakerSpec.scala
@@ -73,6 +73,9 @@ object UsingResourceMakerSpec extends Properties {
     }
 
   object TryFxCtor extends FxCtor[Try] with CanCatch[Try] {
+
+    override implicit protected def fxCtor: FxCtor[Try] = this
+
     override def effectOf[A](a: => A): Try[A] = Try(a)
 
     override def pureOf[A](a: A): Try[A] = Try(a)

--- a/modules/effectie-core/shared/src/test/scala/effectie/resource/UsingResourceSpec.scala
+++ b/modules/effectie-core/shared/src/test/scala/effectie/resource/UsingResourceSpec.scala
@@ -73,6 +73,9 @@ object UsingResourceSpec extends Properties {
     }
 
   object TryFxCtor extends FxCtor[Try] with CanCatch[Try] {
+
+    override implicit protected def fxCtor: FxCtor[Try] = this
+
     override def effectOf[A](a: => A): Try[A] = Try(a)
 
     override def pureOf[A](a: A): Try[A] = Try(a)

--- a/modules/effectie-monix3/shared/src/main/scala/effectie/instances/monix3/canCatch.scala
+++ b/modules/effectie-monix3/shared/src/main/scala/effectie/instances/monix3/canCatch.scala
@@ -1,6 +1,6 @@
 package effectie.instances.monix3
 
-import effectie.core.CanCatch
+import effectie.core.{CanCatch, FxCtor}
 import monix.eval.Task
 
 /** @author Kevin Lee
@@ -9,6 +9,8 @@ import monix.eval.Task
 object canCatch {
 
   implicit object canCatchTask extends CanCatch[Task] {
+
+    override implicit protected val fxCtor: FxCtor[Task] = effectie.instances.monix3.fxCtor.taskFxCtor
 
     @inline override final def flatMapFa[A, B](fa: Task[A])(f: A => Task[B]): Task[B] = fa.flatMap(f)
 

--- a/modules/effectie-monix3/shared/src/main/scala/effectie/instances/monix3/fx.scala
+++ b/modules/effectie-monix3/shared/src/main/scala/effectie/instances/monix3/fx.scala
@@ -1,6 +1,6 @@
 package effectie.instances.monix3
 
-import effectie.core.Fx
+import effectie.core.{Fx, FxCtor}
 import monix.eval.Task
 
 import scala.util.Try
@@ -12,23 +12,25 @@ object fx {
 
   implicit object taskFx extends Fx[Task] {
 
-    @inline override final def effectOf[A](a: => A): Task[A] = fxCtor.taskFxCtor.effectOf(a)
+    override implicit protected val fxCtor: FxCtor[Task] = effectie.instances.monix3.fxCtor.taskFxCtor
 
-    @inline override final def pureOf[A](a: A): Task[A] = fxCtor.taskFxCtor.pureOf(a)
+    @inline override final def effectOf[A](a: => A): Task[A] = fxCtor.effectOf(a)
 
-    @inline override final def pureOrError[A](a: => A): Task[A] = fxCtor.taskFxCtor.pureOrError(a)
+    @inline override final def pureOf[A](a: A): Task[A] = fxCtor.pureOf(a)
 
-    @inline override val unitOf: Task[Unit] = fxCtor.taskFxCtor.unitOf
+    @inline override final def pureOrError[A](a: => A): Task[A] = fxCtor.pureOrError(a)
 
-    @inline override final def errorOf[A](throwable: Throwable): Task[A] = fxCtor.taskFxCtor.errorOf(throwable)
+    @inline override val unitOf: Task[Unit] = fxCtor.unitOf
+
+    @inline override final def errorOf[A](throwable: Throwable): Task[A] = fxCtor.errorOf(throwable)
 
     @inline override final def fromEither[A](either: Either[Throwable, A]): Task[A] =
-      fxCtor.taskFxCtor.fromEither(either)
+      fxCtor.fromEither(either)
 
     @inline override final def fromOption[A](option: Option[A])(orElse: => Throwable): Task[A] =
-      fxCtor.taskFxCtor.fromOption(option)(orElse)
+      fxCtor.fromOption(option)(orElse)
 
-    @inline override final def fromTry[A](tryA: Try[A]): Task[A] = fxCtor.taskFxCtor.fromTry(tryA)
+    @inline override final def fromTry[A](tryA: Try[A]): Task[A] = fxCtor.fromTry(tryA)
 
     @inline override final def flatMapFa[A, B](fa: Task[A])(f: A => Task[B]): Task[B] = fa.flatMap(f)
 


### PR DESCRIPTION
Close #480 - Remove `implicit fxCtor: FxCtor[F]` param from the catch methods in `CanCatch`