### PR TITLE
effectie v2.0.0-beta8

### DIFF
--- a/changelogs/2.0.0-beta8.md
+++ b/changelogs/2.0.0-beta8.md
@@ -1,0 +1,45 @@
+## [2.0.0-beta8](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-26..2023-03-07) - 2023-03-07
+
+### Changes
+
+* Remove unused implicit params (#497)
+  ```scala
+  def catchNonFatal[A](
+    f: PartialFunction[Throwable, A]
+  )(
+    implicit canCatch: CanCatch[F],
+    fxCtor: FxCtor[F], // <= This is unused
+  ): F[Either[A, B]] =
+    canCatch.catchNonFatal[A, B](fb())(f)
+  ```
+  The `implicit` param `fxCtor: FxCtor[F]` has been removed.
+* Rename `ConsoleEffect` to `ConsoleFx` (#499)
+* Move `flatMapFa` from `CanCatch` to `FxCtor` (#501)
+  ```scala
+  def flatMapFa[A, B](fa: F[A])(f: A => F[B]): F[B]
+  ```
+* Move `FxCtor` from instance creation of `ConsoleFx` to each `ConsoleFx` method param (#504)
+  ```scala
+  implicit def consoleFxF[F[*]: FxCtor: FlatMap]: ConsoleFx[F] = ...
+  ```
+  to
+  ```scala
+  trait ConsoleFx[F[*]] {
+    def readLn(implicit fxCtor: FxCtor[F]): F[String]
+  
+    def readPassword(implicit fxCtor: FxCtor[F]): F[Array[Char]]
+  
+    def putStr(value: String)(implicit fxCtor: FxCtor[F]): F[Unit]
+  
+    def putStrLn(value: String)(implicit fxCtor: FxCtor[F]): F[Unit]
+  
+    def putErrStr(value: String)(implicit fxCtor: FxCtor[F]): F[Unit]
+  
+    def putErrStrLn(value: String)(implicit fxCtor: FxCtor[F]): F[Unit]
+  
+    def readYesNo(prompt: String)(implicit fxCtor: FxCtor[F]): F[YesNo]
+  }
+  ```
+* `ConsoleFx` instance should not depend on cats (`Monad`) (#505)
+
+  Instead, it depends on `FxCtor` now.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta8"


### PR DESCRIPTION
# effectie v2.0.0-beta8
## [2.0.0-beta8](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-26..2023-03-07) - 2023-03-07

### Changes

* Remove unused implicit params (#497)
  ```scala
  def catchNonFatal[A](
    f: PartialFunction[Throwable, A]
  )(
    implicit canCatch: CanCatch[F],
    fxCtor: FxCtor[F], // <= This is unused
  ): F[Either[A, B]] =
    canCatch.catchNonFatal[A, B](fb())(f)
  ```
  The `implicit` param `fxCtor: FxCtor[F]` has been removed.
* Rename `ConsoleEffect` to `ConsoleFx` (#499)
* Move `flatMapFa` from `CanCatch` to `FxCtor` (#501)
  ```scala
  def flatMapFa[A, B](fa: F[A])(f: A => F[B]): F[B]
  ```
* Move `FxCtor` from instance creation of `ConsoleFx` to each `ConsoleFx` method param (#504)
  ```scala
  implicit def consoleFxF[F[*]: FxCtor: FlatMap]: ConsoleFx[F] = ...
  ```
  to
  ```scala
  trait ConsoleFx[F[*]] {
    def readLn(implicit fxCtor: FxCtor[F]): F[String]
  
    def readPassword(implicit fxCtor: FxCtor[F]): F[Array[Char]]
  
    def putStr(value: String)(implicit fxCtor: FxCtor[F]): F[Unit]
  
    def putStrLn(value: String)(implicit fxCtor: FxCtor[F]): F[Unit]
  
    def putErrStr(value: String)(implicit fxCtor: FxCtor[F]): F[Unit]
  
    def putErrStrLn(value: String)(implicit fxCtor: FxCtor[F]): F[Unit]
  
    def readYesNo(prompt: String)(implicit fxCtor: FxCtor[F]): F[YesNo]
  }
  ```
* `ConsoleFx` instance should not depend on cats (`Monad`) (#505)

  Instead, it depends on `FxCtor` now.
