### PR TITLE
Close #529 - Remove unnecessary re-evaluation of `ResourceMaker`

### DIFF
--- a/modules/effectie-core/shared/src/main/scala/effectie/resource/ResourceMaker.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/resource/ResourceMaker.scala
@@ -14,7 +14,8 @@ trait ResourceMaker[F[*]] {
 object ResourceMaker {
   def apply[F[*]: ResourceMaker]: ResourceMaker[F] = implicitly[ResourceMaker[F]]
 
-  def usingResourceMaker: ResourceMaker[Try] = new UsingResourceMaker
+  val usingResourceMaker: ResourceMaker[Try] = new UsingResourceMaker
+
   private final class UsingResourceMaker extends ResourceMaker[Try] {
     override def forAutoCloseable[A <: AutoCloseable](fa: Try[A]): ReleasableResource[Try, A] =
       ReleasableResource.usingResourceFromTry(fa)


### PR DESCRIPTION
Close #529 - Remove unnecessary re-evaluation of `ResourceMaker`