### PR TITLE
Close #559 - Fix the comments of the `deprecated` methods in `Ce2ResourceMaker` and `Ce3ResourceMaker`

### DIFF
--- a/modules/effectie-cats-effect2/shared/src/main/scala/effectie/resource/Ce2ResourceMaker.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala/effectie/resource/Ce2ResourceMaker.scala
@@ -8,7 +8,7 @@ import cats.effect.{BracketThrow, Sync}
   */
 object Ce2ResourceMaker {
 
-  @deprecated(message = "Please use withResource instead", since = "2.0.0-beta10")
+  @deprecated(message = "Please use Ce2ResourceMaker.maker instead", since = "2.0.0-beta10")
   def forAutoCloseable[F[*]: Sync: BracketThrow]: ResourceMaker[F] = maker
 
   def maker[F[*]: Sync: BracketThrow]: ResourceMaker[F] = new Ce2ResourceMaker[F]

--- a/modules/effectie-cats-effect3/shared/src/main/scala/effectie/resource/Ce3ResourceMaker.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala/effectie/resource/Ce3ResourceMaker.scala
@@ -9,7 +9,7 @@ import cats.effect.kernel.MonadCancelThrow
   */
 object Ce3ResourceMaker {
 
-  @deprecated(message = "Please use withResource instead", since = "2.0.0-beta10")
+  @deprecated(message = "Please use Ce3ResourceMaker.maker instead", since = "2.0.0-beta10")
   def forAutoCloseable[F[*]: Sync: MonadCancelThrow]: ResourceMaker[F] = maker
 
   def maker[F[*]: Sync: MonadCancelThrow]: ResourceMaker[F] = new Ce3ResourceMaker[F]


### PR DESCRIPTION
Close #559 - Fix the comments of the `deprecated` methods in `Ce2ResourceMaker` and `Ce3ResourceMaker`