### PR TITLE
Update: docs - to comply with the latest effectie (ConsoleEffect => ConsoleFx and no more instances.console) / the latest effectie version info

### DIFF
--- a/docs/latest/cats-effect2/cats-effect2.md
+++ b/docs/latest/cats-effect2/cats-effect2.md
@@ -6,7 +6,7 @@ title: "For Cats Effect"
 ## Effectie for Cats Effect
 
 * [Fx](fx/fx.md)
-* [ConsoleEffect](console-effect.md)
+* [ConsoleFx](console-fx.md)
 * [CanCatch](fx/error-handling/can-catch.md)
 * [CanHandleError](fx/error-handling/can-handle-error.md)
 * [FromFuture](from-future.md)
@@ -35,10 +35,10 @@ object Something {
   def apply[F[_]: Something]: Something[F] =
     implicitly[Something[F]]
 
-  implicit def something[F[_]: Fx: ConsoleEffect: Monad]: Something[F] =
+  implicit def something[F[_]: Fx: Monad]: Something[F] =
     new SomethingF[F]
 
-  final class SomethingF[F[_]: Fx: ConsoleEffect: Monad]
+  final class SomethingF[F[_]: Fx: Monad]
     extends Something[F] {
 
     override def foo[A: Semigroup](a: A): F[A] =
@@ -79,7 +79,6 @@ object Something {
 }
 
 import effectie.instances.ce2.fx._
-import effectie.instances.console._
 
 println(Something[IO].foo(1).unsafeRunSync())
 

--- a/docs/latest/cats-effect2/console-fx.md
+++ b/docs/latest/cats-effect2/console-fx.md
@@ -1,10 +1,10 @@
 ---
 sidebar_position: 5
 id: console-effect
-title: "ConsoleEffect"
+title: "ConsoleFx"
 ---
 
-## ConsoleEffect
+## ConsoleFx
 
 ```scala mdoc:compile-only
 import cats._
@@ -22,29 +22,28 @@ object Something {
   def apply[F[_]: Something]: Something[F] =
     implicitly[Something[F]]
 
-  implicit def something[F[_]: ConsoleEffect: Monad]: Something[F] =
+  implicit def something[F[_]: Fx: Monad]: Something[F] =
     new SomethingF[F]
 
-  final class SomethingF[F[_]: ConsoleEffect: Monad]
+  final class SomethingF[F[_]: Fx: Monad]
     extends Something[F] {
 
     def foo[A](): F[Unit] = for {
-      _ <- ConsoleEffect[F].putStrLn("Hello")
-      answer <- ConsoleEffect[F].readYesNo("Would you like to proceed?")
+      _ <- ConsoleFx[F].putStrLn("Hello")
+      answer <- ConsoleFx[F].readYesNo("Would you like to proceed?")
       result = answer match {
             case YesNo.Yes =>
               "Done"
             case YesNo.No =>
               "Cancelled"
           }
-      _ <- ConsoleEffect[F].putStrLn(result)
+      _ <- ConsoleFx[F].putStrLn(result)
     } yield ()
   }
 }
 
 import cats.effect._
 import effectie.instances.ce2.fx._
-import effectie.instances.console._
 
 val foo = Something[IO].foo()
 foo.unsafeRunSync()
@@ -83,10 +82,10 @@ object Something {
   def apply[F[_]: Something]: Something[F] =
     implicitly[Something[F]]
 
-  implicit def something[F[_]: ConsoleEffect: Monad]: Something[F] =
+  implicit def something[F[_]: Fx: Monad]: Something[F] =
     new SomethingF[F]
 
-  final class SomethingF[F[_]: ConsoleEffect: Monad]
+  final class SomethingF[F[_]: Fx: Monad]
     extends Something[F] {
 
     def foo[A](): F[Unit] = for {

--- a/docs/latest/monix3/monix3.md
+++ b/docs/latest/monix3/monix3.md
@@ -32,10 +32,10 @@ object Something {
   def apply[F[_]: Something]: Something[F] =
     implicitly[Something[F]]
 
-  implicit def something[F[_]: Fx: ConsoleEffect: Monad]: Something[F] =
+  implicit def something[F[_]: Fx: Monad]: Something[F] =
     new SomethingF[F]
 
-  final class SomethingF[F[_]: Fx: ConsoleEffect: Monad]
+  final class SomethingF[F[_]: Fx: Monad]
     extends Something[F] {
 
     override def foo[A: Semigroup](a: A): F[A] =
@@ -77,7 +77,6 @@ object Something {
 import monix.execution.Scheduler.Implicits.global
 
 import effectie.instances.monix3.fx._
-import effectie.instances.console._
 
 println(Something[Task].foo(1).runSyncUnsafe())
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -119,7 +119,7 @@ const websiteConfig = {
               "path": "v1",
             },
             "current": {
-              "label": "2.0.0-beta7",
+              "label": "2.0.0-beta8",
             },
           }
         },

--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -24,6 +24,10 @@ function Version() {
     (version) => version !== latestVersion && version.name !== 'current',
   ).concat([
     {
+      "name": "2.0.0-beta7",
+      "label": "2.0.0-beta7",
+    },
+    {
       "name": "2.0.0-beta6",
       "label": "2.0.0-beta6",
     },


### PR DESCRIPTION
Update: docs - to comply with the latest effectie (`ConsoleEffect` => `ConsoleFx` and no more `instances.console`) / the latest effectie version info