### PR TITLE
effectie v2.0.0-beta11

### DIFF
--- a/changelogs/2.0.0-beta11.md
+++ b/changelogs/2.0.0-beta11.md
@@ -1,0 +1,6 @@
+## [2.0.0-beta11](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-16..2023-07-22) - 2023-07-22
+
+### Fixed
+* Fix the comments of the `deprecated` methods in `Ce2ResourceMaker` and `Ce3ResourceMaker` (#559)
+  * `Ce2ResourceMaker`: `Please use withResource instead` => `Please use Ce2ResourceMaker.maker instead`
+  * `Ce3ResourceMaker`: `Please use withResource instead` => `Please use Ce3ResourceMaker.maker instead`

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta11"


### PR DESCRIPTION
# effectie v2.0.0-beta11
## [2.0.0-beta11](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-16..2023-07-22) - 2023-07-22

### Fixed
* Fix the comments of the `deprecated` methods in `Ce2ResourceMaker` and `Ce3ResourceMaker` (#559)
  * `Ce2ResourceMaker`: `Please use withResource instead` => `Please use Ce2ResourceMaker.maker instead`
  * `Ce3ResourceMaker`: `Please use withResource instead` => `Please use Ce3ResourceMaker.maker instead`
