### PR TITLE
Close #489 - Fix typo in the missing implicit instance messages and update the messages to use instances of Fx instead of others

### DIFF
--- a/modules/effectie-core/shared/src/main/scala/effectie/core/CanCatch.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/core/CanCatch.scala
@@ -4,34 +4,9 @@ import scala.annotation.implicitNotFound
 
 @implicitNotFound(
   """
-  Could not find an implicit CanCatch[${F}]. You can probably find it from the effectie.instance package.
-  ---
-  If you want to use IO from cats-effect 2, try effectie-cats-effect2.
-    import effectie.instances.ce2.canCatch._
-    // for Scala 3
-    import effectie.instances.ce2.canCatch.given
-
-  For cats-effect 3, try effectie-cats-effect3.
-    import effectie.instances.ce3.canCatch._
-    // for Scala 3
-    import effectie.instances.ce3.canCatch.given
-
-  If you want to use Task from Monix 3, try effectie-monix3.
-    import effectie.instances.monix3.canCatch._
-    // for Scala 3
-    import effectie.instances.monix3.canCatch.given
-
-  For Scala's Future, It is just
-    import effectie.instances.future.canCatch._
-    // for Scala 3
-    import effectie.instances.future.canCatch.given
-
-  If you don't want to use any effect but the raw data, you can use the instance for cats.Id
-    import effectie.instances.id.canCatch._
-    // for Scala 3
-    import effectie.instances.id.canCatch.given
-  ---
-  """
+  Could not find an implicit CanCatch[${F}]. You can probably find it from the effectie.instances package.
+  It is recommended to use an instance for Fx instead of an instance for CanCatch.""" +
+    compileTimeMessages.ListOfFxInstances
 )
 trait CanCatch[F[*]] {
 

--- a/modules/effectie-core/shared/src/main/scala/effectie/core/CanHandleError.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/core/CanHandleError.scala
@@ -7,34 +7,9 @@ import scala.annotation.implicitNotFound
   */
 @implicitNotFound(
   """
-  Could not find an implicit CanHandleError[${F}]. You can probably find it from the effectie.instance package.
-  ---
-  If you want to use IO from cats-effect 2, try effectie-cats-effect2.
-    import effectie.instances.ce2.canHandleError._
-    // for Scala 3
-    import effectie.instances.ce2.canHandleError.given
-
-  For cats-effect 3, try effectie-cats-effect3.
-    import effectie.instances.ce3.canHandleError._
-    // for Scala 3
-    import effectie.instances.ce3.canHandleError.given
-
-  If you want to use Task from Monix 3, try effectie-monix3.
-    import effectie.instances.monix3.canHandleError._
-    // for Scala 3
-    import effectie.instances.monix3.canHandleError.given
-
-  For Scala's Future, It is just
-    import effectie.instances.future.canHandleError._
-    // for Scala 3
-    import effectie.instances.future.canHandleError.given
-
-  If you don't want to use any effect but the raw data, you can use the instance for cats.Id
-    import effectie.instances.id.canHandleError._
-    // for Scala 3
-    import effectie.instances.id.canHandleError.given
-  ---
-  """
+  Could not find an implicit CanHandleError[${F}]. You can probably find it from the effectie.instances package.
+  It is recommended to use an instance for Fx instead of an instance for CanHandleError.""" +
+    compileTimeMessages.ListOfFxInstances
 )
 trait CanHandleError[F[*]] {
 

--- a/modules/effectie-core/shared/src/main/scala/effectie/core/CanRecover.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/core/CanRecover.scala
@@ -7,34 +7,9 @@ import scala.annotation.implicitNotFound
   */
 @implicitNotFound(
   """
-  Could not find an implicit CanRecover[${F}]. You can probably find it from the effectie.instance package.
-  ---
-  If you want to use IO from cats-effect 2, try effectie-cats-effect2.
-    import effectie.instances.ce2.canRecover._
-    // for Scala 3
-    import effectie.instances.ce2.canRecover.given
-
-  For cats-effect 3, try effectie-cats-effect3.
-    import effectie.instances.ce3.canRecover._
-    // for Scala 3
-    import effectie.instances.ce3.canRecover.given
-
-  If you want to use Task from Monix 3, try effectie-monix3.
-    import effectie.instances.monix3.canRecover._
-    // for Scala 3
-    import effectie.instances.monix3.canRecover.given
-
-  For Scala's Future, It is just
-    import effectie.instances.future.canRecover._
-    // for Scala 3
-    import effectie.instances.future.canRecover.given
-
-  If you don't want to use any effect but the raw data, you can use the instance for cats.Id
-    import effectie.instances.id.canRecover._
-    // for Scala 3
-    import effectie.instances.id.canRecover.given
-  ---
-  """
+  Could not find an implicit CanRecover[${F}]. You can probably find it from the effectie.instances package.
+  It is recommended to use an instance for Fx instead of an instance for CanRecover.""" +
+    compileTimeMessages.ListOfFxInstances
 )
 trait CanRecover[F[*]] {
 

--- a/modules/effectie-core/shared/src/main/scala/effectie/core/ConsoleEffect.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/core/ConsoleEffect.scala
@@ -4,7 +4,7 @@ import scala.annotation.implicitNotFound
 
 @implicitNotFound(
   """
-  Could not find an implicit ConsoleEffect[${F}]. You can probably find it from the effectie.instance package.
+  Could not find an implicit ConsoleEffect[${F}]. You can probably find it from the effectie.instances package.
   ---
   You can simply,
     import effectie.instances.console._

--- a/modules/effectie-core/shared/src/main/scala/effectie/core/FromFuture.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/core/FromFuture.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration.Duration
   */
 @implicitNotFound(
   """
-  Could not find an implicit FromFuture[${F}]. You can probably find it from the effectie.instance package.
+  Could not find an implicit FromFuture[${F}]. You can probably find it from the effectie.instances package.
   ---
   If you want to use IO from cats-effect 2, try effectie-cats-effect2.
     import effectie.instances.ce2.fromFuture._

--- a/modules/effectie-core/shared/src/main/scala/effectie/core/FxCtor.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/core/FxCtor.scala
@@ -4,34 +4,9 @@ import scala.annotation.implicitNotFound
 
 @implicitNotFound(
   """
-  Could not find an implicit FxCtor[${F}]. You can probably find it from the effectie.instance package.
-  ---
-  If you want to use IO from cats-effect 2, try effectie-cats-effect2.
-    import effectie.instances.ce2.fxCtor._
-    // for Scala 3
-    import effectie.instances.ce2.fxCtor.given
-
-  For cats-effect 3, try effectie-cats-effect3.
-    import effectie.instances.ce3.fxCtor._
-    // for Scala 3
-    import effectie.instances.ce3.fxCtor.given
-
-  If you want to use Task from Monix 3, try effectie-monix3.
-    import effectie.instances.monix3.fxCtor._
-    // for Scala 3
-    import effectie.instances.monix3.fxCtor.given
-
-  For Scala's Future, It is just
-    import effectie.instances.future.fxCtor._
-    // for Scala 3
-    import effectie.instances.future.fxCtor.given
-
-  If you don't want to use any effect but the raw data, you can use the instance for cats.Id
-    import effectie.instances.id.fxCtor._
-    // for Scala 3
-    import effectie.instances.id.fxCtor.given
-  ---
-  """
+  Could not find an implicit FxCtor[${F}]. You can probably find it from the effectie.instances package.
+  It is recommended to use an instance for Fx instead of an instance for FxCtor.""" +
+    compileTimeMessages.ListOfFxInstances
 )
 trait FxCtor[F[*]] {
   def effectOf[A](a: => A): F[A]

--- a/modules/effectie-core/shared/src/main/scala/effectie/core/ToFuture.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/core/ToFuture.scala
@@ -8,7 +8,7 @@ import scala.concurrent.Future
   */
 @implicitNotFound(
   """
-  Could not find an implicit ToFuture[${F}]. You can probably find it from the effectie.instance package.
+  Could not find an implicit ToFuture[${F}]. You can probably find it from the effectie.instances package.
   ---
   If you want to use IO from cats-effect 2, try effectie-cats-effect2.
     import effectie.instances.ce2.toFuture._

--- a/modules/effectie-core/shared/src/main/scala/effectie/core/compileTimeMessages.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/core/compileTimeMessages.scala
@@ -1,13 +1,12 @@
 package effectie.core
 
-import scala.annotation.implicitNotFound
-
 /** @author Kevin Lee
-  * @since 2021-11-03
+  * @since 2023-02-23
   */
-@implicitNotFound(
-  """
-  Could not find an implicit Fx[${F}]. You can probably find it from the effectie.instances package.
+private[core] object compileTimeMessages {
+  // $COVERAGE-OFF$
+  final val ListOfFxInstances = // scalafix:ok DisableSyntax.noFinalVal
+    """
   ---
   If you want to use IO from cats-effect 2, try effectie-cats-effect2.
     import effectie.instances.ce2.fx._
@@ -50,11 +49,5 @@ import scala.annotation.implicitNotFound
     import effectie.instances.id.fx.idFx
   ---
   """
-)
-trait Fx[F[*]] extends FxCtor[F] with CanCatch[F] with CanHandleError[F] with CanRecover[F]
-
-object Fx {
-
-  def apply[F[*]: Fx]: Fx[F] = implicitly[Fx[F]]
-
+  // $COVERAGE-ON$
 }


### PR DESCRIPTION
Close #489 - Fix typo in the missing implicit instance messages and update the messages to use instances of `Fx` instead of others