### PR TITLE
Update: GitHub issue ticket templates (markdown => yaml) to have more structured ticket templates (for v1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report-v1.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report-v1.yml
@@ -1,0 +1,129 @@
+name: 'Bug v1'
+description: For a bug report for effectie v1
+labels: ["bug", "v1"]
+assignees:
+- Kevin-Lee
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Bug
+        Add bug details
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: The summary of ths bug
+      placeholder: Add abcdef ... for blah
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ----
+        
+        # Project Details
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Please provide the effectie version
+      placeholder: 2.0.0
+    validations:
+      required: true
+
+  - type: input
+    id: scala-version
+    attributes:
+      label: Scala Version
+      description: Please provide the version of Scala you're using
+      placeholder: 2.13.10, 3.2.2, ...
+    validations:
+      required: true
+
+  - type: input
+    id: java-version
+    attributes:
+      label: Java Version
+      description: Please provide the version of Java you're using
+      placeholder: 17 or Adoptium Temurin-17+35 (build 17+35)
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: The description of ths bug
+      placeholder: Add more detailed description of the bug
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to Reproduce
+      description: Steps to reproduce the bug. Please ensure that the ticket for the same bug doesn't exist.
+      placeholder: |
+        1. Given these input values '...'
+        2. When do something '...'
+        3. The result is '...'
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If there's any screenshot to show the bug, please add it here
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ----
+        
+        # Additional Information (Completely Optional)
+        Please share any opinions or information you have found through research about bugs by yourself
+
+  - type: dropdown
+    id: cause-type
+    attributes:
+      label: Please select one of the following if you want to add a cause. Otherwise, please leave it unselected.
+      multiple: false
+      options:
+        - Cause
+        - Possible Cause
+    validations:
+      required: false
+
+  - type: textarea
+    id: cause
+    attributes:
+      label: Cause
+      description: Please write down the cause or the possible cause if you want to add. Otherwise, please leave it empty.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: solution-type
+    attributes:
+      label: Please select one of the following if you want to add a solution. Otherwise, please leave it unselected.
+      multiple: false
+      options:
+        - Solution
+        - Possible Solution
+    validations:
+      required: false
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+      description: Please write down a solution or a possible solution if you want to add. Otherwise, please leave it empty.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task-template-v1.yml
+++ b/.github/ISSUE_TEMPLATE/task-template-v1.yml
@@ -1,0 +1,45 @@
+name: 'Task v1'
+description: For any non-bug task ticket for effectie v1
+labels: ["task", "v1"]
+assignees:
+  - Kevin-Lee
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Task
+        Add task details
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: The summary of ths task
+      placeholder: Add abcdef ... for blah
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ----
+        
+        # Project Details
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Please provide the effectie version
+      placeholder: 0.1.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: The description of ths task
+      placeholder: Add more detailed description of the task
+    validations:
+      required: false


### PR DESCRIPTION
Update: GitHub issue ticket templates (markdown => yaml) to have more structured ticket templates (for v1)