### PR TITLE
effectie v2.0.0-beta12

### DIFF
--- a/changelogs/2.0.0-beta12.md
+++ b/changelogs/2.0.0-beta12.md
@@ -1,0 +1,26 @@
+## [2.0.0-beta12](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-23..2023-09-09) - 2023-09-09
+
+### New Features
+* Add `CanRestart` for retrying `F[A]` (#566)
+  ```scala
+  trait CanRestart[F[*]] {
+    def restartWhile[A](fa: F[A])(p: A => Boolean): F[A]
+  
+    def restartUntil[A](fa: F[A])(p: A => Boolean): F[A]
+  
+    def restartOnError[A](fa: F[A])(maxRetries: Long): F[A]
+  
+    def restartOnErrorIfTrue[A](fa: F[A])(p: Throwable => Boolean): F[A]
+  }
+  ```
+
+* Add instances of `CanCatch`, `CanHandleError`, `CanRecover`, `FromFuture`, `Fx` and `FxCtor` with `Sync` and `Async` (#568)
+  
+  So it can be done like this with the `effectie.instances.ce2.f` and `effectie.instances.ce3.f` packages.
+  ```scala
+  def foo[F[*]: Fx](n: Int): F[Int] = Fx[F].effectOf(n * 2)
+
+  // Fx[F] can be satisfied with just Sync[F] like this.
+  import effectie.instances.ce2.f.fx._
+  def bar[F[*]: Sync](n: Int): F[Int] = foo(n)
+  ```

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta12"


### PR DESCRIPTION
# effectie v2.0.0-beta12
## [2.0.0-beta12](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-23..2023-09-09) - 2023-09-09

### New Features
* Add `CanRestart` for retrying `F[A]` (#566)
  ```scala
  trait CanRestart[F[*]] {
    def restartWhile[A](fa: F[A])(p: A => Boolean): F[A]
  
    def restartUntil[A](fa: F[A])(p: A => Boolean): F[A]
  
    def restartOnError[A](fa: F[A])(maxRetries: Long): F[A]
  
    def restartOnErrorIfTrue[A](fa: F[A])(p: Throwable => Boolean): F[A]
  }
  ```

* Add instances of `CanCatch`, `CanHandleError`, `CanRecover`, `FromFuture`, `Fx` and `FxCtor` with `Sync` and `Async` (#568)
  
  So it can be done like this with the `effectie.instances.ce2.f` and `effectie.instances.ce3.f` packages.
  ```scala
  def foo[F[*]: Fx](n: Int): F[Int] = Fx[F].effectOf(n * 2)

  // Fx[F] can be satisfied with just Sync[F] like this.
  import effectie.instances.ce2.f.fx._
  def bar[F[*]: Sync](n: Int): F[Int] = foo(n)
  ```
