### PR TITLE
Issue #499 - Fix missing `implicit` instance message for `ConsoleFx`

### DIFF
--- a/modules/effectie-core/shared/src/main/scala/effectie/core/ConsoleFx.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/core/ConsoleFx.scala
@@ -4,7 +4,7 @@ import scala.annotation.implicitNotFound
 
 @implicitNotFound(
   """
-  Could not find an implicit ConsoleEffect[${F}]. You can probably find it from the effectie.instances package.
+  Could not find an implicit ConsoleFx[${F}]. You can probably find it from the effectie.instances package.
   ---
   You can simply,
     import effectie.instances.console._


### PR DESCRIPTION
Issue #499 - Fix missing `implicit` instance message for `ConsoleFx`