### PR TITLE
Close #534 - Add `pure[A](a: A)` and `eval[A](fa: F[A])` to `ResourceMaker`

### DIFF
--- a/modules/effectie-cats-effect2/shared/src/main/scala/effectie/resource/Ce2Resource.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala/effectie/resource/Ce2Resource.scala
@@ -9,18 +9,20 @@ trait Ce2Resource[F[*], A] extends ReleasableResource[F, A] {
   def underlying: Resource[F, A]
 }
 object Ce2Resource {
-  def fromAutoCloseable[F[*]: Sync: BracketThrow, A <: AutoCloseable](acquire: F[A]): Ce2Resource[F, A] =
-    new Ce2ResourceF[F, A](acquire)(a => Sync[F].delay(a.close()))
+  def fromAutoCloseable[F[*]: Sync, A <: AutoCloseable](acquire: F[A]): ReleasableResource[F, A] =
+    new Ce2ResourceF[F, A](Resource.fromAutoCloseable(acquire))
 
-  def make[F[*]: Sync: BracketThrow, A](acquire: F[A])(release: A => F[Unit]): Ce2Resource[F, A] =
-    new Ce2ResourceF[F, A](acquire)(release)
+  def make[F[*]: BracketThrow, A](acquire: F[A])(release: A => F[Unit]): ReleasableResource[F, A] =
+    new Ce2ResourceF[F, A](Resource.make(acquire)(release))
 
-  private final class Ce2ResourceF[F[*]: Sync: BracketThrow, A](acquire: F[A])(release: A => F[Unit])
+  def apply[F[*]: BracketThrow, A](underlying: Resource[F, A]): ReleasableResource[F, A] =
+    new Ce2ResourceF(underlying)
+
+  private final class Ce2ResourceF[F[*]: BracketThrow, A](override val underlying: Resource[F, A])
       extends Ce2Resource[F, A] {
 
-    override val underlying: Resource[F, A] = Resource.make[F, A](acquire)(release)
-
     override def use[B](f: A => F[B]): F[B] = underlying.use(f)
+
   }
 
 }

--- a/modules/effectie-cats-effect2/shared/src/main/scala/effectie/resource/Ce2ResourceMaker.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala/effectie/resource/Ce2ResourceMaker.scala
@@ -1,5 +1,6 @@
 package effectie.resource
 
+import cats.Monad
 import cats.effect.{BracketThrow, Sync}
 
 /** @author Kevin Lee
@@ -19,6 +20,10 @@ object Ce2ResourceMaker {
 
     override def make[A](fa: => F[A])(release: A => F[Unit]): ReleasableResource[F, A] =
       Ce2Resource.make[F, A](fa)(release)
+
+    override def pure[A](a: A): ReleasableResource[F, A] = make(Monad[F].pure(a))(_ => Monad[F].unit)
+
+    override def eval[A](fa: F[A]): ReleasableResource[F, A] = make(fa)(_ => Monad[F].unit)
   }
 
 }

--- a/modules/effectie-cats-effect2/shared/src/test/scala/effectie/resource/Ce2ResourceMakerSpec.scala
+++ b/modules/effectie-cats-effect2/shared/src/test/scala/effectie/resource/Ce2ResourceMakerSpec.scala
@@ -4,7 +4,8 @@ import cats.effect._
 import cats.syntax.all._
 import effectie.instances.ce2.fx.ioFx
 import effectie.resource.data.TestErrors.TestException
-import effectie.resource.data.{TestResource, TestResourceNoAutoClose}
+import effectie.resource.data.{TestResource, TestResourceNoAutoClose, TestableResource}
+import effectie.syntax.all._
 import hedgehog._
 import hedgehog.runner._
 
@@ -21,7 +22,7 @@ object Ce2ResourceMakerSpec extends Properties {
       testForAutoCloseable,
     ),
     property(
-      "test Ce2Resource.fromAutoCloseable - error case",
+      "test Ce2ResourceMaker.fromAutoCloseable - error case",
       testForAutoCloseableErrorCase,
     ),
     property(
@@ -29,8 +30,24 @@ object Ce2ResourceMakerSpec extends Properties {
       testForMake,
     ),
     property(
-      "test Ce2Resource.make - error case",
+      "test Ce2ResourceMaker.make - error case",
       testForMakeErrorCase,
+    ),
+    property(
+      "test Ce2ResourceMaker.pure",
+      testForPure,
+    ),
+    property(
+      "test Ce2ResourceMaker.pure - error case",
+      testForPureErrorCase,
+    ),
+    property(
+      "test Ce2ResourceMaker.eval",
+      testForEval,
+    ),
+    property(
+      "test Ce2ResourceMaker.eval - error case",
+      testForEvalErrorCase,
     ),
   )
 
@@ -102,6 +119,100 @@ object Ce2ResourceMakerSpec extends Properties {
           _.release(),
           content,
           _ => F.raiseError(TestException(123)),
+          Option({
+            case TestException(123) => Result.success
+            case ex: Throwable =>
+              Result
+                .failure
+                .log(s"TestException was expected but it is ${ex.getClass.getSimpleName}. Error: ${ex.toString}")
+          }),
+        )
+        .unsafeRunSync()
+    }
+
+  def testForPure: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      implicit val resourceMaker: ResourceMaker[F] = Ce2ResourceMaker.maker
+      ResourceMakerSpec
+        .testFor[F](TestResourceNoAutoClose.apply)(
+          resourceMaker.pure,
+          content,
+          _ => F.pure(Result.success),
+          closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+          none,
+        )
+        .unsafeRunSync()
+    }
+
+  def testForPureErrorCase: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      implicit val resourceMaker: ResourceMaker[F] = Ce2ResourceMaker.maker
+
+      ResourceMakerSpec
+        .testFor[F](TestResourceNoAutoClose.apply)(
+          resourceMaker.pure,
+          content,
+          _ => F.raiseError(TestException(123)),
+          closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+          Option({
+            case TestException(123) => Result.success
+            case ex: Throwable =>
+              Result
+                .failure
+                .log(s"TestException was expected but it is ${ex.getClass.getSimpleName}. Error: ${ex.toString}")
+          }),
+        )
+        .unsafeRunSync()
+    }
+
+  def testForEval: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      implicit val resourceMaker: ResourceMaker[F] = Ce2ResourceMaker.maker
+      ResourceMakerSpec
+        .testFor[F](TestResourceNoAutoClose.apply)(
+          testResource => resourceMaker.eval(effectOf(testResource)),
+          content,
+          _ => F.pure(Result.success),
+          closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+          none,
+        )
+        .unsafeRunSync()
+    }
+
+  def testForEvalErrorCase: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      implicit val resourceMaker: ResourceMaker[F] = Ce2ResourceMaker.maker
+
+      ResourceMakerSpec
+        .testFor[F](TestResourceNoAutoClose.apply)(
+          testResource => resourceMaker.eval(effectOf(testResource)),
+          content,
+          _ => F.raiseError(TestException(123)),
+          closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
           Option({
             case TestException(123) => Result.success
             case ex: Throwable =>

--- a/modules/effectie-cats-effect3/shared/src/main/scala/effectie/resource/Ce3ResourceMaker.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala/effectie/resource/Ce3ResourceMaker.scala
@@ -1,5 +1,6 @@
 package effectie.resource
 
+import cats.Monad
 import cats.effect.Sync
 import cats.effect.kernel.MonadCancelThrow
 
@@ -20,6 +21,10 @@ object Ce3ResourceMaker {
 
     override def make[A](fa: => F[A])(release: A => F[Unit]): ReleasableResource[F, A] =
       Ce3Resource.make[F, A](fa)(release)
+
+    override def pure[A](a: A): ReleasableResource[F, A] = make(Monad[F].pure(a))(_ => Monad[F].unit)
+
+    override def eval[A](fa: F[A]): ReleasableResource[F, A] = make(fa)(_ => Monad[F].unit)
   }
 
 }

--- a/modules/effectie-cats-effect3/shared/src/test/scala/effectie/resource/Ce3ResourceMakerSpec.scala
+++ b/modules/effectie-cats-effect3/shared/src/test/scala/effectie/resource/Ce3ResourceMakerSpec.scala
@@ -4,7 +4,8 @@ import cats.effect._
 import cats.syntax.all._
 import effectie.instances.ce3.fx.ioFx
 import effectie.resource.data.TestErrors.TestException
-import effectie.resource.data.{TestResource, TestResourceNoAutoClose}
+import effectie.resource.data.{TestResource, TestResourceNoAutoClose, TestableResource}
+import effectie.syntax.all._
 import hedgehog._
 import hedgehog.runner._
 
@@ -33,6 +34,22 @@ object Ce3ResourceMakerSpec extends Properties {
     property(
       "test Ce3ResourceMaker.make - error case",
       testMakeErrorCase,
+    ),
+    property(
+      "test Ce3ResourceMaker.pure",
+      testPure,
+    ),
+    property(
+      "test Ce3ResourceMaker.pure - error case",
+      testPureErrorCase,
+    ),
+    property(
+      "test Ce3ResourceMaker.eval",
+      testEval,
+    ),
+    property(
+      "test Ce3ResourceMaker.eval - error case",
+      testEvalErrorCase,
     ),
   )
 
@@ -115,6 +132,102 @@ object Ce3ResourceMakerSpec extends Properties {
           _.release(),
           content,
           _ => F.raiseError(TestException(123)),
+          Option({
+            case TestException(123) => Result.success
+            case ex: Throwable =>
+              Result
+                .failure
+                .log(s"TestException was expected but it is ${ex.getClass.getSimpleName}. Error: ${ex.toString}")
+          }),
+        )
+        .unsafeRunSync()
+    }
+
+  def testPure: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      implicit val resourceMaker: ResourceMaker[F] = Ce3ResourceMaker.maker
+
+      ResourceMakerSpec
+        .testFor[F](TestResourceNoAutoClose.apply)(
+          resourceMaker.pure,
+          content,
+          _ => F.delay(Result.success),
+          closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+          none,
+        )
+        .unsafeRunSync()
+    }
+
+  def testPureErrorCase: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      implicit val resourceMaker: ResourceMaker[F] = Ce3ResourceMaker.maker
+
+      ResourceMakerSpec
+        .testFor[F](TestResourceNoAutoClose.apply)(
+          resourceMaker.pure,
+          content,
+          _ => F.raiseError(TestException(123)),
+          closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+          Option({
+            case TestException(123) => Result.success
+            case ex: Throwable =>
+              Result
+                .failure
+                .log(s"TestException was expected but it is ${ex.getClass.getSimpleName}. Error: ${ex.toString}")
+          }),
+        )
+        .unsafeRunSync()
+    }
+
+  def testEval: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      implicit val resourceMaker: ResourceMaker[F] = Ce3ResourceMaker.maker
+
+      ResourceMakerSpec
+        .testFor[F](TestResourceNoAutoClose.apply)(
+          testResource => resourceMaker.eval(effectOf(testResource)),
+          content,
+          _ => F.delay(Result.success),
+          closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+          none,
+        )
+        .unsafeRunSync()
+    }
+
+  def testEvalErrorCase: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      implicit val resourceMaker: ResourceMaker[F] = Ce3ResourceMaker.maker
+
+      ResourceMakerSpec
+        .testFor[F](TestResourceNoAutoClose.apply)(
+          testResource => resourceMaker.eval(effectOf(testResource)),
+          content,
+          _ => F.raiseError(TestException(123)),
+          closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
           Option({
             case TestException(123) => Result.success
             case ex: Throwable =>

--- a/modules/effectie-core/shared/src/main/scala/effectie/resource/ReleasableResource.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/resource/ReleasableResource.scala
@@ -9,6 +9,7 @@ import scala.util.Try
 trait ReleasableResource[F[*], A] {
 
   def use[B](f: A => F[B]): F[B]
+
 }
 
 object ReleasableResource {

--- a/modules/effectie-core/shared/src/main/scala/effectie/resource/ResourceMaker.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/resource/ResourceMaker.scala
@@ -10,6 +10,10 @@ trait ResourceMaker[F[*]] {
   def forAutoCloseable[A <: AutoCloseable](fa: F[A]): ReleasableResource[F, A]
 
   def make[A](fa: => F[A])(release: A => F[Unit]): ReleasableResource[F, A]
+
+  def pure[A](a: A): ReleasableResource[F, A]
+
+  def eval[A](fa: F[A]): ReleasableResource[F, A]
 }
 object ResourceMaker {
   def apply[F[*]: ResourceMaker]: ResourceMaker[F] = implicitly[ResourceMaker[F]]
@@ -22,6 +26,10 @@ object ResourceMaker {
 
     override def make[A](fa: => Try[A])(release: A => Try[Unit]): ReleasableResource[Try, A] =
       ReleasableResource.makeTry(fa)(release)
+
+    override def pure[A](a: A): ReleasableResource[Try, A] = make(Try(a))(_ => Try(()))
+
+    override def eval[A](fa: Try[A]): ReleasableResource[Try, A] = make(fa)(_ => Try(()))
   }
 
   def futureResourceMaker(implicit ec: ExecutionContext): ResourceMaker[Future] =
@@ -33,5 +41,9 @@ object ResourceMaker {
 
     override def make[A](fa: => Future[A])(release: A => Future[Unit]): ReleasableResource[Future, A] =
       ReleasableResource.makeFuture(fa)(release)
+
+    override def pure[A](a: A): ReleasableResource[Future, A] = make(Future.successful(a))(_ => Future.unit)
+
+    override def eval[A](fa: Future[A]): ReleasableResource[Future, A] = make(fa)(_ => Future.unit)
   }
 }

--- a/modules/effectie-core/shared/src/test/scala/effectie/resource/FutureResourceMakerSpec.scala
+++ b/modules/effectie-core/shared/src/test/scala/effectie/resource/FutureResourceMakerSpec.scala
@@ -2,7 +2,7 @@ package effectie.resource
 
 import cats.syntax.all._
 import effectie.resource.data.TestErrors.TestException
-import effectie.resource.data.{TestResource, TestResourceNoAutoClose}
+import effectie.resource.data.{TestResource, TestResourceNoAutoClose, TestableResource}
 import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
 import hedgehog._
 import hedgehog.runner._
@@ -35,6 +35,22 @@ object FutureResourceMakerSpec extends Properties {
     property(
       "test ResourceMaker.futureResourceMaker: ResourceMaker[Future] with make - error case in closing",
       testFutureResourceMakerMakeErrorCaseInClosing,
+    ),
+    property(
+      "test ResourceMaker.futureResourceMaker: ResourceMaker[Future] with pure",
+      testFutureResourceMakerPure,
+    ),
+    property(
+      "test ResourceMaker.futureResourceMaker: ResourceMaker[Future] with pure - error case",
+      testFutureResourceMakerPureErrorCase,
+    ),
+    property(
+      "test ResourceMaker.futureResourceMaker: ResourceMaker[Future] with eval",
+      testFutureResourceMakerEval,
+    ),
+    property(
+      "test ResourceMaker.futureResourceMaker: ResourceMaker[Future] with eval - error case",
+      testFutureResourceMakerEvalErrorCase,
     ),
   )
 
@@ -238,6 +254,174 @@ object FutureResourceMakerSpec extends Properties {
             content,
             _ => Future.successful(Result.success),
             none,
+          )
+      )
+
+    }
+
+  def testFutureResourceMakerPure: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      import effectie.instances.future.fx._
+      import extras.concurrent.testing.ConcurrentSupport
+
+      import scala.concurrent.Future
+      import scala.concurrent.duration._
+
+      implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+      val waitFor                                   = WaitFor(200.milliseconds)
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(3)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      implicit val resourceMaker: ResourceMaker[Future] = ResourceMaker.futureResourceMaker
+
+      ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(
+        ResourceMakerSpec
+          .testFor[Future](TestResourceNoAutoClose.apply)(
+            resourceMaker.pure,
+            content,
+            _ => Future.successful(Result.success),
+            closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+            none,
+          )
+      )
+
+    }
+
+  def testFutureResourceMakerPureErrorCase: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      import effectie.instances.future.fx._
+      import extras.concurrent.testing.ConcurrentSupport
+
+      import scala.concurrent.Future
+      import scala.concurrent.duration._
+
+      implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+      val waitFor                                   = WaitFor(200.milliseconds)
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(3)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      implicit val resourceMaker: ResourceMaker[Future] = ResourceMaker.futureResourceMaker
+
+      ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(
+        ResourceMakerSpec
+          .testFor[Future](TestResourceNoAutoClose.apply)(
+            resourceMaker.pure,
+            content,
+            _ => Future.failed(TestException(123)),
+            closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+            Option({
+              case TestException(123) => Result.success
+              case ex: Throwable =>
+                Result
+                  .failure
+                  .log(s"TestException was expected but it is ${ex.getClass.getSimpleName}. Error: ${ex.toString}")
+            }),
+          )
+      )
+
+    }
+
+  def testFutureResourceMakerEval: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      import effectie.instances.future.fx._
+      import extras.concurrent.testing.ConcurrentSupport
+
+      import scala.concurrent.Future
+      import scala.concurrent.duration._
+
+      implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+      val waitFor                                   = WaitFor(200.milliseconds)
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(3)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      implicit val resourceMaker: ResourceMaker[Future] = ResourceMaker.futureResourceMaker
+
+      ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(
+        ResourceMakerSpec
+          .testFor[Future](TestResourceNoAutoClose.apply)(
+            testResource => resourceMaker.eval(Future(testResource)),
+            content,
+            _ => Future.successful(Result.success),
+            closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+            none,
+          )
+      )
+
+    }
+
+  def testFutureResourceMakerEvalErrorCase: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      import effectie.instances.future.fx._
+      import extras.concurrent.testing.ConcurrentSupport
+
+      import scala.concurrent.Future
+      import scala.concurrent.duration._
+
+      implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+      val waitFor                                   = WaitFor(200.milliseconds)
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(3)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      implicit val resourceMaker: ResourceMaker[Future] = ResourceMaker.futureResourceMaker
+
+      ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(
+        ResourceMakerSpec
+          .testFor[Future](TestResourceNoAutoClose.apply)(
+            testResource => resourceMaker.eval(Future(testResource)),
+            content,
+            _ => Future.failed(TestException(123)),
+            closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+            Option({
+              case TestException(123) => Result.success
+              case ex: Throwable =>
+                Result
+                  .failure
+                  .log(s"TestException was expected but it is ${ex.getClass.getSimpleName}. Error: ${ex.toString}")
+            }),
           )
       )
 

--- a/modules/effectie-core/shared/src/test/scala/effectie/resource/UsingResourceMakerSpec.scala
+++ b/modules/effectie-core/shared/src/test/scala/effectie/resource/UsingResourceMakerSpec.scala
@@ -3,7 +3,7 @@ package effectie.resource
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.resource.data.TestErrors.TestException
-import effectie.resource.data.{TestResource, TestResourceNoAutoClose}
+import effectie.resource.data.{TestResource, TestResourceNoAutoClose, TestableResource}
 import hedgehog._
 import hedgehog.runner._
 
@@ -34,6 +34,22 @@ object UsingResourceMakerSpec extends Properties {
     property(
       "test ResourceMaker.usingResourceMaker: ResourceMaker[Try].make - error case in closing",
       testUsingResourceMakerMakeErrorCaseInClosing,
+    ),
+    property(
+      "test ResourceMaker.usingResourceMaker: ResourceMaker[Try].pure",
+      testUsingResourceMakerPure,
+    ),
+    property(
+      "test ResourceMaker.usingResourceMaker: ResourceMaker[Try].pure - error case",
+      testUsingResourceMakerPureErrorCase,
+    ),
+    property(
+      "test ResourceMaker.usingResourceMaker: ResourceMaker[Try].eval",
+      testUsingResourceMakerEval,
+    ),
+    property(
+      "test ResourceMaker.usingResourceMaker: ResourceMaker[Try].eval - error case",
+      testUsingResourceMakerEvalErrorCase,
     ),
   )
 
@@ -152,6 +168,104 @@ object UsingResourceMakerSpec extends Properties {
           content,
           _ => Try(Result.success),
           none,
+        )
+        .fold(err => Result.failure.log(s"Unexpected error: ${err.toString}"), identity)
+    }
+
+  def testUsingResourceMakerPure: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+
+      implicit val resourceMaker: ResourceMaker[Try] = ResourceMaker.usingResourceMaker
+
+      ResourceMakerSpec
+        .testFor[Try](TestResourceNoAutoClose.apply)(
+          testResource => resourceMaker.pure(testResource),
+          content,
+          _ => Try(Result.success),
+          closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+          none,
+        )
+        .fold(err => Result.failure.log(s"Unexpected error: ${err.toString}"), identity)
+    }
+
+  def testUsingResourceMakerPureErrorCase: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      implicit val resourceMaker: ResourceMaker[Try] = ResourceMaker.usingResourceMaker
+
+      ResourceMakerSpec
+        .testFor[Try](TestResourceNoAutoClose.apply)(
+          testResource => resourceMaker.pure(testResource),
+          content,
+          _ => Failure(TestException(123)),
+          closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+          Option({
+            case TestException(123) => Result.success
+            case ex: Throwable =>
+              Result
+                .failure
+                .log(s"TestException was expected but it is ${ex.getClass.getSimpleName}. Error: ${ex.toString}")
+          }),
+        )
+        .fold(err => Result.failure.log(s"Unexpected error: ${err.toString}"), identity)
+    }
+
+  def testUsingResourceMakerEval: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+
+      implicit val resourceMaker: ResourceMaker[Try] = ResourceMaker.usingResourceMaker
+
+      ResourceMakerSpec
+        .testFor[Try](TestResourceNoAutoClose.apply)(
+          testResource => resourceMaker.eval(Try(testResource)),
+          content,
+          _ => Try(Result.success),
+          closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+          none,
+        )
+        .fold(err => Result.failure.log(s"Unexpected error: ${err.toString}"), identity)
+    }
+
+  def testUsingResourceMakerEvalErrorCase: Property =
+    for {
+      content <- Gen
+                   .string(Gen.unicode, Range.linear(1, 100))
+                   .list(Range.linear(1, 10))
+                   .map(_.toVector)
+                   .log("content")
+    } yield {
+      implicit val resourceMaker: ResourceMaker[Try] = ResourceMaker.usingResourceMaker
+
+      ResourceMakerSpec
+        .testFor[Try](TestResourceNoAutoClose.apply)(
+          testResource => resourceMaker.eval(Try(testResource)),
+          content,
+          _ => Failure(TestException(123)),
+          closeStatus => closeStatus ==== TestableResource.CloseStatus.NotClosed,
+          Option({
+            case TestException(123) => Result.success
+            case ex: Throwable =>
+              Result
+                .failure
+                .log(s"TestException was expected but it is ${ex.getClass.getSimpleName}. Error: ${ex.toString}")
+          }),
         )
         .fold(err => Result.failure.log(s"Unexpected error: ${err.toString}"), identity)
     }


### PR DESCRIPTION
Close #534 - Add `pure[A](a: A)` and `eval[A](fa: F[A])` to `ResourceMaker`