### PR TITLE
effectie v2.0.0-beta6

### DIFF
--- a/changelogs/2.0.0-beta6.md
+++ b/changelogs/2.0.0-beta6.md
@@ -1,0 +1,37 @@
+## [2.0.0-beta6](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-01-15..2023-02-11) - 2023-02-11
+
+### Change
+* Remove `implicit fxCtor: FxCtor[F]` param from the catch methods in `CanCatch` (#480)
+  
+  The following methods in `CanCatch`
+  ```scala
+  def catchNonFatal[A, B](
+    fb: => F[B]
+  )(
+    f: PartialFunction[Throwable, A]
+  )(
+    implicit fxCtor: FxCtor[F]
+  ): F[Either[A, B]]
+  
+  def catchNonFatalEither[A, AA >: A, B](
+    fab: => F[Either[A, B]]
+  )(
+    f: PartialFunction[Throwable, AA]
+  )(
+    implicit fxCtor: FxCtor[F]
+  ): F[Either[AA, B]] 
+  ```
+  have been changed to
+  ```scala
+  def catchNonFatal[A, B](
+    fb: => F[B]
+  )(
+    f: PartialFunction[Throwable, A]
+  ): F[Either[A, B]]
+  
+  def catchNonFatalEither[A, AA >: A, B](
+    fab: => F[Either[A, B]]
+  )(
+    f: PartialFunction[Throwable, AA]
+  ): F[Either[AA, B]] 
+  ```

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta6"


### PR DESCRIPTION
# effectie v2.0.0-beta6
## [2.0.0-beta6](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-01-15..2023-02-11) - 2023-02-11

### Change
* Remove `implicit fxCtor: FxCtor[F]` param from the catch methods in `CanCatch` (#480)
  
  The following methods in `CanCatch`
  ```scala
  def catchNonFatal[A, B](
    fb: => F[B]
  )(
    f: PartialFunction[Throwable, A]
  )(
    implicit fxCtor: FxCtor[F]
  ): F[Either[A, B]]
  
  def catchNonFatalEither[A, AA >: A, B](
    fab: => F[Either[A, B]]
  )(
    f: PartialFunction[Throwable, AA]
  )(
    implicit fxCtor: FxCtor[F]
  ): F[Either[AA, B]] 
  ```
  have been changed to
  ```scala
  def catchNonFatal[A, B](
    fb: => F[B]
  )(
    f: PartialFunction[Throwable, A]
  ): F[Either[A, B]]
  
  def catchNonFatalEither[A, AA >: A, B](
    fab: => F[Either[A, B]]
  )(
    f: PartialFunction[Throwable, AA]
  ): F[Either[AA, B]] 
  ```
