### PR TITLE
Fix the name of `object` extending `FxOfTry` / Make `FromFutureToIdTimeout` and `FromFutureToTryTimeout` value classes

### DIFF
--- a/modules/effectie-core/shared/src/main/scala/effectie/core/FromFuture.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/core/FromFuture.scala
@@ -46,7 +46,7 @@ object FromFuture {
 
   def apply[F[*]: FromFuture]: FromFuture[F] = implicitly[FromFuture[F]]
 
-  final case class FromFutureToIdTimeout(fromFutureToIdTimeout: Duration)
+  final case class FromFutureToIdTimeout(fromFutureToIdTimeout: Duration) extends AnyVal
 
-  final case class FromFutureToTryTimeout(fromFutureToTryTimeout: Duration)
+  final case class FromFutureToTryTimeout(fromFutureToTryTimeout: Duration) extends AnyVal
 }

--- a/modules/effectie-core/shared/src/main/scala/effectie/instances/tries/fx.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/instances/tries/fx.scala
@@ -15,5 +15,5 @@ object fx {
       with canHandleError.TryCanHandleError
       with canRecover.TryCanRecover
 
-  implicit object futureFx extends FxOfTry
+  implicit object tryFx extends FxOfTry
 }


### PR DESCRIPTION
Fix the name of `object` extending `FxOfTry` / Make `FromFutureToIdTimeout` and `FromFutureToTryTimeout` value classes