### PR TITLE
effectie v2.0.0-beta7

### DIFF
--- a/changelogs/2.0.0-beta7.md
+++ b/changelogs/2.0.0-beta7.md
@@ -1,0 +1,12 @@
+## [2.0.0-beta7](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-12..2023-02-25) - 2023-02-25
+
+### New Features
+* Add `pureOfOption`, `pureOfSome`, `pureOfNone`, `pureOfRight` and `pureOfLeft` to `FxCtor` and `Fx` (#488)
+  * `Fx[F].pureOfOption[A](a: A): F[Option[A]]`
+  * `Fx[F].pureOfSome[A](a: A): F[Option[A]]`
+  * `Fx[F].pureOfNone[A]: F[Option[A]]`
+  * `Fx[F].pureOfRight[A][B](b: B): F[Either[A, B]]`
+  * `Fx[F].pureOfLeft[B][A](a: A): F[Either[A, B]]`
+
+### Fix
+* Fix typo in the missing `implicit` instance messages (#489)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta7"


### PR DESCRIPTION
# effectie v2.0.0-beta7
## [2.0.0-beta7](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-12..2023-02-25) - 2023-02-25

### New Features
* Add `pureOfOption`, `pureOfSome`, `pureOfNone`, `pureOfRight` and `pureOfLeft` to `FxCtor` and `Fx` (#488)
  * `Fx[F].pureOfOption[A](a: A): F[Option[A]]`
  * `Fx[F].pureOfSome[A](a: A): F[Option[A]]`
  * `Fx[F].pureOfNone[A]: F[Option[A]]`
  * `Fx[F].pureOfRight[A][B](b: B): F[Either[A, B]]`
  * `Fx[F].pureOfLeft[B][A](a: A): F[Either[A, B]]`

### Fix
* Fix typo in the missing `implicit` instance messages (#489)
