### PR TITLE
Close #530 - Rename `withResource` in `Ce2ResourceMaker` and `Ce3ResourceMaker` to `maker`

### DIFF
--- a/modules/effectie-cats-effect2/shared/src/main/scala/effectie/resource/Ce2ResourceMaker.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala/effectie/resource/Ce2ResourceMaker.scala
@@ -8,9 +8,9 @@ import cats.effect.{BracketThrow, Sync}
 object Ce2ResourceMaker {
 
   @deprecated(message = "Please use withResource instead", since = "2.0.0-beta10")
-  def forAutoCloseable[F[*]: Sync: BracketThrow]: ResourceMaker[F] = withResource
+  def forAutoCloseable[F[*]: Sync: BracketThrow]: ResourceMaker[F] = maker
 
-  def withResource[F[*]: Sync: BracketThrow]: ResourceMaker[F] = new Ce2ResourceMaker[F]
+  def maker[F[*]: Sync: BracketThrow]: ResourceMaker[F] = new Ce2ResourceMaker[F]
 
   private final class Ce2ResourceMaker[F[*]: Sync: BracketThrow] extends ResourceMaker[F] {
 

--- a/modules/effectie-cats-effect2/shared/src/test/scala/effectie/resource/Ce2ResourceMakerSpec.scala
+++ b/modules/effectie-cats-effect2/shared/src/test/scala/effectie/resource/Ce2ResourceMakerSpec.scala
@@ -42,7 +42,7 @@ object Ce2ResourceMakerSpec extends Properties {
                    .map(_.toVector)
                    .log("content")
     } yield {
-      implicit val resourceMaker: ResourceMaker[F] = Ce2ResourceMaker.withResource
+      implicit val resourceMaker: ResourceMaker[F] = Ce2ResourceMaker.maker
       ResourceMakerSpec
         .testForAutoCloseable[F](TestResource.apply)(content, _ => F.unit, none)
         .unsafeRunSync()
@@ -56,7 +56,7 @@ object Ce2ResourceMakerSpec extends Properties {
                    .map(_.toVector)
                    .log("content")
     } yield {
-      implicit val resourceMaker: ResourceMaker[F] = Ce2ResourceMaker.withResource
+      implicit val resourceMaker: ResourceMaker[F] = Ce2ResourceMaker.maker
 
       ResourceMakerSpec
         .testForAutoCloseable[F](TestResource.apply)(
@@ -81,7 +81,7 @@ object Ce2ResourceMakerSpec extends Properties {
                    .map(_.toVector)
                    .log("content")
     } yield {
-      implicit val resourceMaker: ResourceMaker[F] = Ce2ResourceMaker.withResource
+      implicit val resourceMaker: ResourceMaker[F] = Ce2ResourceMaker.maker
       ResourceMakerSpec
         .testForMake[F](TestResourceNoAutoClose.apply)(_.release(), content, _ => F.pure(Result.success), none)
         .unsafeRunSync()
@@ -95,7 +95,7 @@ object Ce2ResourceMakerSpec extends Properties {
                    .map(_.toVector)
                    .log("content")
     } yield {
-      implicit val resourceMaker: ResourceMaker[F] = Ce2ResourceMaker.withResource
+      implicit val resourceMaker: ResourceMaker[F] = Ce2ResourceMaker.maker
 
       ResourceMakerSpec
         .testForMake[F](TestResourceNoAutoClose.apply)(

--- a/modules/effectie-cats-effect3/shared/src/main/scala/effectie/resource/Ce3ResourceMaker.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala/effectie/resource/Ce3ResourceMaker.scala
@@ -9,9 +9,9 @@ import cats.effect.kernel.MonadCancelThrow
 object Ce3ResourceMaker {
 
   @deprecated(message = "Please use withResource instead", since = "2.0.0-beta10")
-  def forAutoCloseable[F[*]: Sync: MonadCancelThrow]: ResourceMaker[F] = withResource
+  def forAutoCloseable[F[*]: Sync: MonadCancelThrow]: ResourceMaker[F] = maker
 
-  def withResource[F[*]: Sync: MonadCancelThrow]: ResourceMaker[F] = new Ce3ResourceMaker[F]
+  def maker[F[*]: Sync: MonadCancelThrow]: ResourceMaker[F] = new Ce3ResourceMaker[F]
 
   private final class Ce3ResourceMaker[F[*]: Sync: MonadCancelThrow] extends ResourceMaker[F] {
 

--- a/modules/effectie-cats-effect3/shared/src/test/scala/effectie/resource/Ce3ResourceMakerSpec.scala
+++ b/modules/effectie-cats-effect3/shared/src/test/scala/effectie/resource/Ce3ResourceMakerSpec.scala
@@ -44,7 +44,7 @@ object Ce3ResourceMakerSpec extends Properties {
                    .map(_.toVector)
                    .log("content")
     } yield {
-      implicit val resourceMaker: ResourceMaker[F] = Ce3ResourceMaker.withResource
+      implicit val resourceMaker: ResourceMaker[F] = Ce3ResourceMaker.maker
 
       ResourceMakerSpec
         .testForAutoCloseable[F](TestResource.apply)(
@@ -63,7 +63,7 @@ object Ce3ResourceMakerSpec extends Properties {
                    .map(_.toVector)
                    .log("content")
     } yield {
-      implicit val resourceMaker: ResourceMaker[F] = Ce3ResourceMaker.withResource
+      implicit val resourceMaker: ResourceMaker[F] = Ce3ResourceMaker.maker
 
       ResourceMakerSpec
         .testForAutoCloseable[F](TestResource.apply)(
@@ -88,7 +88,7 @@ object Ce3ResourceMakerSpec extends Properties {
                    .map(_.toVector)
                    .log("content")
     } yield {
-      implicit val resourceMaker: ResourceMaker[F] = Ce3ResourceMaker.withResource
+      implicit val resourceMaker: ResourceMaker[F] = Ce3ResourceMaker.maker
 
       ResourceMakerSpec
         .testForMake[F](TestResourceNoAutoClose.apply)(
@@ -108,7 +108,7 @@ object Ce3ResourceMakerSpec extends Properties {
                    .map(_.toVector)
                    .log("content")
     } yield {
-      implicit val resourceMaker: ResourceMaker[F] = Ce3ResourceMaker.withResource
+      implicit val resourceMaker: ResourceMaker[F] = Ce3ResourceMaker.maker
 
       ResourceMakerSpec
         .testForMake[F](TestResourceNoAutoClose.apply)(


### PR DESCRIPTION
Close #530 - Rename `withResource` in `Ce2ResourceMaker` and `Ce3ResourceMaker` to `maker`