### PR TITLE
effectie v2.0.0-beta10

### DIFF
--- a/changelogs/2.0.0-beta10.md
+++ b/changelogs/2.0.0-beta10.md
@@ -1,0 +1,111 @@
+## [2.0.0-beta10](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-03-19..2023-07-15) - 2023-07-15
+
+### New Feature
+
+* Add `fromEffect(fa: => F[A]): F[A]` to `FxCtor` and `Fx` (#524)
+  ```scala
+  Fx[IO].fromEffect(IO(1)) // IO[Int]
+  FxCtor[IO].fromEffect(IO(1)) // IO[Int]
+  ```
+
+
+* Add `make[A](fa: => F[A])(release: A => F[Unit]): ReleasableResource[F, A]` to `ResourceMaker[F[*]]` (#527)
+  ```scala
+  def make[A](fa: => F[A])(release: A => F[Unit]): ReleasableResource[F, A]
+  ```
+
+  * `Try`
+    ```scala
+    val resourceMaker = ResourceMaker.usingResourceMaker
+    resourceMaker
+      .make(Try(new SomeResource()))(a => Try(a.release())) // ReleasableResource[Try, SomeResource]
+      .use { someResource =>
+        // do something with someResource
+        Try(result) // Try[ResultType]
+      } // Try[ResultType]
+    ```
+
+  * Future
+    ```scala
+    val resourceMaker = ResourceMaker.futureResourceMaker
+    resourceMaker
+      .make(Future(new SomeResource()))(a => Future(a.release())) // ReleasableResource[Future, SomeResource]
+      .use { someResource =>
+        // do something with someResource
+        Future.successful(result) // Future[ResultType]
+      } // Future[ResultType]
+    ```
+
+  * Cats Effect 2
+    ```scala
+    val resourceMaker = Ce2ResourceMaker.withResource
+    resourceMaker
+      .make(IO(new SomeResource()))(a => IO(a.release())) // ReleasableResource[IO, SomeResource]
+      .use { someResource =>
+        // do something with someResource
+        IO.pure(result) // IO[ResultType]
+      } // IO[ResultType]
+    ```
+
+  * Cats Effect 3
+    ```scala
+    val resourceMaker = Ce3ResourceMaker.withResource
+    resourceMaker
+      .make(IO(new SomeResource()))(a => IO(a.release())) // ReleasableResource[IO, SomeResource]
+      .use { someResource =>
+        // do something with someResource
+        IO.pure(result) // IO[ResultType]
+      } // IO[ResultType]
+    ```
+
+
+* Add `pure[A](a: A)` and `eval[A](fa: F[A])` to `ResourceMaker` (#534)
+  ```scala
+  trait ResourceMaker[F[*]] {
+    ...
+  
+    def pure[A](a: A): ReleasableResource[F, A]
+  
+    def eval[A](fa: F[A]): ReleasableResource[F, A]
+  }
+  ```
+
+
+* Add `ReleasableResource.pure` (#542)
+  ```scala
+  ReleasableResource.pure(resource: A): ReleasableResource[F, A]
+  ```
+  So `A` doesn't have to be `AutoCloseable` as it's just a pure value.
+
+
+* Add `ReleasableResource.map` and `ReleasableResource.flatMap` (#544)
+  ```scala
+  ReleasableResource.map(f: A => B)
+  ReleasableResource.flatMap(f: A => ReleasableResource[F, B])
+  ```
+
+
+* Add `Functor` type-class for `ReleasableResource` (#548)
+
+
+* Add `Applicative` type-class for `ReleasableResource` (#550)
+
+
+
+### Changes
+
+* Remove unnecessary re-evaluation of `ResourceMaker` (#529)
+
+  The following `ResourceMaker` constructor method is just `val` now.
+  ```scala
+  effectie.resource.ResourceMaker.usingResourceMaker
+  ```
+
+
+* Rename `withResource` in `Ce2ResourceMaker` and `Ce3ResourceMaker` to `maker` (#530)
+
+
+* Move `ResourceMaker` and `ReleasableResource` to `effectie-cats` (#546)
+  
+  Having `ReleasableResource` in `effectie-cats` is required to have `Functor` and `Monad` type-classes.
+

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta10"


### PR DESCRIPTION
# effectie v2.0.0-beta10
## [2.0.0-beta10](https://github.com/Kevin-Lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-03-19..2023-07-15) - 2023-07-15

### New Feature

* Add `fromEffect(fa: => F[A]): F[A]` to `FxCtor` and `Fx` (#524)
  ```scala
  Fx[IO].fromEffect(IO(1)) // IO[Int]
  FxCtor[IO].fromEffect(IO(1)) // IO[Int]
  ```


* Add `make[A](fa: => F[A])(release: A => F[Unit]): ReleasableResource[F, A]` to `ResourceMaker[F[*]]` (#527)
  ```scala
  def make[A](fa: => F[A])(release: A => F[Unit]): ReleasableResource[F, A]
  ```

  * `Try`
    ```scala
    val resourceMaker = ResourceMaker.usingResourceMaker
    resourceMaker
      .make(Try(new SomeResource()))(a => Try(a.release())) // ReleasableResource[Try, SomeResource]
      .use { someResource =>
        // do something with someResource
        Try(result) // Try[ResultType]
      } // Try[ResultType]
    ```

  * Future
    ```scala
    val resourceMaker = ResourceMaker.futureResourceMaker
    resourceMaker
      .make(Future(new SomeResource()))(a => Future(a.release())) // ReleasableResource[Future, SomeResource]
      .use { someResource =>
        // do something with someResource
        Future.successful(result) // Future[ResultType]
      } // Future[ResultType]
    ```

  * Cats Effect 2
    ```scala
    val resourceMaker = Ce2ResourceMaker.withResource
    resourceMaker
      .make(IO(new SomeResource()))(a => IO(a.release())) // ReleasableResource[IO, SomeResource]
      .use { someResource =>
        // do something with someResource
        IO.pure(result) // IO[ResultType]
      } // IO[ResultType]
    ```

  * Cats Effect 3
    ```scala
    val resourceMaker = Ce3ResourceMaker.withResource
    resourceMaker
      .make(IO(new SomeResource()))(a => IO(a.release())) // ReleasableResource[IO, SomeResource]
      .use { someResource =>
        // do something with someResource
        IO.pure(result) // IO[ResultType]
      } // IO[ResultType]
    ```


* Add `pure[A](a: A)` and `eval[A](fa: F[A])` to `ResourceMaker` (#534)
  ```scala
  trait ResourceMaker[F[*]] {
    ...
  
    def pure[A](a: A): ReleasableResource[F, A]
  
    def eval[A](fa: F[A]): ReleasableResource[F, A]
  }
  ```


* Add `ReleasableResource.pure` (#542)
  ```scala
  ReleasableResource.pure(resource: A): ReleasableResource[F, A]
  ```
  So `A` doesn't have to be `AutoCloseable` as it's just a pure value.


* Add `ReleasableResource.map` and `ReleasableResource.flatMap` (#544)
  ```scala
  ReleasableResource.map(f: A => B)
  ReleasableResource.flatMap(f: A => ReleasableResource[F, B])
  ```


* Add `Functor` type-class for `ReleasableResource` (#548)


* Add `Applicative` type-class for `ReleasableResource` (#550)



### Changes

* Remove unnecessary re-evaluation of `ResourceMaker` (#529)

  The following `ResourceMaker` constructor method is just `val` now.
  ```scala
  effectie.resource.ResourceMaker.usingResourceMaker
  ```


* Rename `withResource` in `Ce2ResourceMaker` and `Ce3ResourceMaker` to `maker` (#530)


* Move `ResourceMaker` and `ReleasableResource` to `effectie-cats` (#546)
  
  Having `ReleasableResource` in `effectie-cats` is required to have `Functor` and `Monad` type-classes.

