### PR TITLE
Close #568 - Add instances of `CanCatch`, `CanHandleError`, `CanRecover`, `FromFuture`, `Fx` and `FxCtor` with `Sync` and `Async`

### DIFF
--- a/modules/effectie-cats-effect2/shared/src/main/scala/effectie/instances/ce2/f/canCatch.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala/effectie/instances/ce2/f/canCatch.scala
@@ -1,0 +1,19 @@
+package effectie.instances.ce2.f
+
+import cats.effect.Sync
+import effectie.core.{CanCatch, FxCtor}
+
+/** @author Kevin Lee
+  * @since 2020-06-07
+  */
+object canCatch {
+
+  implicit def syncCanCatch[F[*]: Sync]: CanCatch[F] = new CanCatch[F] {
+
+    override implicit protected val fxCtor: FxCtor[F] = effectie.instances.ce2.f.fxCtor.syncFxCtor
+
+    @inline override final def catchNonFatalThrowable[A](fa: => F[A]): F[Either[Throwable, A]] =
+      Sync[F].attempt(fa)
+  }
+
+}

--- a/modules/effectie-cats-effect2/shared/src/main/scala/effectie/instances/ce2/f/canHandleError.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala/effectie/instances/ce2/f/canHandleError.scala
@@ -1,0 +1,22 @@
+package effectie.instances.ce2.f
+
+import cats.effect.Sync
+import cats.syntax.all._
+import effectie.core.CanHandleError
+
+/** @author Kevin Lee
+  * @since 2020-08-17
+  */
+object canHandleError {
+
+  implicit def syncCanHandleError[F[*]: Sync]: CanHandleError[F] = new CanHandleError[F] {
+
+    @inline override final def handleNonFatalWith[A, AA >: A](fa: => F[A])(handleError: Throwable => F[AA]): F[AA] =
+      Sync[F].handleErrorWith(fa.widen[AA])(handleError(_))
+
+    @inline override final def handleNonFatal[A, AA >: A](fa: => F[A])(handleError: Throwable => AA): F[AA] =
+      Sync[F].handleError(fa.widen[AA])(handleError)
+
+  }
+
+}

--- a/modules/effectie-cats-effect2/shared/src/main/scala/effectie/instances/ce2/f/canRecover.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala/effectie/instances/ce2/f/canRecover.scala
@@ -1,0 +1,26 @@
+package effectie.instances.ce2.f
+
+import cats.effect.Sync
+import cats.syntax.all._
+import effectie.core.CanRecover
+
+/** @author Kevin Lee
+  * @since 2020-08-17
+  */
+object canRecover {
+
+  implicit def syncCanRecover[F[*]: Sync]: CanRecover[F] = new CanRecover[F] {
+
+    @inline override final def recoverFromNonFatalWith[A, AA >: A](fa: => F[A])(
+      handleError: PartialFunction[Throwable, F[AA]]
+    ): F[AA] =
+      Sync[F].recoverWith(fa.widen[AA])(handleError)
+
+    @inline override final def recoverFromNonFatal[A, AA >: A](fa: => F[A])(
+      handleError: PartialFunction[Throwable, AA]
+    ): F[AA] =
+      Sync[F].recover(fa.widen[AA])(handleError)
+
+  }
+
+}

--- a/modules/effectie-cats-effect2/shared/src/main/scala/effectie/instances/ce2/f/fromFuture.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala/effectie/instances/ce2/f/fromFuture.scala
@@ -1,0 +1,19 @@
+package effectie.instances.ce2.f
+
+import cats.effect.{Async, ContextShift}
+import effectie.core.FromFuture
+
+import scala.concurrent.Future
+
+/** @author Kevin Lee
+  * @since 2020-09-22
+  */
+object fromFuture {
+
+  implicit def fromFutureToAsync[F[*]: Async: ContextShift]: FromFuture[F] =
+    new FromFuture[F] {
+      @inline override def toEffect[A](future: => Future[A]): F[A] =
+        Async.fromFuture(Async[F].delay(future))
+    }
+
+}

--- a/modules/effectie-cats-effect2/shared/src/main/scala/effectie/instances/ce2/f/fx.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala/effectie/instances/ce2/f/fx.scala
@@ -1,0 +1,55 @@
+package effectie.instances.ce2.f
+
+import cats.effect.Sync
+import effectie.core.{Fx, FxCtor}
+
+import scala.util.Try
+
+object fx {
+
+  implicit def syncFx[F[*]: Sync]: Fx[F] = new Fx[F] {
+
+    override implicit protected val fxCtor: FxCtor[F] = effectie.instances.ce2.f.fxCtor.syncFxCtor
+
+    @inline override final def effectOf[A](a: => A): F[A] = fxCtor.effectOf(a)
+
+    @inline override final def fromEffect[A](fa: => F[A]): F[A] = fxCtor.fromEffect(fa)
+
+    @inline override final def pureOf[A](a: A): F[A] = fxCtor.pureOf(a)
+
+    @inline override val unitOf: F[Unit] = fxCtor.unitOf
+
+    @inline override final def pureOrError[A](a: => A): F[A] = fxCtor.pureOrError(a)
+
+    @inline override final def errorOf[A](throwable: Throwable): F[A] = fxCtor.errorOf(throwable)
+
+    @inline override final def fromEither[A](either: Either[Throwable, A]): F[A] = fxCtor.fromEither(either)
+
+    @inline override final def fromOption[A](option: Option[A])(orElse: => Throwable): F[A] =
+      fxCtor.fromOption(option)(orElse)
+
+    @inline override final def fromTry[A](tryA: Try[A]): F[A] = fxCtor.fromTry(tryA)
+
+    @inline override final def flatMapFa[A, B](fa: F[A])(f: A => F[B]): F[B] = Sync[F].flatMap(fa)(f)
+
+    @inline override final def catchNonFatalThrowable[A](fa: => F[A]): F[Either[Throwable, A]] =
+      canCatch.syncCanCatch.catchNonFatalThrowable(fa)
+
+    @inline override final def handleNonFatalWith[A, AA >: A](fa: => F[A])(handleError: Throwable => F[AA]): F[AA] =
+      canHandleError.syncCanHandleError.handleNonFatalWith[A, AA](fa)(handleError)
+
+    @inline override final def handleNonFatal[A, AA >: A](fa: => F[A])(handleError: Throwable => AA): F[AA] =
+      canHandleError.syncCanHandleError.handleNonFatal[A, AA](fa)(handleError)
+
+    @inline override final def recoverFromNonFatalWith[A, AA >: A](fa: => F[A])(
+      handleError: PartialFunction[Throwable, F[AA]]
+    ): F[AA] =
+      canRecover.syncCanRecover.recoverFromNonFatalWith[A, AA](fa)(handleError)
+
+    @inline override final def recoverFromNonFatal[A, AA >: A](fa: => F[A])(
+      handleError: PartialFunction[Throwable, AA]
+    ): F[AA] =
+      canRecover.syncCanRecover.recoverFromNonFatal[A, AA](fa)(handleError)
+  }
+
+}

--- a/modules/effectie-cats-effect2/shared/src/main/scala/effectie/instances/ce2/f/fxCtor.scala
+++ b/modules/effectie-cats-effect2/shared/src/main/scala/effectie/instances/ce2/f/fxCtor.scala
@@ -1,0 +1,34 @@
+package effectie.instances.ce2.f
+
+import cats.effect.Sync
+import effectie.core.FxCtor
+
+import scala.util.Try
+
+object fxCtor {
+
+  implicit def syncFxCtor[F[*]: Sync]: FxCtor[F] = new FxCtor[F] {
+
+    @inline override final def effectOf[A](a: => A): F[A] = Sync[F].delay(a)
+
+    @inline override final def fromEffect[A](fa: => F[A]): F[A] = Sync[F].defer(fa)
+
+    @inline override final def pureOf[A](a: A): F[A] = Sync[F].pure(a)
+
+    @inline override final def pureOrError[A](a: => A): F[A] = Sync[F].catchNonFatal(a)
+
+    @inline override val unitOf: F[Unit] = Sync[F].unit
+
+    @inline override final def errorOf[A](throwable: Throwable): F[A] = Sync[F].raiseError(throwable)
+
+    @inline override final def fromEither[A](either: Either[Throwable, A]): F[A] = Sync[F].fromEither(either)
+
+    @inline override final def fromOption[A](option: Option[A])(orElse: => Throwable): F[A] =
+      Sync[F].fromOption(option, orElse)
+
+    @inline override final def fromTry[A](tryA: Try[A]): F[A] = Sync[F].fromTry(tryA)
+
+    @inline override final def flatMapFa[A, B](fa: F[A])(f: A => F[B]): F[B] = Sync[F].flatMap(fa)(f)
+  }
+
+}

--- a/modules/effectie-cats-effect2/shared/src/test/scala/effectie/instances/ce2/f/canCatchSpec.scala
+++ b/modules/effectie-cats-effect2/shared/src/test/scala/effectie/instances/ce2/f/canCatchSpec.scala
@@ -1,0 +1,270 @@
+package effectie.instances.ce2.f
+
+import cats._
+import cats.data.EitherT
+import cats.effect._
+import cats.syntax.all._
+import effectie.SomeControlThrowable
+import effectie.core._
+import effectie.instances.ce2.f.canCatch.syncCanCatch
+import effectie.syntax.error._
+import effectie.syntax.fx._
+import effectie.testing.types._
+import extras.concurrent.testing.types.ErrorLogger
+import fxCtor._
+import hedgehog._
+import hedgehog.runner._
+
+/** @author Kevin Lee
+  * @since 2020-07-31
+  */
+object canCatchSpec extends Properties {
+
+  private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+  override def tests: List[Test] = ioSpecs
+
+  val ioSpecs = List(
+    /* IO */
+    example(
+      "test CanCatch[IO]catchNonFatalThrowable should catch NonFatal",
+      IoSpec.testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalThrowable should not catch Fatal",
+      IoSpec.testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalThrowable should return the successful result",
+      IoSpec.testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatal should catch NonFatal",
+      IoSpec.testCanCatch_IO_catchNonFatalShouldCatchNonFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatal should not catch Fatal",
+      IoSpec.testCanCatch_IO_catchNonFatalShouldNotCatchFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatal should return the successful result",
+      IoSpec.testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEither should catch NonFatal",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEither should not catch Fatal",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEither should return the successful result",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEither should return the failed result",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEitherT should catch NonFatal",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEitherT should not catch Fatal",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEitherT should return the successful result",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEitherT should return the failed result",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult,
+    ),
+  )
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def throwThrowable[A](throwable: => Throwable): A =
+    throw throwable // scalafix:ok DisableSyntax.throw
+
+  def run[F[*]: FxCtor: Functor, A](a: => A): F[A] =
+    effectOf[F](a)
+
+  object IoSpec {
+
+    def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = expectedExpcetion.asLeft[Int]
+      val actual            = CanCatch[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+      try {
+        val actual = CanCatch[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: SomeControlThrowable =>
+          ex.getMessage ==== fatalExpcetion.getMessage
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Int](1)
+      val expected = 1.asRight[Throwable]
+      val actual   = CanCatch[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanCatch_IO_catchNonFatalShouldCatchNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+      try {
+        val actual = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: SomeControlThrowable =>
+          ex.getMessage ==== fatalExpcetion.getMessage
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Int](1)
+      val expected = 1.asRight[SomeError]
+      val actual   = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: SomeControlThrowable =>
+          ex.getMessage ==== fatalExpcetion.getMessage
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual   = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+      try {
+        val actual = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: SomeControlThrowable =>
+          ex.getMessage ==== fatalExpcetion.getMessage
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
+
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected = 1.asRight[SomeError]
+      val actual   = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+
+      actual ==== expected
+    }
+
+  }
+
+}

--- a/modules/effectie-cats-effect2/shared/src/test/scala/effectie/instances/ce2/f/canHandleErrorSpec.scala
+++ b/modules/effectie-cats-effect2/shared/src/test/scala/effectie/instances/ce2/f/canHandleErrorSpec.scala
@@ -1,0 +1,587 @@
+package effectie.instances.ce2.f
+
+import effectie.instances.ce2.f.canHandleError.syncCanHandleError
+import cats._
+import cats.data.EitherT
+import cats.effect.IO
+import cats.syntax.all._
+import effectie.SomeControlThrowable
+import effectie.core._
+import effectie.syntax.error._
+import effectie.syntax.fx._
+import effectie.testing.types.SomeError
+import extras.concurrent.testing.types.ErrorLogger
+import effectie.instances.ce2.f.fxCtor.syncFxCtor
+import hedgehog._
+import hedgehog.runner._
+
+import scala.util.control.{ControlThrowable, NonFatal}
+
+/** @author Kevin Lee
+  * @since 2020-08-17
+  */
+object canHandleErrorSpec extends Properties {
+  implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+  override def tests: List[Test] = ioSpecs
+
+  /* IO */
+  private val ioSpecs = List(
+    example(
+      "test CanHandleError[IO].handleNonFatalWith should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalWith should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalWith should return the successful result",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalWithEither should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalWithEither should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalWithEither should return the successful result",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalWithEither should return the failed result",
+      IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherNonFatalWith should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldHandleNonFatalWith,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherNonFatalWith should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherNonFatalWith should return the successful result",
+      IoSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherNonFatalWith should return the failed result",
+      IoSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldReturnFailedResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatalWith should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatalWith should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatalWith should return the successful result",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatalWith should return the failed result",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatal should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalShouldHandleNonFatal,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatal should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalShouldNotHandleFatal,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatal should return the successful result",
+      IoSpec.testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalEither should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalEither should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalEither should return the successful result",
+      IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleNonFatalEither should return the failed result",
+      IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherNonFatal should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleEitherNonFatalShouldHandleNonFatal,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherNonFatal should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherNonFatal should return the successful result",
+      IoSpec.testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherNonFatal should return the failed result",
+      IoSpec.testCanHandleError_IO_handleEitherNonFatalShouldReturnFailedResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatal should handle NonFatal",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatal should not handle Fatal",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatal should return the successful result",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[IO].handleEitherTNonFatal should return the failed result",
+      IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult,
+    ),
+  )
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def throwThrowable[A](throwable: => Throwable): A =
+    throw throwable // scalafix:ok DisableSyntax.throw
+
+  def run[F[*]: FxCtor: Functor, A](a: => A): F[A] =
+    effectOf[F](a)
+
+  object IoSpec {
+
+    def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 123
+      val actual            = CanHandleError[IO]
+        .handleNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) =>
+            IO.pure(expected)
+        }
+        .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+      try {
+        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Int](1)
+      val expected = 1
+      val actual   = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(999)).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+      val actualFailedResult   =
+        CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(expectedFailedResult)).unsafeRunSync()
+
+      val expectedSuccessResult = 1.asRight[SomeError]
+      val actualSuccessResult   =
+        CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(1.asRight[SomeError])).unsafeRunSync()
+
+      actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: SomeControlThrowable =>
+          ex.getMessage ==== fatalExpcetion.getMessage
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO(999.asRight[SomeError])).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleEitherNonFatalWithShouldHandleNonFatalWith: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult    = CanHandleError[IO]
+        .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+        .unsafeRunSync()
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   =
+        CanHandleError[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+
+      actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual =
+          CanHandleError[IO]
+            .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+            .unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        CanHandleError[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanHandleError[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult    = CanHandleError[IO]
+        .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+        .value
+        .unsafeRunSync()
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   =
+        CanHandleError[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
+
+      actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+      try {
+        val actual =
+          CanHandleError[IO]
+            .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+            .value
+            .unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        CanHandleError[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanHandleError[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleNonFatalShouldHandleNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 123
+      val actual            = CanHandleError[IO]
+        .handleNonFatal(fa) {
+          case NonFatal(`expectedExpcetion`) =>
+            expected
+        }
+        .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+      try {
+        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Int](1)
+      val expected = 1
+      val actual   = CanHandleError[IO].handleNonFatal(fa)(_ => 999).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+      val actualFailedResult   = CanHandleError[IO].handleNonFatal(fa)(_ => expectedFailedResult).unsafeRunSync()
+
+      val expectedSuccessResult = 1.asRight[SomeError]
+      val actualSuccessResult   = CanHandleError[IO].handleNonFatal(fa)(_ => 1.asRight[SomeError]).unsafeRunSync()
+
+      actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[IO].handleNonFatal(fa)(_ => 999.asRight[SomeError]).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleEitherNonFatalShouldHandleNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult    = CanHandleError[IO]
+        .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+        .unsafeRunSync()
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   =
+        CanHandleError[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+
+      actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual =
+          CanHandleError[IO]
+            .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+            .unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleEitherNonFatalShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanHandleError[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult    = CanHandleError[IO]
+        .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+        .value
+        .unsafeRunSync()
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   =
+        CanHandleError[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
+
+      actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+      try {
+        val actual =
+          CanHandleError[IO]
+            .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+            .value
+            .unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = {
+
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanHandleError[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
+
+      actual ==== expected
+    }
+
+  }
+
+}

--- a/modules/effectie-cats-effect2/shared/src/test/scala/effectie/instances/ce2/f/canRecoverSpec.scala
+++ b/modules/effectie-cats-effect2/shared/src/test/scala/effectie/instances/ce2/f/canRecoverSpec.scala
@@ -1,0 +1,667 @@
+package effectie.instances.ce2.f
+
+import cats._
+import cats.data.EitherT
+import cats.effect.IO
+import cats.syntax.all._
+import effectie.SomeControlThrowable
+import effectie.core._
+import effectie.instances.ce2.f.fxCtor._
+import effectie.syntax.error._
+import effectie.syntax.fx._
+import effectie.testing.types.SomeError
+import extras.concurrent.testing.types.ErrorLogger
+import hedgehog._
+import hedgehog.runner._
+
+import scala.util.control.{ControlThrowable, NonFatal}
+
+/** @author Kevin Lee
+  * @since 2020-08-17
+  */
+object canRecoverSpec extends Properties {
+  implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+  override def tests: List[Test] = ioSpecs
+
+  /* IO */
+  val ioSpecs = List(
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWith should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWith should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWith should return the successful result",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWithEither should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWithEither should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWithEither should return the successful result",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWithEither should return the failed result",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnFailedResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatalWith should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatalWith should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatalWith should return the successful result",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatalWith should return the failed result",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnFailedResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatalWith should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatalWith should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatalWith should return the successful result",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatalWith should return the failed result",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnFailedResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatal should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatal should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatal should return the successful result",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalEither should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalEither should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalEither should return the successful result",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalEither should return the failed result",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldReturnFailedResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatal should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatal should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatal should return the successful result",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatal should return the failed result",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldReturnFailedResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatal should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatal should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatal should return the successful result",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatal should return the failed result",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnFailedResult,
+    ),
+  )
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def throwThrowable[A](throwable: => Throwable): A =
+    throw throwable // scalafix:ok DisableSyntax.throw
+
+  def run[F[*]: FxCtor: Functor, A](a: => A): F[A] =
+    effectOf[F](a)
+
+  object IOSpec {
+    import canRecover._
+
+    def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 123
+      val actual            = CanRecover[IO]
+        .recoverFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) =>
+            IO.pure(expected)
+        }
+        .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+
+      val io = CanRecover[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedExpcetion`) => IO.pure(123) }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Int](1)
+      val expected = 1
+      val actual   = CanRecover[IO]
+        .recoverFromNonFatalWith(fa) {
+          case NonFatal(_) => IO.pure(999)
+        }
+        .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+      val actualFailedResult   = CanRecover[IO]
+        .recoverFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) => IO.pure(expectedFailedResult)
+        }
+        .unsafeRunSync()
+
+      val expectedSuccessResult = 1.asRight[SomeError]
+      val actualSuccessResult   = CanRecover[IO]
+        .recoverFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) => IO.pure(1.asRight[SomeError])
+        }
+        .unsafeRunSync()
+
+      actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+      val io = CanRecover[IO].recoverFromNonFatalWith(fa) {
+        case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
+      }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanRecover[IO]
+        .recoverFromNonFatalWith(fa) {
+          case NonFatal(_) => IO(999.asRight[SomeError])
+        }
+        .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanRecover[IO]
+        .recoverFromNonFatalWith(fa) {
+          case NonFatal(_) => IO.pure(123.asRight[SomeError])
+        }
+        .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult    = CanRecover[IO]
+        .recoverEitherFromNonFatalWith(fa) {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+        .unsafeRunSync()
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   = CanRecover[IO]
+        .recoverEitherFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
+        }
+        .unsafeRunSync()
+
+      actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+      val io = CanRecover[IO].recoverEitherFromNonFatalWith(fa) {
+        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+      }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanRecover[IO]
+        .recoverEitherFromNonFatalWith(fa) {
+          case NonFatal(_) => IO.pure(123.asRight[SomeError])
+        }
+        .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanRecover[IO]
+          .recoverEitherFromNonFatalWith(fa) {
+            case NonFatal(_) => IO.pure(123.asRight[SomeError])
+          }
+          .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult    = CanRecover[IO]
+        .recoverEitherTFromNonFatalWith(fa) {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+        .value
+        .unsafeRunSync()
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   = CanRecover[IO]
+        .recoverEitherTFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
+        }
+        .value
+        .unsafeRunSync()
+
+      actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+
+      val io = CanRecover[IO].recoverEitherTFromNonFatalWith(fa) {
+        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+      }
+      try {
+        val actual = io.value.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected = 1.asRight[SomeError]
+      val actual   = CanRecover[IO]
+        .recoverEitherTFromNonFatalWith(fa) {
+          case NonFatal(_) => IO.pure(123.asRight[SomeError])
+        }
+        .value
+        .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanRecover[IO]
+          .recoverEitherTFromNonFatalWith(fa) {
+            case NonFatal(_) => IO.pure(123.asRight[SomeError])
+          }
+          .value
+          .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    // /
+
+    def testCanRecover_IO_recoverFromNonFatalShouldRecoverFromNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 123
+      val actual            = CanRecover[IO]
+        .recoverFromNonFatal(fa) {
+          case NonFatal(`expectedExpcetion`) =>
+            expected
+        }
+        .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+
+      val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123 }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Int](1)
+      val expected = 1
+      val actual   = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999 }.unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalEitherShouldRecoverFromNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+      val actualFailedResult   = CanRecover[IO]
+        .recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => expectedFailedResult }
+        .unsafeRunSync()
+
+      val expectedSuccessResult = 1.asRight[SomeError]
+      val actualSuccessResult   = CanRecover[IO]
+        .recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 1.asRight[SomeError] }
+        .unsafeRunSync()
+
+      actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+      val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999.asRight[SomeError] }.unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }.unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanRecover_IO_recoverEitherFromNonFatalShouldRecoverFromNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult    =
+        CanRecover[IO]
+          .recoverEitherFromNonFatal(fa) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+          .unsafeRunSync()
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   =
+        CanRecover[IO]
+          .recoverEitherFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+          .unsafeRunSync()
+
+      actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+      val io =
+        CanRecover[IO].recoverEitherFromNonFatal(fa) {
+          case err => SomeError.someThrowable(err).asLeft[Int]
+        }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        CanRecover[IO]
+          .recoverEitherFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+          .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanRecover[IO]
+          .recoverEitherFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+          .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanRecover_IO_recoverEitherTFromNonFatalShouldRecoverFromNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult    =
+        CanRecover[IO]
+          .recoverEitherTFromNonFatal(fa) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+          .value
+          .unsafeRunSync()
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   =
+        CanRecover[IO]
+          .recoverEitherTFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+          .value
+          .unsafeRunSync()
+
+      actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+
+      val io =
+        CanRecover[IO].recoverEitherTFromNonFatal(fa) {
+          case err => SomeError.someThrowable(err).asLeft[Int]
+        }
+      try {
+        val actual = io.value.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult: Result = {
+
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        CanRecover[IO]
+          .recoverEitherTFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+          .value
+          .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+    def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanRecover[IO]
+          .recoverEitherTFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+          .value
+          .unsafeRunSync()
+
+      actual ==== expected
+    }
+
+  }
+
+}

--- a/modules/effectie-cats-effect2/shared/src/test/scala/effectie/instances/ce2/f/fromFutureSpec.scala
+++ b/modules/effectie-cats-effect2/shared/src/test/scala/effectie/instances/ce2/f/fromFutureSpec.scala
@@ -1,0 +1,43 @@
+package effectie.instances.ce2.f
+
+import cats.effect._
+import effectie.core.FromFuture
+import effectie.instances.ce2.compat.CatsEffectIoCompatForFuture
+import extras.concurrent.testing.ConcurrentSupport
+import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
+import effectie.instances.ce2.f.fromFuture.fromFutureToAsync
+import hedgehog._
+import hedgehog.runner._
+
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+/** @author Kevin Lee
+  * @since 2020-09-22
+  */
+object fromFutureSpec extends Properties {
+  implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+  private val waitFor300Millis = WaitFor(300.milliseconds)
+
+  override def tests: List[Test] = List(
+    property("test FromFuture[IO].toEffect", IoSpec.testToEffect)
+  )
+
+  object IoSpec {
+    def testToEffect: Property = for {
+      a <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("a")
+    } yield {
+      val compat = new CatsEffectIoCompatForFuture
+      import compat.{es, ec, cs}
+
+      ConcurrentSupport.runAndShutdown(es, waitFor300Millis) {
+        lazy val fa = Future(a)
+        val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
+
+        actual ==== a
+      }
+    }
+  }
+
+}

--- a/modules/effectie-cats-effect2/shared/src/test/scala/effectie/instances/ce2/f/fxCtorSpec.scala
+++ b/modules/effectie-cats-effect2/shared/src/test/scala/effectie/instances/ce2/f/fxCtorSpec.scala
@@ -1,0 +1,76 @@
+package effectie.instances.ce2.f
+
+import cats.effect._
+import effectie.specs.fxCtorSpec.FxCtorSpecs
+import effectie.testing.tools
+import effectie.instances.ce2.f.fxCtor.syncFxCtor
+import extras.concurrent.testing.types.ErrorLogger
+import hedgehog._
+import hedgehog.runner._
+
+/** @author Kevin Lee
+  * @since 2020-12-06
+  */
+object fxCtorSpec extends Properties {
+
+  override def tests: List[Test] =
+    ioSpecs
+
+  private val assertWithAttempt: (IO[Int], Either[Throwable, Int]) => Result = { (io, expected) =>
+    val actual = io.attempt.unsafeRunSync()
+    (actual ==== expected).log(s"$actual does not equal to $expected")
+  }
+
+  implicit private val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+  private val unit: Unit = ()
+
+  private val ioSpecs = List(
+    property("test FxCtor[IO].effectOf", FxCtorSpecs.testEffectOf[IO](_.unsafeRunSync() ==== unit)),
+    property("test FxCtor[IO].fromEffect(effectOf)", FxCtorSpecs.testFromEffect[IO](_.unsafeRunSync() ==== unit)),
+    property("test FxCtor[IO].fromEffect(pureOf)", FxCtorSpecs.testFromEffectWithPure[IO](_.unsafeRunSync() ==== unit)),
+    property("test FxCtor[IO].pureOf", FxCtorSpecs.testPureOf[IO](_.unsafeRunSync() ==== unit)),
+    property(
+      "test FxCtor[IO].pureOrError(success case)",
+      FxCtorSpecs.testPureOrErrorSuccessCase[IO](_.unsafeRunSync() ==== unit),
+    ),
+    example(
+      "test FxCtor[IO].pureOrError(error case)",
+      FxCtorSpecs.testPureOrErrorErrorCase[IO] { (io, expected) =>
+        tools.expectThrowable(io.unsafeRunSync(), expected)
+      },
+    ),
+    example("test FxCtor[IO].unitOf", FxCtorSpecs.testUnitOf[IO](_.unsafeRunSync() ==== unit)),
+    example(
+      "test FxCtor[IO].errorOf",
+      FxCtorSpecs.testErrorOf[IO] { (io, expected) =>
+        tools.expectThrowable(io.unsafeRunSync(), expected)
+      },
+    ),
+    property(
+      "test FxCtor[IO].fromEither(Right)",
+      FxCtorSpecs.testFromEitherRightCase[IO](assertWithAttempt),
+    ),
+    property(
+      "test FxCtor[IO].fromEither(Left)",
+      FxCtorSpecs.testFromEitherLeftCase[IO](assertWithAttempt),
+    ),
+    property(
+      "test FxCtor[IO].fromOption(Some)",
+      FxCtorSpecs.testFromOptionSomeCase[IO](assertWithAttempt),
+    ),
+    property(
+      "test FxCtor[IO].fromOption(None)",
+      FxCtorSpecs.testFromOptionNoneCase[IO](assertWithAttempt),
+    ),
+    property(
+      "test FxCtor[IO].fromTry(Success)",
+      FxCtorSpecs.testFromTrySuccessCase[IO](assertWithAttempt),
+    ),
+    property(
+      "test FxCtor[IO].fromTry(Failure)",
+      FxCtorSpecs.testFromTryFailureCase[IO](assertWithAttempt),
+    ),
+  )
+
+}

--- a/modules/effectie-cats-effect2/shared/src/test/scala/effectie/instances/ce2/f/fxSpec.scala
+++ b/modules/effectie-cats-effect2/shared/src/test/scala/effectie/instances/ce2/f/fxSpec.scala
@@ -1,0 +1,1504 @@
+package effectie.instances.ce2.f
+
+import cats.data.EitherT
+import cats.effect._
+import cats.syntax.all._
+import cats.{Eq, Functor}
+import effectie.SomeControlThrowable
+import effectie.core._
+import effectie.instances.ce2.f.fx.syncFx
+import effectie.specs.MonadSpec
+import effectie.specs.fxSpec.FxSpecs
+import effectie.syntax.error._
+import effectie.testing.tools
+import effectie.testing.types.SomeError
+import extras.concurrent.testing.types.ErrorLogger
+import hedgehog._
+import hedgehog.runner._
+
+import scala.util.control.{ControlThrowable, NonFatal}
+
+/** @author Kevin Lee
+  * @since 2020-12-06
+  */
+object fxSpec extends Properties {
+
+  override def tests: List[Test] = ioSpecs
+
+  private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+  private val assertWithAttempt: (IO[Int], Either[Throwable, Int]) => Result = { (io, expected) =>
+    val actual = io.attempt.unsafeRunSync()
+    (actual ==== expected).log(s"$actual does not equal to $expected")
+  }
+
+  private val unit: Unit = ()
+
+  /* IO */
+  private val ioSpecs = List(
+    property("test Fx[IO].effectOf", FxSpecs.testEffectOf[IO](_.unsafeRunSync() ==== unit)),
+    property("test Fx[IO].fromEffect(effectOf)", FxSpecs.testFromEffect[IO](_.unsafeRunSync() ==== unit)),
+    property("test Fx[IO].fromEffect(pureOf)", FxSpecs.testFromEffectWithPure[IO](_.unsafeRunSync() ==== unit)),
+    property("test Fx[IO].pureOf", FxSpecs.testPureOf[IO](_.unsafeRunSync() ==== unit)),
+    property(
+      "test Fx[IO].pureOrError(success case)",
+      FxSpecs.testPureOrErrorSuccessCase[IO](_.unsafeRunSync() ==== unit),
+    ),
+    example(
+      "test Fx[IO].pureOrError(error case)",
+      FxSpecs.testPureOrErrorErrorCase[IO] { (io, expected) =>
+        tools.expectThrowable(io.unsafeRunSync(), expected)
+      },
+    ),
+    example("test Fx[IO].unitOf", FxSpecs.testUnitOf[IO](_.unsafeRunSync() ==== unit)),
+    example(
+      "test Fx[IO].errorOf",
+      FxSpecs.testErrorOf[IO] { (io, expected) =>
+        tools.expectThrowable(io.unsafeRunSync(), expected)
+      },
+    ),
+    property("test Fx[IO].fromEither(Right)", FxSpecs.testFromEitherRightCase[IO](assertWithAttempt)),
+    property("test Fx[IO].fromEither(Left)", FxSpecs.testFromEitherLeftCase[IO](assertWithAttempt)),
+    property("test Fx[IO].fromOption(Some)", FxSpecs.testFromOptionSomeCase[IO](assertWithAttempt)),
+    property("test Fx[IO].fromOption(None)", FxSpecs.testFromOptionNoneCase[IO](assertWithAttempt)),
+    property("test Fx[IO].fromTry(Success)", FxSpecs.testFromTrySuccessCase[IO](assertWithAttempt)),
+    property("test Fx[IO].fromTry(Failure)", FxSpecs.testFromTryFailureCase[IO](assertWithAttempt)),
+  ) ++
+    IoSpec.testMonadLaws ++
+    List(
+      example(
+        "test Fx[IO]catchNonFatalThrowable should catch NonFatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalThrowableShouldCatchNonFatal,
+      ),
+      example(
+        "test Fx[IO]catchNonFatalThrowable should not catch Fatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalThrowableShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO]catchNonFatalThrowable should return the successful result",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalThrowableShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO]catchNonFatal should catch NonFatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalShouldCatchNonFatal,
+      ),
+      example(
+        "test Fx[IO]catchNonFatal should not catch Fatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO]catchNonFatal should return the successful result",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO]catchNonFatalEither should catch NonFatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherShouldCatchNonFatal,
+      ),
+      example(
+        "test Fx[IO]catchNonFatalEither should not catch Fatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO]catchNonFatalEither should return the successful result",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO]catchNonFatalEither should return the failed result",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO]catchNonFatalEitherT should catch NonFatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherTShouldCatchNonFatal,
+      ),
+      example(
+        "test Fx[IO]catchNonFatalEitherT should not catch Fatal",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherTShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO]catchNonFatalEitherT should return the successful result",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherTShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO]catchNonFatalEitherT should return the failed result",
+        IoSpec.CanCatchSpec.testFx_IO_catchNonFatalEitherTShouldReturnFailedResult,
+      ),
+    ) ++
+    List(
+      /* IO */
+      example(
+        "test Fx[IO].handleNonFatalWith should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalWith should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalWith should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalWithEither should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalWithEither should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalWithEither should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalWithEither should return the failed result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatalWith should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldHandleNonFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatalWith should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatalWith should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatalWith should return the failed result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatalWith should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatalWith should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatalWith should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatalWith should return the failed result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].handleNonFatal should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalShouldHandleNonFatal,
+      ),
+      example(
+        "test Fx[IO].handleNonFatal should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalShouldNotHandleFatal,
+      ),
+      example(
+        "test Fx[IO].handleNonFatal should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalEither should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalEither should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalEither should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalEither should return the failed result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatal should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalShouldHandleNonFatal,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatal should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatal should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatal should return the failed result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatal should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatal should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatal should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatal should return the failed result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult,
+      ),
+    ) ++ List(
+      example(
+        "test Fx[IO].recoverFromNonFatalWith should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalWith should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalWith should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalWithEither should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalWithEither should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalWithEither should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalWithEither should return the failed result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatalWith should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatalWith should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatalWith should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatalWith should return the failed result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatalWith should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatalWith should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatalWith should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatalWith should return the failed result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatal should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatal should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatal should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalEither should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalEither should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalEither should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalEither should return the failed result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatal should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatal should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatal should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatal should return the failed result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatal should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatal should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatal should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatal should return the failed result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnFailedResult,
+      ),
+    )
+
+  def throwThrowable[A](throwable: => Throwable): A =
+    throw throwable // scalafix:ok DisableSyntax.throw
+
+  def run[F[*]: Fx: Functor, A](a: => A): F[A] =
+    Fx[F].effectOf(a)
+
+  object IoSpec {
+
+    def testMonadLaws: List[Test] = {
+      import cats.syntax.eq._
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).unsafeRunSync()
+
+      MonadSpec.testMonadLaws[IO]("IO")
+    }
+
+    object CanCatchSpec {
+
+      def testFx_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+        val expected          = expectedExpcetion.asLeft[Int]
+        val actual            = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testFx_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testFx_IO_catchNonFatalThrowableShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Int](1)
+        val expected = 1.asRight[Throwable]
+        val actual   = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testFx_IO_catchNonFatalShouldCatchNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+        val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actual            = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testFx_IO_catchNonFatalShouldNotCatchFatal: Result = {
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testFx_IO_catchNonFatalShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Int](1)
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testFx_IO_catchNonFatalEitherShouldCatchNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa       = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actual   = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testFx_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testFx_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testFx_IO_catchNonFatalEitherShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testFx_IO_catchNonFatalEitherTShouldCatchNonFatal: Result = {
+
+        val expectedExpcetion               = new RuntimeException("Something's wrong")
+        val fa: EitherT[IO, SomeError, Int] = EitherT(
+          run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        )
+        val expected                        = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actual = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testFx_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+        try {
+          val actual = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testFx_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = {
+
+        val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testFx_IO_catchNonFatalEitherTShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+
+        actual ==== expected
+      }
+
+    }
+
+    object CanHandleErrorSpec {
+
+      def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+        val expected          = 123
+        val actual            = Fx[IO]
+          .handleNonFatalWith(fa) {
+            case NonFatal(`expectedExpcetion`) =>
+              IO.pure(expected)
+          }
+          .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Int](1)
+        val expected = 1
+        val actual   = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(999)).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+        val actualFailedResult   =
+          Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(expectedFailedResult)).unsafeRunSync()
+
+        val expectedSuccessResult = 1.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(1.asRight[SomeError])).unsafeRunSync()
+
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].handleNonFatalWith(fa)(_ => IO(999.asRight[SomeError])).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleEitherNonFatalWithShouldHandleNonFatalWith: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    = Fx[IO]
+          .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+          .unsafeRunSync()
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+        try {
+          val actual =
+            Fx[IO]
+              .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   =
+          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    = Fx[IO]
+          .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+          .value
+          .unsafeRunSync()
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
+
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+        try {
+          val actual =
+            Fx[IO]
+              .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+              .value
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+        val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+        val expected = 1.asRight[SomeError]
+        val actual   =
+          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value.unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleNonFatalShouldHandleNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+        val expected          = 123
+        val actual            = Fx[IO]
+          .handleNonFatal(fa) {
+            case NonFatal(`expectedExpcetion`) =>
+              expected
+          }
+          .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Int](1)
+        val expected = 1
+        val actual   = Fx[IO].handleNonFatal(fa)(_ => 999).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+        val actualFailedResult   = Fx[IO].handleNonFatal(fa)(_ => expectedFailedResult).unsafeRunSync()
+
+        val expectedSuccessResult = 1.asRight[SomeError]
+        val actualSuccessResult   = Fx[IO].handleNonFatal(fa)(_ => 1.asRight[SomeError]).unsafeRunSync()
+
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].handleNonFatal(fa)(_ => 999.asRight[SomeError]).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleEitherNonFatalShouldHandleNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    = Fx[IO]
+          .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+          .unsafeRunSync()
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+        try {
+          val actual =
+            Fx[IO]
+              .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleEitherNonFatalShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    = Fx[IO]
+          .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+          .value
+          .unsafeRunSync()
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
+
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+        try {
+          val actual =
+            Fx[IO]
+              .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+              .value
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = {
+
+        val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value.unsafeRunSync()
+
+        actual ==== expected
+      }
+
+    }
+
+    object CanRecoverSpec {
+
+      def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+        val expected          = 123
+        val actual            = Fx[IO]
+          .recoverFromNonFatalWith(fa) {
+            case NonFatal(`expectedExpcetion`) =>
+              IO.pure(expected)
+          }
+          .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+
+        val io = Fx[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedExpcetion`) => IO.pure(123) }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Int](1)
+        val expected = 1
+        val actual   = Fx[IO]
+          .recoverFromNonFatalWith(fa) {
+            case NonFatal(_) => IO.pure(999)
+          }
+          .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+        val actualFailedResult   = Fx[IO]
+          .recoverFromNonFatalWith(fa) {
+            case NonFatal(`expectedExpcetion`) => IO.pure(expectedFailedResult)
+          }
+          .unsafeRunSync()
+
+        val expectedSuccessResult = 1.asRight[SomeError]
+        val actualSuccessResult   = Fx[IO]
+          .recoverFromNonFatalWith(fa) {
+            case NonFatal(`expectedExpcetion`) => IO.pure(1.asRight[SomeError])
+          }
+          .unsafeRunSync()
+
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+        val io = Fx[IO].recoverFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
+        }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO]
+          .recoverFromNonFatalWith(fa) {
+            case NonFatal(_) => IO(999.asRight[SomeError])
+          }
+          .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          = Fx[IO]
+          .recoverFromNonFatalWith(fa) {
+            case NonFatal(_) => IO.pure(123.asRight[SomeError])
+          }
+          .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    = Fx[IO]
+          .recoverEitherFromNonFatalWith(fa) {
+            case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          }
+          .unsafeRunSync()
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   = Fx[IO]
+          .recoverEitherFromNonFatalWith(fa) {
+            case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
+          }
+          .unsafeRunSync()
+
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+        val io = Fx[IO].recoverEitherFromNonFatalWith(fa) {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO]
+          .recoverEitherFromNonFatalWith(fa) {
+            case NonFatal(_) => IO.pure(123.asRight[SomeError])
+          }
+          .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO]
+            .recoverEitherFromNonFatalWith(fa) {
+              case NonFatal(_) => IO.pure(123.asRight[SomeError])
+            }
+            .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    = Fx[IO]
+          .recoverEitherTFromNonFatalWith(fa) {
+            case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          }
+          .value
+          .unsafeRunSync()
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   = Fx[IO]
+          .recoverEitherTFromNonFatalWith(fa) {
+            case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
+          }
+          .value
+          .unsafeRunSync()
+
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+
+        val io = Fx[IO].recoverEitherTFromNonFatalWith(fa) {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+        try {
+          val actual = io.value.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+        val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO]
+          .recoverEitherTFromNonFatalWith(fa) {
+            case NonFatal(_) => IO.pure(123.asRight[SomeError])
+          }
+          .value
+          .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO]
+            .recoverEitherTFromNonFatalWith(fa) {
+              case NonFatal(_) => IO.pure(123.asRight[SomeError])
+            }
+            .value
+            .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      // /
+
+      def testCanRecover_IO_recoverFromNonFatalShouldRecoverFromNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+        val expected          = 123
+        val actual            = Fx[IO]
+          .recoverFromNonFatal(fa) {
+            case NonFatal(`expectedExpcetion`) =>
+              expected
+          }
+          .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+
+        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123 }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Int](1)
+        val expected = 1
+        val actual   = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999 }.unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalEitherShouldRecoverFromNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+        val actualFailedResult   = Fx[IO]
+          .recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => expectedFailedResult }
+          .unsafeRunSync()
+
+        val expectedSuccessResult = 1.asRight[SomeError]
+        val actualSuccessResult   = Fx[IO]
+          .recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 1.asRight[SomeError] }
+          .unsafeRunSync()
+
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999.asRight[SomeError] }.unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }.unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanRecover_IO_recoverEitherFromNonFatalShouldRecoverFromNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    =
+          Fx[IO]
+            .recoverEitherFromNonFatal(fa) {
+              case err => SomeError.someThrowable(err).asLeft[Int]
+            }
+            .unsafeRunSync()
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO]
+            .recoverEitherFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+            .unsafeRunSync()
+
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+        val io =
+          Fx[IO].recoverEitherFromNonFatal(fa) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult: Result = {
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   =
+          Fx[IO]
+            .recoverEitherFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+            .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO]
+            .recoverEitherFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+            .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanRecover_IO_recoverEitherTFromNonFatalShouldRecoverFromNonFatal: Result = {
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+        val expectedFailedResult  = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult    =
+          Fx[IO]
+            .recoverEitherTFromNonFatal(fa) {
+              case err => SomeError.someThrowable(err).asLeft[Int]
+            }
+            .value
+            .unsafeRunSync()
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO]
+            .recoverEitherTFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+            .value
+            .unsafeRunSync()
+
+        actualFailedResult ==== expectedFailedResult and actualSuccessResult ==== expectedSuccessResult
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+
+        val io =
+          Fx[IO].recoverEitherTFromNonFatal(fa) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+        try {
+          val actual = io.value.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult: Result = {
+
+        val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+        val expected = 1.asRight[SomeError]
+        val actual   =
+          Fx[IO]
+            .recoverEitherTFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+            .value
+            .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+      def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnFailedResult: Result = {
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO]
+            .recoverEitherTFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+            .value
+            .unsafeRunSync()
+
+        actual ==== expected
+      }
+
+    }
+
+  }
+
+}

--- a/modules/effectie-cats-effect3/shared/src/main/scala/effectie/instances/ce3/f/canCatch.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala/effectie/instances/ce3/f/canCatch.scala
@@ -1,0 +1,20 @@
+package effectie.instances.ce3.f
+
+import cats.effect.Sync
+import effectie.core.{CanCatch, FxCtor}
+
+/** @author Kevin Lee
+  * @since 2020-06-07
+  */
+object canCatch {
+
+  implicit def syncCanCatch[F[*]: Sync]: CanCatch[F] = new CanCatch[F] {
+
+    override implicit protected val fxCtor: FxCtor[F] = effectie.instances.ce3.f.fxCtor.syncFxCtor
+
+    @inline override final def catchNonFatalThrowable[A](fa: => F[A]): F[Either[Throwable, A]] =
+      Sync[F].attempt(fa)
+
+  }
+
+}

--- a/modules/effectie-cats-effect3/shared/src/main/scala/effectie/instances/ce3/f/canHandleError.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala/effectie/instances/ce3/f/canHandleError.scala
@@ -1,0 +1,22 @@
+package effectie.instances.ce3.f
+
+import cats.effect.Sync
+import cats.syntax.all._
+import effectie.core.CanHandleError
+
+/** @author Kevin Lee
+  * @since 2020-08-17
+  */
+object canHandleError {
+
+  implicit def syncCanHandleError[F[*]: Sync]: CanHandleError[F] = new CanHandleError[F] {
+
+    @inline override final def handleNonFatalWith[A, AA >: A](fa: => F[A])(handleError: Throwable => F[AA]): F[AA] =
+      Sync[F].handleErrorWith(fa.widen[AA])(handleError)
+
+    @inline override final def handleNonFatal[A, AA >: A](fa: => F[A])(handleError: Throwable => AA): F[AA] =
+      Sync[F].handleError(fa.widen[AA])(handleError)
+
+  }
+
+}

--- a/modules/effectie-cats-effect3/shared/src/main/scala/effectie/instances/ce3/f/canRecover.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala/effectie/instances/ce3/f/canRecover.scala
@@ -1,0 +1,25 @@
+package effectie.instances.ce3.f
+
+import cats.effect.Sync
+import cats.syntax.all._
+import effectie.core.CanRecover
+
+/** @author Kevin Lee
+  * @since 2020-08-17
+  */
+object canRecover {
+
+  implicit def syncCanRecover[F[*]: Sync]: CanRecover[F] = new CanRecover[F] {
+
+    @inline override final def recoverFromNonFatalWith[A, AA >: A](fa: => F[A])(
+      handleError: PartialFunction[Throwable, F[AA]]
+    ): F[AA] =
+      Sync[F].recoverWith(fa.widen[AA])(handleError)
+
+    @inline override final def recoverFromNonFatal[A, AA >: A](fa: => F[A])(
+      handleError: PartialFunction[Throwable, AA]
+    ): F[AA] =
+      Sync[F].recover(fa.widen[AA])(handleError)
+  }
+
+}

--- a/modules/effectie-cats-effect3/shared/src/main/scala/effectie/instances/ce3/f/fromFuture.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala/effectie/instances/ce3/f/fromFuture.scala
@@ -1,0 +1,20 @@
+package effectie.instances.ce3.f
+
+import cats.effect.Async
+import effectie.core.FromFuture
+
+import scala.concurrent.Future
+
+/** @author Kevin Lee
+  * @since 2020-09-22
+  */
+object fromFuture {
+
+  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
+  implicit def fromFutureToAsync[F[*]: Async]: FromFuture[F] =
+    new FromFuture[F] {
+      override def toEffect[A](future: => Future[A]): F[A] =
+        Async[F].fromFuture[A](Async[F].delay(future))
+    }
+
+}

--- a/modules/effectie-cats-effect3/shared/src/main/scala/effectie/instances/ce3/f/fx.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala/effectie/instances/ce3/f/fx.scala
@@ -1,0 +1,55 @@
+package effectie.instances.ce3.f
+
+import cats.effect.Sync
+import effectie.core.{Fx, FxCtor}
+
+import scala.util.Try
+
+object fx {
+
+  implicit def syncFx[F[*]: Sync]: Fx[F] = new Fx[F] {
+
+    override implicit protected val fxCtor: FxCtor[F] = effectie.instances.ce3.f.fxCtor.syncFxCtor
+
+    @inline override final def effectOf[A](a: => A): F[A] = fxCtor.effectOf(a)
+
+    @inline override final def fromEffect[A](fa: => F[A]): F[A] = fxCtor.fromEffect(fa)
+
+    @inline override final def pureOf[A](a: A): F[A] = fxCtor.pureOf(a)
+
+    @inline override final def pureOrError[A](a: => A): F[A] = fxCtor.pureOrError(a)
+
+    @inline override val unitOf: F[Unit] = fxCtor.unitOf
+
+    @inline override final def errorOf[A](throwable: Throwable): F[A] = fxCtor.errorOf(throwable)
+
+    @inline override final def fromEither[A](either: Either[Throwable, A]): F[A] = fxCtor.fromEither(either)
+
+    @inline override final def fromOption[A](option: Option[A])(orElse: => Throwable): F[A] =
+      fxCtor.fromOption(option)(orElse)
+
+    @inline override final def fromTry[A](tryA: Try[A]): F[A] = fxCtor.fromTry(tryA)
+
+    @inline override final def flatMapFa[A, B](fa: F[A])(f: A => F[B]): F[B] = Sync[F].flatMap(fa)(f)
+
+    @inline override final def catchNonFatalThrowable[A](fa: => F[A]): F[Either[Throwable, A]] =
+      canCatch.syncCanCatch.catchNonFatalThrowable(fa)
+
+    @inline override final def handleNonFatalWith[A, AA >: A](fa: => F[A])(handleError: Throwable => F[AA]): F[AA] =
+      canHandleError.syncCanHandleError.handleNonFatalWith[A, AA](fa)(handleError)
+
+    @inline override final def handleNonFatal[A, AA >: A](fa: => F[A])(handleError: Throwable => AA): F[AA] =
+      canHandleError.syncCanHandleError.handleNonFatal[A, AA](fa)(handleError)
+
+    @inline override final def recoverFromNonFatalWith[A, AA >: A](fa: => F[A])(
+      handleError: PartialFunction[Throwable, F[AA]]
+    ): F[AA] =
+      canRecover.syncCanRecover.recoverFromNonFatalWith[A, AA](fa)(handleError)
+
+    @inline override final def recoverFromNonFatal[A, AA >: A](fa: => F[A])(
+      handleError: PartialFunction[Throwable, AA]
+    ): F[AA] =
+      canRecover.syncCanRecover.recoverFromNonFatal[A, AA](fa)(handleError)
+  }
+
+}

--- a/modules/effectie-cats-effect3/shared/src/main/scala/effectie/instances/ce3/f/fxCtor.scala
+++ b/modules/effectie-cats-effect3/shared/src/main/scala/effectie/instances/ce3/f/fxCtor.scala
@@ -1,0 +1,34 @@
+package effectie.instances.ce3.f
+
+import cats.effect.Sync
+import effectie.core.FxCtor
+
+import scala.util.Try
+
+object fxCtor {
+
+  implicit def syncFxCtor[F[*]: Sync]: FxCtor[F] = new FxCtor[F] {
+
+    @inline override final def effectOf[A](a: => A): F[A] = Sync[F].delay(a)
+
+    @inline override final def fromEffect[A](fa: => F[A]): F[A] = Sync[F].defer(fa)
+
+    @inline override final def pureOf[A](a: A): F[A] = Sync[F].pure(a)
+
+    @inline override final def pureOrError[A](a: => A): F[A] = Sync[F].catchNonFatal(a)
+
+    @inline override val unitOf: F[Unit] = Sync[F].unit
+
+    @inline override final def errorOf[A](throwable: Throwable): F[A] = Sync[F].raiseError(throwable)
+
+    @inline override final def fromEither[A](either: Either[Throwable, A]): F[A] = Sync[F].fromEither(either)
+
+    @inline override final def fromOption[A](option: Option[A])(orElse: => Throwable): F[A] =
+      Sync[F].fromOption(option, orElse)
+
+    @inline override final def fromTry[A](tryA: Try[A]): F[A] = Sync[F].fromTry(tryA)
+
+    @inline override final def flatMapFa[A, B](fa: F[A])(f: A => F[B]): F[B] = Sync[F].flatMap(fa)(f)
+  }
+
+}

--- a/modules/effectie-cats-effect3/shared/src/test/scala-3/effectie/instances/ce3/testing/IoAppUtils.scala
+++ b/modules/effectie-cats-effect3/shared/src/test/scala-3/effectie/instances/ce3/testing/IoAppUtils.scala
@@ -1,8 +1,7 @@
 package effectie.instances.ce3.testing
 
 import cats.effect.unsafe.{IORuntime, IORuntimeConfig}
-import extras.concurrent.testing.ConcurrentSupport
-import extras.concurrent.testing.types.ErrorLogger
+import hedgehog.core.Result
 
 import java.util.concurrent.ExecutorService
 
@@ -10,6 +9,17 @@ import java.util.concurrent.ExecutorService
   * @since 2021-07-22
   */
 object IoAppUtils {
+
+  def runWithRuntime(runtime: IORuntime)(test: IORuntime => Result): Result = {
+    try test(runtime)
+    finally runtime.shutdown()
+  }
+
+  def computeWorkerThreadCount: Int = {
+    val num = Math.max(2, Runtime.getRuntime.availableProcessors())
+    println(s"Worker thread count: ${num.toString}")
+    num
+  }
 
   def runtime(es: ExecutorService): IORuntime = runtime()
 

--- a/modules/effectie-cats-effect3/shared/src/test/scala/effectie/instances/ce3/f/canCatchSpec.scala
+++ b/modules/effectie-cats-effect3/shared/src/test/scala/effectie/instances/ce3/f/canCatchSpec.scala
@@ -1,0 +1,292 @@
+package effectie.instances.ce3.f
+
+import effectie.instances.ce3.f.canCatch._
+import cats._
+import cats.data.EitherT
+import cats.effect._
+import cats.instances.all._
+import cats.syntax.all._
+import effectie.SomeControlThrowable
+import effectie.core._
+import effectie.syntax.error._
+import effectie.syntax.fx._
+import effectie.testing.types._
+import effectie.instances.ce3.testing
+import extras.concurrent.testing.ConcurrentSupport
+import extras.concurrent.testing.types.ErrorLogger
+import extras.hedgehog.ce3.syntax.runner._
+import effectie.instances.ce3.f.fxCtor._
+import hedgehog._
+import hedgehog.runner._
+
+import java.util.concurrent.ExecutorService
+
+/** @author Kevin Lee
+  * @since 2020-07-31
+  */
+object canCatchSpec extends Properties {
+
+  implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+  override def tests: List[Test] = ioSpecs
+
+  val ioSpecs = List(
+    /* IO */
+    example(
+      "test CanCatch[IO]catchNonFatalThrowable should catch NonFatal",
+      IoSpec.testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalThrowable should not catch Fatal",
+      IoSpec.testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalThrowable should return the successful result",
+      IoSpec.testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatal should catch NonFatal",
+      IoSpec.testCanCatch_IO_catchNonFatalShouldCatchNonFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatal should not catch Fatal",
+      IoSpec.testCanCatch_IO_catchNonFatalShouldNotCatchFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatal should return the successful result",
+      IoSpec.testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEither should catch NonFatal",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEither should not catch Fatal",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEither should return the successful result",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEither should return the failed result",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEitherT should catch NonFatal",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEitherT should not catch Fatal",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEitherT should return the successful result",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanCatch[IO]catchNonFatalEitherT should return the failed result",
+      IoSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult,
+    ),
+  )
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def throwThrowable[A](throwable: => Throwable): A =
+    throw throwable // scalafix:ok DisableSyntax.throw
+
+  def run[F[*]: FxCtor: Functor, A](a: => A): F[A] =
+    effectOf[F](a)
+
+  object IoSpec {
+
+    def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = expectedExpcetion.asLeft[Int]
+      val actual            = CanCatch[IO].catchNonFatalThrowable(fa)
+
+      actual.completeAs(expected)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
+
+      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
+
+      testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+        try {
+          val actual = CanCatch[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+      }
+
+    }
+
+    def testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa: IO[Int] = run[IO, Int](1)
+      val expected    = 1.asRight[Throwable]
+      val actual      = CanCatch[IO].catchNonFatalThrowable(fa)
+
+      actual.completeAs(expected)
+    }
+
+    def testCanCatch_IO_catchNonFatalShouldCatchNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable)
+
+      actual.completeAs(expected)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
+
+      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
+      testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+        try {
+          val actual = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+      }
+
+    }
+
+    def testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa: IO[Int] = run[IO, Int](1)
+      val expected    = 1.asRight[SomeError]
+      val actual      = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable)
+
+      actual.completeAs(expected)
+    }
+
+    def testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual            = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable)
+
+      actual.completeAs(expected)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
+
+      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
+      testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+        try {
+          val actual = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+      }
+    }
+
+    def testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable)
+
+      actual.completeAs(expected)
+    }
+
+    def testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable)
+
+      actual.completeAs(expected)
+    }
+
+    def testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actual   = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
+
+      actual.completeAs(expected)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
+
+      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
+      testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+        try {
+          val actual = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+      }
+
+    }
+
+    def testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected = 1.asRight[SomeError]
+      val actual   = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
+
+      actual.completeAs(expected)
+    }
+
+    def testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
+
+      actual.completeAs(expected)
+    }
+
+  }
+
+}

--- a/modules/effectie-cats-effect3/shared/src/test/scala/effectie/instances/ce3/f/canHandleErrorSpec.scala
+++ b/modules/effectie-cats-effect3/shared/src/test/scala/effectie/instances/ce3/f/canHandleErrorSpec.scala
@@ -1,0 +1,1613 @@
+package effectie.instances.ce3.f
+
+import canHandleError._
+import cats._
+import cats.data.EitherT
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import cats.instances.all._
+import cats.syntax.all._
+import effectie.SomeControlThrowable
+import effectie.core._
+import effectie.syntax.error._
+import effectie.syntax.fx._
+import effectie.testing.types.SomeError
+import effectie.instances.ce3.testing
+import extras.concurrent.testing.ConcurrentSupport
+import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
+import extras.hedgehog.ce3.syntax.runner._
+import fxCtor._
+import hedgehog._
+import hedgehog.runner._
+
+import java.util.concurrent.ExecutorService
+import scala.util.control.{ControlThrowable, NonFatal}
+
+/** @author Kevin Lee
+  * @since 2020-08-17
+  */
+object canHandleErrorSpec extends Properties {
+
+  implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+  override def tests: List[Test] = ioSpecs ++ futureSpecs ++ idSpecs
+
+  /* IO */
+  private val ioSpecs =
+    List(
+      example(
+        "test CanHandleError[IO].handleNonFatalWith should handle NonFatal",
+        IoSpec.testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatalWith should not handle Fatal",
+        IoSpec.testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatalWith should return the successful result",
+        IoSpec.testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatalWithEither should handle NonFatal",
+        IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatalWithEither should not handle Fatal",
+        IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatalWithEither should return the successful result",
+        IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatalWithEither should return the failed result",
+        IoSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherNonFatalWith should handle NonFatal",
+        IoSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldHandleNonFatalWith,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherNonFatalWith should not handle Fatal",
+        IoSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherNonFatalWith should return the successful result",
+        IoSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherNonFatalWith should return the failed result",
+        IoSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldReturnFailedResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherTNonFatalWith should handle NonFatal",
+        IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherTNonFatalWith should not handle Fatal",
+        IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherTNonFatalWith should return the successful result",
+        IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherTNonFatalWith should return the failed result",
+        IoSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatal should handle NonFatal",
+        IoSpec.testCanHandleError_IO_handleNonFatalShouldHandleNonFatal,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatal should not handle Fatal",
+        IoSpec.testCanHandleError_IO_handleNonFatalShouldNotHandleFatal,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatal should return the successful result",
+        IoSpec.testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatalEither should handle NonFatal",
+        IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatalEither should not handle Fatal",
+        IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatalEither should return the successful result",
+        IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleNonFatalEither should return the failed result",
+        IoSpec.testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherNonFatal should handle NonFatal",
+        IoSpec.testCanHandleError_IO_handleEitherNonFatalShouldHandleNonFatal,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherNonFatal should not handle Fatal",
+        IoSpec.testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherNonFatal should return the successful result",
+        IoSpec.testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherNonFatal should return the failed result",
+        IoSpec.testCanHandleError_IO_handleEitherNonFatalShouldReturnFailedResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherTNonFatal should handle NonFatal",
+        IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherTNonFatal should not handle Fatal",
+        IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherTNonFatal should return the successful result",
+        IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test CanHandleError[IO].handleEitherTNonFatal should return the failed result",
+        IoSpec.testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult,
+      ),
+    )
+
+  /* Future */
+  private val futureSpecs = effectie.instances.future.canHandleErrorSpec.futureSpecs ++ List(
+    example(
+      "test CanHandleError[Future].handleEitherTNonFatalWith should handle NonFatal",
+      FutureSpec.testCanHandleError_Future_handleEitherTNonFatalWithShouldHandleNonFatalWith,
+    ),
+    example(
+      "test CanHandleError[Future].handleEitherTNonFatalWith should return the successful result",
+      FutureSpec.testCanHandleError_Future_handleEitherTNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[Future].handleEitherTNonFatalWith should return the failed result",
+      FutureSpec.testCanHandleError_Future_handleEitherTNonFatalWithShouldReturnFailedResult,
+    ),
+    example(
+      "test CanHandleError[Future].handleEitherTNonFatal should handle NonFatal",
+      FutureSpec.testCanHandleError_Future_handleEitherTNonFatalShouldHandleNonFatal,
+    ),
+    example(
+      "test CanHandleError[Future].handleEitherTNonFatal should return the successful result",
+      FutureSpec.testCanHandleError_Future_handleEitherTNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[Future].handleEitherTNonFatal should return the failed result",
+      FutureSpec.testCanHandleError_Future_handleEitherTNonFatalShouldReturnFailedResult,
+    ),
+  )
+
+  /* Id */
+  private val idSpecs = List(
+    example(
+      "test CanHandleError[Id].handleNonFatalWith should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalWith should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithShouldNotHandleFatalWith,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalWith should return the successful result",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalWithEither should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithEitherShouldHandleNonFatalWith,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalWithEither should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithEitherShouldNotHandleFatalWith,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalWithEither should return the successful result",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithEitherShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalWithEither should return the failed result",
+      IdSpec.testCanHandleError_Id_handleNonFatalWithEitherShouldReturnFailedResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherNonFatalWith should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleEitherNonFatalWithShouldHandleNonFatalWith,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherNonFatalWith should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleEitherNonFatalWithShouldNotHandleFatalWith,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherNonFatalWith should return the successful result",
+      IdSpec.testCanHandleError_Id_handleEitherNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherNonFatalWith should return the failed result",
+      IdSpec.testCanHandleError_Id_handleEitherNonFatalWithShouldReturnFailedResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatalWith should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalWithShouldHandleNonFatalWith,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatalWith should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalWithShouldNotHandleFatalWith,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatalWith should return the successful result",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatalWith should return the failed result",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalWithShouldReturnFailedResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatal should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalShouldHandleNonFatal,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatal should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalShouldNotHandleFatal,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatal should return the successful result",
+      IdSpec.testCanHandleError_Id_handleNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalEither should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalEitherShouldHandleNonFatal,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalEither should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleNonFatalEitherShouldNotHandleFatal,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalEither should return the successful result",
+      IdSpec.testCanHandleError_Id_handleNonFatalEitherShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleNonFatalEither should return the failed result",
+      IdSpec.testCanHandleError_Id_handleNonFatalEitherShouldReturnFailedResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherNonFatal should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleEitherNonFatalShouldHandleNonFatal,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherNonFatal should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleEitherNonFatalShouldNotHandleFatal,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherNonFatal should return the successful result",
+      IdSpec.testCanHandleError_Id_handleEitherNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherNonFatal should return the failed result",
+      IdSpec.testCanHandleError_Id_handleEitherNonFatalShouldReturnFailedResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatal should handle NonFatal",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalShouldHandleNonFatal,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatal should not handle Fatal",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalShouldNotHandleFatal,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatal should return the successful result",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanHandleError[Id].handleEitherTNonFatal should return the failed result",
+      IdSpec.testCanHandleError_Id_handleEitherTNonFatalShouldReturnFailedResult,
+    ),
+  )
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def throwThrowable[A](throwable: => Throwable): A =
+    throw throwable // scalafix:ok DisableSyntax.throw
+
+  def run[F[*]: FxCtor: Functor, A](a: => A): F[A] =
+    effectOf[F](a)
+
+  object IoSpec {
+
+    def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 123
+      val actual            = CanHandleError[IO]
+        .handleNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) =>
+            IO.pure(expected)
+        }
+
+      actual.completeAs(expected)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
+
+      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+      try {
+        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = run[IO, Int](1)
+      val expected = 1
+      val actual   = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(999))
+
+      actual.completeAs(expected)
+    }
+
+    def testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+      val actualFailedResult   =
+        CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(expectedFailedResult))
+
+      val expectedSuccessResult = 1.asRight[SomeError]
+      val actualSuccessResult   =
+        CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(1.asRight[SomeError]))
+
+      actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
+
+      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: SomeControlThrowable =>
+          ex.getMessage ==== fatalExpcetion.getMessage
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO(999.asRight[SomeError]))
+
+      actual.completeAs(expected)
+    }
+
+    def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
+
+      actual.completeAs(expected)
+    }
+
+    def testCanHandleError_IO_handleEitherNonFatalWithShouldHandleNonFatalWith: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   = CanHandleError[IO]
+        .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   =
+        CanHandleError[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
+
+      actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
+
+      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual =
+          CanHandleError[IO]
+            .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+            .unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        CanHandleError[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
+
+      actual.completeAs(expected)
+    }
+
+    def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanHandleError[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
+
+      actual.completeAs(expected)
+    }
+
+    def testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   = CanHandleError[IO]
+        .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+        .value
+
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   =
+        CanHandleError[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value
+
+      actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
+
+      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+      try {
+        val actual =
+          CanHandleError[IO]
+            .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+            .value
+            .unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result =
+      withIO { implicit ticker =>
+
+        val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+        val expected = 1.asRight[SomeError]
+        val actual   =
+          CanHandleError[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value
+
+        actual.completeAs(expected)
+      }
+
+    def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanHandleError[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value
+
+      actual.completeAs(expected)
+    }
+
+    def testCanHandleError_IO_handleNonFatalShouldHandleNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 123
+      val actual            = CanHandleError[IO]
+        .handleNonFatal(fa) {
+          case NonFatal(`expectedExpcetion`) =>
+            expected
+        }
+
+      actual.completeAs(expected)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
+
+      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+      try {
+        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = run[IO, Int](1)
+      val expected = 1
+      val actual   = CanHandleError[IO].handleNonFatal(fa)(_ => 999)
+
+      actual.completeAs(expected)
+    }
+
+    def testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+      val actualFailedResult   = CanHandleError[IO].handleNonFatal(fa)(_ => expectedFailedResult)
+
+      val expectedSuccessResult = 1.asRight[SomeError]
+      val actualSuccessResult   = CanHandleError[IO].handleNonFatal(fa)(_ => 1.asRight[SomeError])
+
+      actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
+
+      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[IO].handleNonFatal(fa)(_ => 999.asRight[SomeError])
+
+      actual.completeAs(expected)
+    }
+
+    def testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError])
+
+      actual.completeAs(expected)
+    }
+
+    def testCanHandleError_IO_handleEitherNonFatalShouldHandleNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   = CanHandleError[IO]
+        .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   =
+        CanHandleError[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError])
+
+      actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
+
+      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual =
+          CanHandleError[IO]
+            .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+            .unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError])
+
+      actual.completeAs(expected)
+    }
+
+    def testCanHandleError_IO_handleEitherNonFatalShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanHandleError[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError])
+
+      actual.completeAs(expected)
+    }
+
+    def testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   = CanHandleError[IO]
+        .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+        .value
+
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   =
+        CanHandleError[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value
+
+      actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
+
+      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+      try {
+        val actual =
+          CanHandleError[IO]
+            .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+            .value
+            .unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value
+
+      actual.completeAs(expected)
+    }
+
+    def testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanHandleError[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value
+
+      actual.completeAs(expected)
+    }
+
+  }
+
+  object FutureSpec {
+    import effectie.instances.future.canHandleError._
+    import effectie.instances.future.fxCtor._
+
+    import java.util.concurrent.{ExecutorService, Executors}
+    import scala.concurrent.duration._
+    import scala.concurrent.{ExecutionContext, Future}
+
+    val waitFor = WaitFor(1.second)
+
+    def testCanHandleError_Future_handleNonFatalWithShouldHandleNonFatalWith: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[Future, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 1
+      val actual            = ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(CanHandleError[Future].handleNonFatalWith(fa)(_ => Future(expected)))
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val fa       = run[Future, Int](1)
+      val expected = 1
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(CanHandleError[Future].handleNonFatalWith(fa)(_ => Future(123)))
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   =
+        ConcurrentSupport.futureToValue(
+          CanHandleError[Future].handleNonFatalWith(fa)(err => Future(SomeError.someThrowable(err).asLeft[Int])),
+          waitFor,
+        )
+
+      val fa2      = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected = 1.asRight[SomeError]
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(CanHandleError[Future].handleNonFatalWith(fa2)(_ => Future(expected)))
+
+      expectedFailedResult ==== actualFailedResult and actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        ConcurrentSupport.futureToValueAndTerminate(
+          executorService,
+          waitFor,
+        )(CanHandleError[Future].handleNonFatalWith(fa)(err => Future(SomeError.someThrowable(err).asLeft[Int])))
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleNonFatalWithEitherShouldReturnFailedResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(CanHandleError[Future].handleNonFatalWith(fa)(_ => Future(1.asRight[SomeError])))
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleEitherNonFatalWithShouldHandleNonFatalWith: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   = ConcurrentSupport.futureToValue(
+        CanHandleError[Future]
+          .handleEitherNonFatalWith(fa)(err => Future(SomeError.someThrowable(err).asLeft[Int])),
+        waitFor,
+      )
+
+      val fa2      = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        ConcurrentSupport.futureToValueAndTerminate(
+          executorService,
+          waitFor,
+        )(CanHandleError[Future].handleEitherNonFatalWith(fa2)(err => Future(expected)))
+
+      actualFailedResult ==== expectedFailedResult and actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(
+        CanHandleError[Future]
+          .handleEitherNonFatalWith(fa)(err => Future(SomeError.someThrowable(err).asLeft[Int]))
+      )
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleEitherNonFatalWithShouldReturnFailedResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        ConcurrentSupport.futureToValueAndTerminate(
+          executorService,
+          waitFor,
+        )(CanHandleError[Future].handleEitherNonFatalWith(fa)(_ => Future(expected)))
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   = ConcurrentSupport.futureToValue(
+        CanHandleError[Future]
+          .handleEitherTNonFatalWith(fa)(err => Future(SomeError.someThrowable(err).asLeft[Int]))
+          .value,
+        waitFor,
+      )
+
+      val fa2 = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        ConcurrentSupport.futureToValueAndTerminate(
+          executorService,
+          waitFor,
+        )(CanHandleError[Future].handleEitherTNonFatalWith(fa2)(err => Future(expected)).value)
+
+      actualFailedResult ==== expectedFailedResult and actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val fa       = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected = 1.asRight[SomeError]
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(
+        CanHandleError[Future]
+          .handleEitherTNonFatalWith(fa)(err => Future(SomeError.someThrowable(err).asLeft[Int]))
+          .value
+      )
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleEitherTNonFatalWithShouldReturnFailedResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        ConcurrentSupport.futureToValueAndTerminate(
+          executorService,
+          waitFor,
+        )(CanHandleError[Future].handleEitherTNonFatalWith(fa)(_ => Future(expected)).value)
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleNonFatalShouldHandleNonFatal: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[Future, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 1
+      val actual            = ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(CanHandleError[Future].handleNonFatal(fa)(_ => expected))
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleNonFatalShouldReturnSuccessfulResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val fa       = run[Future, Int](1)
+      val expected = 1
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(CanHandleError[Future].handleNonFatal(fa)(_ => 123))
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleNonFatalEitherShouldHandleNonFatal: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   =
+        ConcurrentSupport.futureToValue(
+          CanHandleError[Future].handleNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]),
+          waitFor,
+        )
+
+      val fa2      = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected = 1.asRight[SomeError]
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(CanHandleError[Future].handleNonFatal(fa2)(_ => expected))
+
+      expectedFailedResult ==== actualFailedResult and actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleNonFatalEitherShouldReturnSuccessfulResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        ConcurrentSupport.futureToValueAndTerminate(
+          executorService,
+          waitFor,
+        )(CanHandleError[Future].handleNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]))
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleNonFatalEitherShouldReturnFailedResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(CanHandleError[Future].handleNonFatal(fa)(_ => 1.asRight[SomeError]))
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleEitherNonFatalShouldHandleNonFatal: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   = ConcurrentSupport.futureToValue(
+        CanHandleError[Future].handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]),
+        waitFor,
+      )
+
+      val fa2      = run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        ConcurrentSupport.futureToValueAndTerminate(
+          executorService,
+          waitFor,
+        )(CanHandleError[Future].handleEitherNonFatal(fa2)(err => expected))
+
+      actualFailedResult ==== expectedFailedResult and actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleEitherNonFatalShouldReturnSuccessfulResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val fa       = run[Future, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(CanHandleError[Future].handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]))
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleEitherNonFatalShouldReturnFailedResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        ConcurrentSupport.futureToValueAndTerminate(
+          executorService,
+          waitFor,
+        )(CanHandleError[Future].handleEitherNonFatal(fa)(_ => expected))
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleEitherTNonFatalShouldHandleNonFatal: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   = ConcurrentSupport.futureToValue(
+        CanHandleError[Future].handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value,
+        waitFor,
+      )
+
+      val fa2 = EitherT(run[Future, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        ConcurrentSupport.futureToValueAndTerminate(
+          executorService,
+          waitFor,
+        )(CanHandleError[Future].handleEitherTNonFatal(fa2)(err => expected).value)
+
+      actualFailedResult ==== expectedFailedResult and actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val fa       = EitherT(run[Future, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected = 1.asRight[SomeError]
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(CanHandleError[Future].handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value)
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Future_handleEitherTNonFatalShouldReturnFailedResult: Result = {
+
+      implicit val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+      implicit val ec: ExecutionContext             =
+        ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[Future, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        ConcurrentSupport.futureToValueAndTerminate(
+          executorService,
+          waitFor,
+        )(CanHandleError[Future].handleEitherTNonFatal(fa)(_ => expected).value)
+
+      actual ==== expected
+    }
+
+  }
+
+  object IdSpec {
+    import effectie.instances.id.fxCtor._
+    import effectie.instances.id.canHandleError._
+
+    def testCanHandleError_Id_handleNonFatalWithShouldHandleNonFatalWith: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 1
+      val actual: Id[Int]   = CanHandleError[Id].handleNonFatalWith(fa)(_ => expected)
+
+      actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_Id_handleNonFatalWithShouldNotHandleFatalWith: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      lazy val fa        = run[Id, Int](throwThrowable[Int](fatalExpcetion))
+
+      try {
+        val actual: Id[Int] = CanHandleError[Id].handleNonFatalWith(fa)(_ => 1)
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_Id_handleNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+      val fa              = run[Id, Int](1)
+      val expected        = 1
+      val actual: Id[Int] = CanHandleError[Id].handleNonFatalWith(fa)(_ => 123)
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   =
+        CanHandleError[Id].handleNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+
+      lazy val fa2 = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[Id].handleNonFatalWith(fa2)(_ => expected)
+
+      actualFailedResult ==== expectedFailedResult and actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_Id_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      lazy val fa        = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual = CanHandleError[Id].handleNonFatalWith(fa)(_ => 1.asRight[SomeError])
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_Id_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[Id, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[Id].handleNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleNonFatalWithEitherShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[Id].handleNonFatalWith(fa)(_ => 1.asRight[SomeError])
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleEitherNonFatalWithShouldHandleNonFatalWith: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   =
+        CanHandleError[Id].handleEitherNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+
+      lazy val fa2 = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[Id].handleEitherNonFatalWith(fa2)(_ => expected)
+
+      actualFailedResult ==== expectedFailedResult and actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_Id_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      lazy val fa        = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual = CanHandleError[Id].handleEitherNonFatalWith(fa)(_ => 1.asRight[SomeError])
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_Id_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[Id, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        CanHandleError[Id].handleEitherNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleEitherNonFatalWithShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[Id].handleEitherNonFatalWith(fa)(_ => 1.asRight[SomeError])
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   =
+        CanHandleError[Id].handleEitherTNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value
+
+      lazy val fa2 = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[Id].handleEitherTNonFatalWith(fa2)(_ => expected).value
+
+      actualFailedResult ==== expectedFailedResult and actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_Id_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+      try {
+        val actual = CanHandleError[Id].handleEitherTNonFatalWith(fa)(_ => 1.asRight[SomeError]).value
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_Id_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result = {
+
+      val fa       = EitherT(run[Id, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        CanHandleError[Id].handleEitherTNonFatalWith(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleEitherTNonFatalWithShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[Id].handleEitherTNonFatalWith(fa)(_ => 1.asRight[SomeError]).value
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleNonFatalShouldHandleNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 1
+      val actual: Id[Int]   = CanHandleError[Id].handleNonFatal(fa)(_ => expected)
+
+      actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_Id_handleNonFatalShouldNotHandleFatal: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      lazy val fa        = run[Id, Int](throwThrowable[Int](fatalExpcetion))
+
+      try {
+        val actual: Id[Int] = CanHandleError[Id].handleNonFatal(fa)(_ => 1)
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_Id_handleNonFatalShouldReturnSuccessfulResult: Result = {
+
+      val fa              = run[Id, Int](1)
+      val expected        = 1
+      val actual: Id[Int] = CanHandleError[Id].handleNonFatal(fa)(_ => 123)
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleNonFatalEitherShouldHandleNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   = CanHandleError[Id].handleNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+
+      lazy val fa2 = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[Id].handleNonFatal(fa2)(_ => expected)
+
+      actualFailedResult ==== expectedFailedResult and actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_Id_handleNonFatalEitherShouldNotHandleFatal: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      lazy val fa        = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual = CanHandleError[Id].handleNonFatal(fa)(_ => 1.asRight[SomeError])
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_Id_handleNonFatalEitherShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[Id, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[Id].handleNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleNonFatalEitherShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[Id].handleNonFatal(fa)(_ => 1.asRight[SomeError])
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleEitherNonFatalShouldHandleNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa           = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   =
+        CanHandleError[Id].handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+
+      lazy val fa2 = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[Id].handleEitherNonFatal(fa2)(_ => expected)
+
+      actualFailedResult ==== expectedFailedResult and actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_Id_handleEitherNonFatalShouldNotHandleFatal: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      lazy val fa        = run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+      try {
+        val actual = CanHandleError[Id].handleEitherNonFatal(fa)(_ => 1.asRight[SomeError])
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_Id_handleEitherNonFatalShouldReturnSuccessfulResult: Result = {
+
+      val fa       = run[Id, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[Id].handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleEitherNonFatalShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[Id].handleEitherNonFatal(fa)(_ => 1.asRight[SomeError])
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleEitherTNonFatalShouldHandleNonFatal: Result = {
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   =
+        CanHandleError[Id].handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value
+
+      lazy val fa2 = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[Id].handleEitherTNonFatal(fa2)(_ => expected).value
+
+      actualFailedResult ==== expectedFailedResult and actual ==== expected
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanHandleError_Id_handleEitherTNonFatalShouldNotHandleFatal: Result = {
+
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      lazy val fa = EitherT(run[Id, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+      try {
+        val actual = CanHandleError[Id].handleEitherTNonFatal(fa)(_ => 1.asRight[SomeError]).value
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanHandleError_Id_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = {
+
+      val fa       = EitherT(run[Id, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected = 1.asRight[SomeError]
+      val actual   = CanHandleError[Id].handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int]).value
+
+      actual ==== expected
+    }
+
+    def testCanHandleError_Id_handleEitherTNonFatalShouldReturnFailedResult: Result = {
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[Id, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanHandleError[Id].handleEitherTNonFatal(fa)(_ => 1.asRight[SomeError]).value
+
+      actual ==== expected
+    }
+
+  }
+
+}

--- a/modules/effectie-cats-effect3/shared/src/test/scala/effectie/instances/ce3/f/canRecoverSpec.scala
+++ b/modules/effectie-cats-effect3/shared/src/test/scala/effectie/instances/ce3/f/canRecoverSpec.scala
@@ -1,0 +1,678 @@
+package effectie.instances.ce3.f
+
+import canRecover._
+import cats._
+import cats.data.EitherT
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import cats.instances.all._
+import cats.syntax.all._
+import effectie.SomeControlThrowable
+import effectie.core._
+import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
+import effectie.syntax.error._
+import effectie.syntax.fx._
+import effectie.instances.ce3.testing
+import effectie.testing.types.SomeError
+import extras.concurrent.testing.types.ErrorLogger
+import extras.hedgehog.ce3.syntax.runner._
+import fxCtor._
+import hedgehog._
+import hedgehog.runner._
+
+import scala.util.control.{ControlThrowable, NonFatal}
+
+/** @author Kevin Lee
+  * @since 2020-08-17
+  */
+object canRecoverSpec extends Properties {
+
+  implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+  override def tests: List[Test] = ioSpecs
+
+  /* IO */
+  val ioSpecs = List(
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWith should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWith should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWith should return the successful result",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWithEither should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWithEither should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWithEither should return the successful result",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalWithEither should return the failed result",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnFailedResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatalWith should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatalWith should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatalWith should return the successful result",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatalWith should return the failed result",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnFailedResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatalWith should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatalWith should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatalWith should return the successful result",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatalWith should return the failed result",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnFailedResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatal should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatal should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatal should return the successful result",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalEither should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalEither should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalEither should return the successful result",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverFromNonFatalEither should return the failed result",
+      IOSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldReturnFailedResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatal should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatal should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatal should return the successful result",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherFromNonFatal should return the failed result",
+      IOSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldReturnFailedResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatal should catch NonFatal",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldRecoverFromNonFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatal should not catch Fatal",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatal should return the successful result",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult,
+    ),
+    example(
+      "test CanRecover[IO].recoverEitherTFromNonFatal should return the failed result",
+      IOSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnFailedResult,
+    ),
+  )
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def throwThrowable[A](throwable: => Throwable): A =
+    throw throwable // scalafix:ok DisableSyntax.throw
+
+  def run[F[*]: FxCtor: Functor, A](a: => A): F[A] =
+    effectOf[F](a)
+
+  object IOSpec {
+
+    def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 123
+      val actual            = CanRecover[IO].recoverFromNonFatalWith(fa) {
+        case NonFatal(`expectedExpcetion`) =>
+          IO.pure(expected)
+      }
+      actual.completeAs(expected)
+
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
+
+      val compat                 = new CatsEffectIoCompatForFuture
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+
+      val io = CanRecover[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedExpcetion`) => IO.pure(123) }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val expected = 1
+      val fa       = run[IO, Int](expected)
+      val actual   = CanRecover[IO]
+        .recoverFromNonFatalWith(fa) {
+          case NonFatal(_) => IO.pure(999)
+        }
+
+      actual.completeAs(expected)
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+      val actualFailedResult   = CanRecover[IO]
+        .recoverFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) => IO.pure(expectedFailedResult)
+        }
+
+      val expectedSuccessResult = 1.asRight[SomeError]
+      val actualSuccessResult   = CanRecover[IO]
+        .recoverFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) => IO.pure(1.asRight[SomeError])
+        }
+
+      actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
+
+      val compat                 = new CatsEffectIoCompatForFuture
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+      val io = CanRecover[IO].recoverFromNonFatalWith(fa) {
+        case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
+      }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult: Result =
+      withIO { implicit ticker =>
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = CanRecover[IO]
+          .recoverFromNonFatalWith(fa) {
+            case NonFatal(_) => IO(999.asRight[SomeError])
+          }
+
+        actual.completeAs(expected)
+      }
+
+    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanRecover[IO]
+        .recoverFromNonFatalWith(fa) {
+          case NonFatal(_) => IO.pure(123.asRight[SomeError])
+        }
+
+      actual.completeAs(expected)
+    }
+
+    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   = CanRecover[IO]
+        .recoverEitherFromNonFatalWith(fa) {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   = CanRecover[IO]
+        .recoverEitherFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
+        }
+
+      actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
+
+      val compat                 = new CatsEffectIoCompatForFuture
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+      val io = CanRecover[IO].recoverEitherFromNonFatalWith(fa) {
+        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+      }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult: Result =
+      withIO { implicit ticker =>
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = CanRecover[IO]
+          .recoverEitherFromNonFatalWith(fa) {
+            case NonFatal(_) => IO.pure(123.asRight[SomeError])
+          }
+
+        actual.completeAs(expected)
+      }
+
+    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanRecover[IO]
+          .recoverEitherFromNonFatalWith(fa) {
+            case NonFatal(_) => IO.pure(123.asRight[SomeError])
+          }
+
+      actual.completeAs(expected)
+    }
+
+    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   = CanRecover[IO]
+        .recoverEitherTFromNonFatalWith(fa) {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+        .value
+
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   = CanRecover[IO]
+        .recoverEitherTFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
+        }
+        .value
+
+      actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
+
+      val compat                 = new CatsEffectIoCompatForFuture
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+
+      val io = CanRecover[IO].recoverEitherTFromNonFatalWith(fa) {
+        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+      }
+      try {
+        val actual = io.value.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult: Result =
+      withIO { implicit ticker =>
+
+        val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+        val expected = 1.asRight[SomeError]
+        val actual   = CanRecover[IO]
+          .recoverEitherTFromNonFatalWith(fa) {
+            case NonFatal(_) => IO.pure(123.asRight[SomeError])
+          }
+          .value
+
+        actual.completeAs(expected)
+      }
+
+    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanRecover[IO]
+          .recoverEitherTFromNonFatalWith(fa) {
+            case NonFatal(_) => IO.pure(123.asRight[SomeError])
+          }
+          .value
+
+      actual.completeAs(expected)
+    }
+
+    // /
+
+    def testCanRecover_IO_recoverFromNonFatalShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+      val expected          = 123
+      val actual            = CanRecover[IO]
+        .recoverFromNonFatal(fa) {
+          case NonFatal(`expectedExpcetion`) =>
+            expected
+        }
+
+      actual.completeAs(expected)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
+
+      val compat                 = new CatsEffectIoCompatForFuture
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+
+      val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123 }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = run[IO, Int](1)
+      val expected = 1
+      val actual   = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999 }
+
+      actual.completeAs(expected)
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalEitherShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+      val actualFailedResult   = CanRecover[IO]
+        .recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => expectedFailedResult }
+
+      val expectedSuccessResult = 1.asRight[SomeError]
+      val actualSuccessResult   = CanRecover[IO]
+        .recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 1.asRight[SomeError] }
+
+      actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
+
+      val compat                 = new CatsEffectIoCompatForFuture
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+      val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999.asRight[SomeError] }
+
+      actual.completeAs(expected)
+    }
+
+    def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+
+      actual.completeAs(expected)
+    }
+
+    def testCanRecover_IO_recoverEitherFromNonFatalShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   =
+        CanRecover[IO]
+          .recoverEitherFromNonFatal(fa) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   =
+        CanRecover[IO]
+          .recoverEitherFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+
+      actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
+
+      val compat                 = new CatsEffectIoCompatForFuture
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+      val io =
+        CanRecover[IO].recoverEitherFromNonFatal(fa) {
+          case err => SomeError.someThrowable(err).asLeft[Int]
+        }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        CanRecover[IO]
+          .recoverEitherFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+
+      actual.completeAs(expected)
+    }
+
+    def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanRecover[IO]
+          .recoverEitherFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+
+      actual.completeAs(expected)
+    }
+
+    def testCanRecover_IO_recoverEitherTFromNonFatalShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+      val expectedExpcetion = new RuntimeException("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+      val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+      val actualFailedResult   =
+        CanRecover[IO]
+          .recoverEitherTFromNonFatal(fa) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+          .value
+
+      val expectedSuccessResult = 123.asRight[SomeError]
+      val actualSuccessResult   =
+        CanRecover[IO]
+          .recoverEitherTFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+          .value
+
+      actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
+
+      val compat                 = new CatsEffectIoCompatForFuture
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+      val expectedExpcetion = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+
+      val io =
+        CanRecover[IO].recoverEitherTFromNonFatal(fa) {
+          case err => SomeError.someThrowable(err).asLeft[Int]
+        }
+      try {
+        val actual = io.value.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedExpcetion
+
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
+    }
+
+    def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+      val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+      val expected = 1.asRight[SomeError]
+      val actual   =
+        CanRecover[IO]
+          .recoverEitherTFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+          .value
+
+      actual.completeAs(expected)
+    }
+
+    def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+      val expectedFailure = SomeError.message("Failed")
+      val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+      val expected        = expectedFailure.asLeft[Int]
+      val actual          =
+        CanRecover[IO]
+          .recoverEitherTFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+          .value
+
+      actual.completeAs(expected)
+    }
+
+  }
+
+}

--- a/modules/effectie-cats-effect3/shared/src/test/scala/effectie/instances/ce3/f/fromFutureSpec.scala
+++ b/modules/effectie-cats-effect3/shared/src/test/scala/effectie/instances/ce3/f/fromFutureSpec.scala
@@ -1,0 +1,46 @@
+package effectie.instances.ce3.f
+
+import cats.effect._
+import cats.effect.unsafe.IORuntime
+import effectie.core.FromFuture
+import effectie.instances.ce3.testing
+import extras.concurrent.testing.ConcurrentSupport
+import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
+import fromFuture._
+import hedgehog._
+import hedgehog.runner._
+
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+/** @author Kevin Lee
+  * @since 2020-09-22
+  */
+object FromFutureSpec extends Properties {
+  private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+  override def tests: List[Test] = List(
+    property("test FromFuture[IO].toEffect", IoSpec.testToEffect)
+  )
+
+  private val waitFor300Millis = WaitFor(300.milliseconds)
+
+  object IoSpec {
+
+    def testToEffect: Property = for {
+      a <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("a")
+    } yield {
+      val compat                 = new effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
+      import compat.ec
+      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+      ConcurrentSupport.runAndShutdown(compat.es, waitFor300Millis) {
+        lazy val fa = Future(a)
+        val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
+
+        actual ==== a
+      }
+    }
+  }
+
+}

--- a/modules/effectie-cats-effect3/shared/src/test/scala/effectie/instances/ce3/f/fxCtorSpec.scala
+++ b/modules/effectie-cats-effect3/shared/src/test/scala/effectie/instances/ce3/f/fxCtorSpec.scala
@@ -1,0 +1,126 @@
+package effectie.instances.ce3.f
+
+import cats.effect._
+import effectie.specs.fxCtorSpec.FxCtorSpecs
+import extras.concurrent.testing.types.ErrorLogger
+import extras.hedgehog.ce3.syntax.runner._
+import fxCtor._
+import hedgehog._
+import hedgehog.runner._
+
+/** @author Kevin Lee
+  * @since 2020-12-06
+  */
+object fxCtorSpec extends Properties {
+  private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+  override def tests: List[Test] = ioSpecs
+
+  private val assertWithAttempt: (IO[Int], Either[Throwable, Int]) => Result = { (ioA, expected) =>
+    withIO { implicit ticker =>
+      ioA.attempt.completeThen { actual =>
+        (actual ==== expected).log(s"$actual does not equal to $expected")
+      }
+    }
+  }
+
+  private val ioSpecs = List(
+    property(
+      "test FxCtor[IO].effectOf",
+      FxCtorSpecs.testEffectOf[IO] { io =>
+        withIO { implicit ticker =>
+          io.completeAs(())
+        }
+      },
+    ),
+    property(
+      "test FxCtor[IO].fromEffect(effectOf)",
+      FxCtorSpecs.testFromEffect[IO] { io =>
+        withIO { implicit ticker =>
+          io.completeAs(())
+        }
+      },
+    ),
+    property(
+      "test FxCtor[IO].fromEffect(pureOf)",
+      FxCtorSpecs.testFromEffectWithPure[IO] { io =>
+        withIO { implicit ticker =>
+          io.completeAs(())
+        }
+      },
+    ),
+    property(
+      "test FxCtor[IO].pureOf",
+      FxCtorSpecs.testPureOf[IO] { io =>
+        withIO { implicit ticker =>
+          io.completeAs(())
+        }
+      },
+    ),
+    property(
+      "test FxCtor[IO].pureOrError(success case)",
+      FxCtorSpecs.testPureOrErrorSuccessCase[IO] { io =>
+        withIO { implicit ticker =>
+          io.completeAs(())
+        }
+      },
+    ),
+    example(
+      "test FxCtor[IO].pureOrError(error case)",
+      FxCtorSpecs.testPureOrErrorErrorCase[IO] { (io, expectedError) =>
+        withIO { implicit ticker =>
+          io.expectError(expectedError)
+        }
+      },
+    ),
+    example(
+      "test FxCtor[IO].unitOf",
+      FxCtorSpecs.testUnitOf[IO] { io =>
+        withIO { implicit ticker =>
+          io.completeAs(())
+        }
+      },
+    ),
+    example(
+      "test FxCtor[IO].errorOf",
+      FxCtorSpecs.testErrorOf[IO] { (io, expectedError) =>
+        withIO { implicit ticker =>
+          io.expectError(expectedError)
+        }
+      },
+    ),
+    property(
+      "test FxCtor[IO].fromEither(Right)",
+      FxCtorSpecs.testFromEitherRightCase[IO](assertWithAttempt),
+    ),
+    property(
+      "test FxCtor[IO].fromEither(Left)",
+      FxCtorSpecs.testFromEitherLeftCase[IO](assertWithAttempt),
+    ),
+    property(
+      "test FxCtor[IO].fromOption(Some)",
+      FxCtorSpecs.testFromOptionSomeCase[IO](assertWithAttempt),
+    ),
+    property(
+      "test FxCtor[IO].fromOption(None)",
+      FxCtorSpecs.testFromOptionNoneCase[IO](assertWithAttempt),
+    ),
+    property(
+      "test FxCtor[IO].fromTry(Success)",
+      FxCtorSpecs.testFromTrySuccessCase[IO](assertWithAttempt),
+    ),
+    property(
+      "test FxCtor[IO].fromTry(Failure)",
+      FxCtorSpecs.testFromTryFailureCase[IO](assertWithAttempt),
+    ),
+    property(
+      "test FxCtor[IO].flatMapFa(IO[A])(A => IO[B])",
+      FxCtorSpecs.testFlatMapFx[IO] { (fb, expected) =>
+        runIO {
+          fb.map(_ ==== expected)
+        }
+      },
+    ),
+  )
+
+}

--- a/modules/effectie-cats-effect3/shared/src/test/scala/effectie/instances/ce3/f/fxSpec.scala
+++ b/modules/effectie-cats-effect3/shared/src/test/scala/effectie/instances/ce3/f/fxSpec.scala
@@ -1,0 +1,1692 @@
+package effectie.instances.ce3.f
+
+import cats.data.EitherT
+import cats.effect._
+import cats.effect.unsafe.IORuntime
+import cats.syntax.all._
+import cats.{Eq, Functor}
+import effectie.SomeControlThrowable
+import effectie.core._
+import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
+import effectie.instances.ce3.testing
+import effectie.instances.ce3.MonadSpec
+import effectie.specs.fxSpec.FxSpecs
+import effectie.syntax.error._
+import effectie.testing.types.SomeError
+import extras.concurrent.testing.ConcurrentSupport
+import extras.concurrent.testing.types.ErrorLogger
+import extras.hedgehog.ce3.syntax.runner._
+import fx._
+import hedgehog._
+import hedgehog.runner._
+
+import java.util.concurrent.ExecutorService
+import scala.util.control.{ControlThrowable, NonFatal}
+
+/** @author Kevin Lee
+  * @since 2020-12-06
+  */
+object fxSpec extends Properties {
+  private implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+  private val assertWithAttempt: (IO[Int], Either[Throwable, Int]) => Result = { (ioA, expected) =>
+    withIO { implicit ticker =>
+      ioA.attempt.completeThen { actual =>
+        (actual ==== expected).log(s"$actual does not equal to $expected")
+      }
+    }
+  }
+
+  override def tests: List[Test] = ioSpecs
+
+  /* IO */
+  private val ioSpecs = List(
+    property(
+      "test Fx[IO].effectOf",
+      FxSpecs.testEffectOf[IO] { io =>
+        withIO { implicit ticker =>
+          io.completeAs(())
+        }
+      },
+    ),
+    property(
+      "test Fx[IO].fromEffect(effectOf)",
+      FxSpecs.testFromEffect[IO] { io =>
+        withIO { implicit ticker =>
+          io.completeAs(())
+        }
+      },
+    ),
+    property(
+      "test Fx[IO].fromEffect(pureOf)",
+      FxSpecs.testFromEffectWithPure[IO] { io =>
+        withIO { implicit ticker =>
+          io.completeAs(())
+        }
+      },
+    ),
+    property(
+      "test Fx[IO].pureOf",
+      FxSpecs.testPureOf[IO] { io =>
+        withIO { implicit ticker =>
+          io.completeAs(())
+        }
+      },
+    ),
+    property(
+      "test Fx[IO].pureOrError(success case)",
+      FxSpecs.testPureOrErrorSuccessCase[IO] { io =>
+        withIO { implicit ticker =>
+          io.completeAs(())
+        }
+      },
+    ),
+    example(
+      "test Fx[IO].pureOrError(error case)",
+      FxSpecs.testPureOrErrorErrorCase[IO] { (io, expectedError) =>
+        withIO { implicit ticker =>
+          io.expectError(expectedError)
+        }
+      },
+    ),
+    example(
+      "test Fx[IO].unitOf",
+      FxSpecs.testUnitOf[IO] { io =>
+        withIO { implicit ticker =>
+          io.completeAs(())
+        }
+      },
+    ),
+    example(
+      "test Fx[IO].errorOf",
+      FxSpecs.testErrorOf[IO] { (io, expectedError) =>
+        withIO { implicit ticker =>
+          io.expectError(expectedError)
+        }
+      },
+    ),
+    property("test Fx[IO].fromEither(Right)", FxSpecs.testFromEitherRightCase[IO](assertWithAttempt)),
+    property("test Fx[IO].fromEither(Left)", FxSpecs.testFromEitherLeftCase[IO](assertWithAttempt)),
+    property("test Fx[IO].fromOption(Some)", FxSpecs.testFromOptionSomeCase[IO](assertWithAttempt)),
+    property("test Fx[IO].fromOption(None)", FxSpecs.testFromOptionNoneCase[IO](assertWithAttempt)),
+    property("test Fx[IO].fromTry(Success)", FxSpecs.testFromTrySuccessCase[IO](assertWithAttempt)),
+    property("test Fx[IO].fromTry(Failure)", FxSpecs.testFromTryFailureCase[IO](assertWithAttempt)),
+    property(
+      "test Fx[IO].flatMapFa(IO[A])(A => IO[B])",
+      FxSpecs.testFlatMapFx[IO] { (fb, expected) =>
+        runIO {
+          fb.map(_ ==== expected)
+        }
+      },
+    ),
+    property("test Fx[IO] Monad laws - Identity", IoSpec.testMonadLaws1_Identity),
+    property("test Fx[IO] Monad laws - Composition", IoSpec.testMonadLaws2_Composition),
+    property("test Fx[IO] Monad laws - IdentityAp", IoSpec.testMonadLaws3_IdentityAp),
+    property("test Fx[IO] Monad laws - Homomorphism", IoSpec.testMonadLaws4_Homomorphism),
+    property("test Fx[IO] Monad laws - Interchange", IoSpec.testMonadLaws5_Interchange),
+    property("test Fx[IO] Monad laws - CompositionAp", IoSpec.testMonadLaws6_CompositionAp),
+    property("test Fx[IO] Monad laws - LeftIdentity", IoSpec.testMonadLaws7_LeftIdentity),
+    property("test Fx[IO] Monad laws - RightIdentity", IoSpec.testMonadLaws8_RightIdentity),
+    property("test Fx[IO] Monad laws - Associativity", IoSpec.testMonadLaws9_Associativity),
+  ) ++
+    List(
+      example(
+        "test CanCatch[IO]catchNonFatalThrowable should catch NonFatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatalThrowable should not catch Fatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatalThrowable should return the successful result",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatal should catch NonFatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalShouldCatchNonFatal,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatal should not catch Fatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalShouldNotCatchFatal,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatal should return the successful result",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatalEither should catch NonFatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatalEither should not catch Fatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatalEither should return the successful result",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatalEither should return the failed result",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatalEitherT should catch NonFatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatalEitherT should not catch Fatal",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatalEitherT should return the successful result",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test CanCatch[IO]catchNonFatalEitherT should return the failed result",
+        IoSpec.CanCatchSpec.testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult,
+      ),
+    ) ++
+    List(
+      /* IO */
+      example(
+        "test Fx[IO].handleNonFatalWith should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalWith should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalWith should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalWithEither should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalWithEither should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalWithEither should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalWithEither should return the failed result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatalWith should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldHandleNonFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatalWith should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatalWith should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatalWith should return the failed result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalWithShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatalWith should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatalWith should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatalWith should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatalWith should return the failed result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].handleNonFatal should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalShouldHandleNonFatal,
+      ),
+      example(
+        "test Fx[IO].handleNonFatal should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalShouldNotHandleFatal,
+      ),
+      example(
+        "test Fx[IO].handleNonFatal should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalEither should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalEither should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalEither should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleNonFatalEither should return the failed result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatal should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalShouldHandleNonFatal,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatal should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatal should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherNonFatal should return the failed result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherNonFatalShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatal should handle NonFatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatal should not handle Fatal",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatal should return the successful result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].handleEitherTNonFatal should return the failed result",
+        IoSpec.CanHandleErrorSpec.testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult,
+      ),
+    ) ++ List(
+      example(
+        "test Fx[IO].recoverFromNonFatalWith should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalWith should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalWith should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalWithEither should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalWithEither should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalWithEither should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalWithEither should return the failed result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatalWith should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatalWith should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatalWith should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatalWith should return the failed result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatalWith should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatalWith should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatalWith should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatalWith should return the failed result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatal should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatal should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatal should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalEither should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalEither should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalEither should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverFromNonFatalEither should return the failed result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverFromNonFatalEitherShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatal should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatal should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatal should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherFromNonFatal should return the failed result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherFromNonFatalShouldReturnFailedResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatal should catch NonFatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldRecoverFromNonFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatal should not catch Fatal",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatal should return the successful result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult,
+      ),
+      example(
+        "test Fx[IO].recoverEitherTFromNonFatal should return the failed result",
+        IoSpec.CanRecoverSpec.testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnFailedResult,
+      ),
+    )
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def throwThrowable[A](throwable: => Throwable): A =
+    throw throwable // scalafix:ok DisableSyntax.throw
+
+  def run[F[*]: Fx: Functor, A](a: => A): F[A] =
+    Fx[F].effectOf(a)
+
+  object IoSpec {
+
+    def testMonadLaws1_Identity: Property = {
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker.withNewTestContext()
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test1_Identity[IO]
+    }
+
+    def testMonadLaws2_Composition: Property = {
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker.withNewTestContext()
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test2_Composition[IO]
+    }
+
+    def testMonadLaws3_IdentityAp: Property = {
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker.withNewTestContext()
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test3_IdentityAp[IO]
+    }
+
+    def testMonadLaws4_Homomorphism: Property = {
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker.withNewTestContext()
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test4_Homomorphism[IO]
+    }
+
+    def testMonadLaws5_Interchange: Property = {
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker.withNewTestContext()
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test5_Interchange[IO]
+    }
+
+    def testMonadLaws6_CompositionAp: Property = {
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker.withNewTestContext()
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test6_CompositionAp[IO]
+    }
+
+    def testMonadLaws7_LeftIdentity: Property = {
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker.withNewTestContext()
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test7_LeftIdentity[IO]
+    }
+
+    def testMonadLaws8_RightIdentity: Property = {
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker.withNewTestContext()
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+      MonadSpec.test8_RightIdentity[IO]
+    }
+
+    def testMonadLaws9_Associativity: Property = {
+      import cats.syntax.eq._
+      implicit val ticket: Ticker = Ticker.withNewTestContext()
+
+      implicit val eqIo: Eq[IO[Int]] =
+        (x, y) => x.flatMap(xx => y.map(_ === xx)).completeAndEqualTo(true)
+
+//      implicit val ioFx: Fx[IO] = Fx.IoFx
+
+      MonadSpec.test9_Associativity[IO]
+    }
+
+    object CanCatchSpec {
+
+      def testCanCatch_IO_catchNonFatalThrowableShouldCatchNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+        val expected          = expectedExpcetion.asLeft[Int]
+        val actual            = Fx[IO].catchNonFatalThrowable(fa)
+
+        actual.completeAs(expected)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa: IO[Int] = run[IO, Int](1)
+        val expected    = 1.asRight[Throwable]
+        val actual      = Fx[IO].catchNonFatalThrowable(fa)
+
+        actual.completeAs(expected)
+      }
+
+      def testCanCatch_IO_catchNonFatalShouldCatchNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+        val expected          = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actual            = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable)
+
+        actual.completeAs(expected)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanCatch_IO_catchNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa: IO[Int] = run[IO, Int](1)
+        val expected    = 1.asRight[SomeError]
+        val actual      = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable)
+
+        actual.completeAs(expected)
+      }
+
+      def testCanCatch_IO_catchNonFatalEitherShouldCatchNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa       = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actual   = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable)
+
+        actual.completeAs(expected)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable)
+
+        actual.completeAs(expected)
+      }
+
+      def testCanCatch_IO_catchNonFatalEitherShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable)
+
+        actual.completeAs(expected)
+      }
+
+      def testCanCatch_IO_catchNonFatalEitherTShouldCatchNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+        val expected = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actual   = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
+
+        actual.completeAs(expected)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+        try {
+          val actual = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
+
+        actual.completeAs(expected)
+      }
+
+      def testCanCatch_IO_catchNonFatalEitherTShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value
+
+        actual.completeAs(expected)
+      }
+
+    }
+
+    object CanHandleErrorSpec {
+
+      def testCanHandleError_IO_handleNonFatalWithShouldHandleNonFatalWith: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+        val expected          = 123
+        val actual            = Fx[IO]
+          .handleNonFatalWith(fa) {
+            case NonFatal(`expectedExpcetion`) =>
+              IO.pure(expected)
+          }
+
+        actual.completeAs(expected)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa       = run[IO, Int](1)
+        val expected = 1
+        val actual   = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(999))
+
+        actual.completeAs(expected)
+      }
+
+      def testCanHandleError_IO_handleNonFatalWithEitherShouldHandleNonFatalWith: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+        val actualFailedResult   =
+          Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(expectedFailedResult))
+
+        val expectedSuccessResult = 1.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(1.asRight[SomeError]))
+
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result =
+        withIO { implicit ticker =>
+
+          val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+          val expected = 1.asRight[SomeError]
+          val actual   = Fx[IO].handleNonFatalWith(fa)(_ => IO(999.asRight[SomeError]))
+
+          actual.completeAs(expected)
+        }
+
+      def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
+
+        actual.completeAs(expected)
+      }
+
+      def testCanHandleError_IO_handleEitherNonFatalWithShouldHandleNonFatalWith: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   = Fx[IO]
+          .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
+
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+        try {
+          val actual =
+            Fx[IO]
+              .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result =
+        withIO { implicit ticker =>
+
+          val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+          val expected = 1.asRight[SomeError]
+          val actual   =
+            Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
+
+          actual.completeAs(expected)
+        }
+
+      def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO].handleEitherNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError]))
+
+        actual.completeAs(expected)
+      }
+
+      def testCanHandleError_IO_handleEitherTNonFatalWithShouldHandleNonFatalWith: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   = Fx[IO]
+          .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+          .value
+
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value
+
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+        try {
+          val actual =
+            Fx[IO]
+              .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+              .value
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result =
+        withIO { implicit ticker =>
+
+          val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+          val expected = 1.asRight[SomeError]
+          val actual   =
+            Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value
+
+          actual.completeAs(expected)
+        }
+
+      def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO].handleEitherTNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).value
+
+        actual.completeAs(expected)
+      }
+
+      def testCanHandleError_IO_handleNonFatalShouldHandleNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+        val expected          = 123
+        val actual            = Fx[IO]
+          .handleNonFatal(fa) {
+            case NonFatal(`expectedExpcetion`) =>
+              expected
+          }
+
+        actual.completeAs(expected)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa       = run[IO, Int](1)
+        val expected = 1
+        val actual   = Fx[IO].handleNonFatal(fa)(_ => 999)
+
+        actual.completeAs(expected)
+      }
+
+      def testCanHandleError_IO_handleNonFatalEitherShouldHandleNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+        val actualFailedResult   = Fx[IO].handleNonFatal(fa)(_ => expectedFailedResult)
+
+        val expectedSuccessResult = 1.asRight[SomeError]
+        val actualSuccessResult   = Fx[IO].handleNonFatal(fa)(_ => 1.asRight[SomeError])
+
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+        try {
+          val actual = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].handleNonFatal(fa)(_ => 999.asRight[SomeError])
+
+        actual.completeAs(expected)
+      }
+
+      def testCanHandleError_IO_handleNonFatalEitherShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError])
+
+        actual.completeAs(expected)
+      }
+
+      def testCanHandleError_IO_handleEitherNonFatalShouldHandleNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   = Fx[IO]
+          .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError])
+
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+
+        try {
+          val actual =
+            Fx[IO]
+              .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError])
+
+        actual.completeAs(expected)
+      }
+
+      def testCanHandleError_IO_handleEitherNonFatalShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO].handleEitherNonFatal(fa)(_ => 123.asRight[SomeError])
+
+        actual.completeAs(expected)
+      }
+
+      def testCanHandleError_IO_handleEitherTNonFatalShouldHandleNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   = Fx[IO]
+          .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+          .value
+
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value
+
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
+
+        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+
+        try {
+          val actual =
+            Fx[IO]
+              .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+              .value
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value
+
+        actual.completeAs(expected)
+      }
+
+      def testCanHandleError_IO_handleEitherTNonFatalShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO].handleEitherTNonFatal(fa)(_ => 123.asRight[SomeError]).value
+
+        actual.completeAs(expected)
+      }
+
+    }
+
+    object CanRecoverSpec {
+
+      def testCanRecover_IO_recoverFromNonFatalWithShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+        val expected          = 123
+        val actual            = Fx[IO].recoverFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) =>
+            IO.pure(expected)
+        }
+        actual.completeAs(expected)
+
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+
+        val io = Fx[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedExpcetion`) => IO.pure(123) }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val expected = 1
+        val fa       = run[IO, Int](expected)
+        val actual   = Fx[IO]
+          .recoverFromNonFatalWith(fa) {
+            case NonFatal(_) => IO.pure(999)
+          }
+
+        actual.completeAs(expected)
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+        val actualFailedResult   = Fx[IO]
+          .recoverFromNonFatalWith(fa) {
+            case NonFatal(`expectedExpcetion`) => IO.pure(expectedFailedResult)
+          }
+
+        val expectedSuccessResult = 1.asRight[SomeError]
+        val actualSuccessResult   = Fx[IO]
+          .recoverFromNonFatalWith(fa) {
+            case NonFatal(`expectedExpcetion`) => IO.pure(1.asRight[SomeError])
+          }
+
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+        val io = Fx[IO].recoverFromNonFatalWith(fa) {
+          case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
+        }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult: Result =
+        withIO { implicit ticker =>
+
+          val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+          val expected = 1.asRight[SomeError]
+          val actual   = Fx[IO]
+            .recoverFromNonFatalWith(fa) {
+              case NonFatal(_) => IO(999.asRight[SomeError])
+            }
+
+          actual.completeAs(expected)
+        }
+
+      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          = Fx[IO]
+          .recoverFromNonFatalWith(fa) {
+            case NonFatal(_) => IO.pure(123.asRight[SomeError])
+          }
+
+        actual.completeAs(expected)
+      }
+
+      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   = Fx[IO]
+          .recoverEitherFromNonFatalWith(fa) {
+            case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          }
+
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   = Fx[IO]
+          .recoverEitherFromNonFatalWith(fa) {
+            case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
+          }
+
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+        val io = Fx[IO].recoverEitherFromNonFatalWith(fa) {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult: Result =
+        withIO { implicit ticker =>
+
+          val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+          val expected = 1.asRight[SomeError]
+          val actual   = Fx[IO]
+            .recoverEitherFromNonFatalWith(fa) {
+              case NonFatal(_) => IO.pure(123.asRight[SomeError])
+            }
+
+          actual.completeAs(expected)
+        }
+
+      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO]
+            .recoverEitherFromNonFatalWith(fa) {
+              case NonFatal(_) => IO.pure(123.asRight[SomeError])
+            }
+
+        actual.completeAs(expected)
+      }
+
+      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldRecoverFromNonFatal: Result =
+        withIO { implicit ticker =>
+
+          val expectedExpcetion = new RuntimeException("Something's wrong")
+          val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+          val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+          val actualFailedResult   = Fx[IO]
+            .recoverEitherTFromNonFatalWith(fa) {
+              case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            }
+            .value
+
+          val expectedSuccessResult = 123.asRight[SomeError]
+          val actualSuccessResult   = Fx[IO]
+            .recoverEitherTFromNonFatalWith(fa) {
+              case NonFatal(`expectedExpcetion`) => IO.pure(123.asRight[SomeError])
+            }
+            .value
+
+          actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+        }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+
+        val io = Fx[IO].recoverEitherTFromNonFatalWith(fa) {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+        try {
+          val actual = io.value.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult: Result =
+        withIO { implicit ticker =>
+
+          val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+          val expected = 1.asRight[SomeError]
+          val actual   = Fx[IO]
+            .recoverEitherTFromNonFatalWith(fa) {
+              case NonFatal(_) => IO.pure(123.asRight[SomeError])
+            }
+            .value
+
+          actual.completeAs(expected)
+        }
+
+      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO]
+            .recoverEitherTFromNonFatalWith(fa) {
+              case NonFatal(_) => IO.pure(123.asRight[SomeError])
+            }
+            .value
+
+        actual.completeAs(expected)
+      }
+
+      // /
+
+      def testCanRecover_IO_recoverFromNonFatalShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+        val expected          = 123
+        val actual            = Fx[IO]
+          .recoverFromNonFatal(fa) {
+            case NonFatal(`expectedExpcetion`) =>
+              expected
+          }
+
+        actual.completeAs(expected)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedExpcetion))
+
+        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123 }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa       = run[IO, Int](1)
+        val expected = 1
+        val actual   = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999 }
+
+        actual.completeAs(expected)
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalEitherShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult = SomeError.message("Recovered Error").asLeft[Int]
+        val actualFailedResult   = Fx[IO]
+          .recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => expectedFailedResult }
+
+        val expectedSuccessResult = 1.asRight[SomeError]
+        val actualSuccessResult   = Fx[IO]
+          .recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 1.asRight[SomeError] }
+
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 999.asRight[SomeError] }
+
+        actual.completeAs(expected)
+      }
+
+      def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+
+        actual.completeAs(expected)
+      }
+
+      def testCanRecover_IO_recoverEitherFromNonFatalShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   =
+          Fx[IO]
+            .recoverEitherFromNonFatal(fa) {
+              case err => SomeError.someThrowable(err).asLeft[Int]
+            }
+
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO]
+            .recoverEitherFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion))
+
+        val io =
+          Fx[IO].recoverEitherFromNonFatal(fa) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa       = run[IO, Either[SomeError, Int]](1.asRight[SomeError])
+        val expected = 1.asRight[SomeError]
+        val actual   =
+          Fx[IO]
+            .recoverEitherFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+
+        actual.completeAs(expected)
+      }
+
+      def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int])
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO]
+            .recoverEitherFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+
+        actual.completeAs(expected)
+      }
+
+      def testCanRecover_IO_recoverEitherTFromNonFatalShouldRecoverFromNonFatal: Result = withIO { implicit ticker =>
+
+        val expectedExpcetion = new RuntimeException("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+        val expectedFailedResult = SomeError.someThrowable(expectedExpcetion).asLeft[Int]
+        val actualFailedResult   =
+          Fx[IO]
+            .recoverEitherTFromNonFatal(fa) {
+              case err => SomeError.someThrowable(err).asLeft[Int]
+            }
+            .value
+
+        val expectedSuccessResult = 123.asRight[SomeError]
+        val actualSuccessResult   =
+          Fx[IO]
+            .recoverEitherTFromNonFatal(fa) { case NonFatal(`expectedExpcetion`) => 123.asRight[SomeError] }
+            .value
+
+        actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
+
+        val compat                 = new CatsEffectIoCompatForFuture
+        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+
+        val expectedExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedExpcetion)))
+
+        val io =
+          Fx[IO].recoverEitherTFromNonFatal(fa) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+        try {
+          val actual = io.value.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedExpcetion
+
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
+      }
+
+      def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
+
+        val fa       = EitherT(run[IO, Either[SomeError, Int]](1.asRight[SomeError]))
+        val expected = 1.asRight[SomeError]
+        val actual   =
+          Fx[IO]
+            .recoverEitherTFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+            .value
+
+        actual.completeAs(expected)
+      }
+
+      def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnFailedResult: Result = withIO { implicit ticker =>
+
+        val expectedFailure = SomeError.message("Failed")
+        val fa              = EitherT(run[IO, Either[SomeError, Int]](expectedFailure.asLeft[Int]))
+        val expected        = expectedFailure.asLeft[Int]
+        val actual          =
+          Fx[IO]
+            .recoverEitherTFromNonFatal(fa) { case NonFatal(_) => 123.asRight[SomeError] }
+            .value
+
+        actual.completeAs(expected)
+      }
+
+    }
+  }
+
+}


### PR DESCRIPTION
Close #568 - Add instances of `CanCatch`, `CanHandleError`, `CanRecover`, `FromFuture`, `Fx` and `FxCtor` with `Sync` and `Async`