### PR TITLE
Fix #584 - Make sure error handling for `Future` uses `Future`'s error handling methods

### DIFF
--- a/modules/effectie-core/shared/src/main/scala/effectie/instances/future/canHandleError.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/instances/future/canHandleError.scala
@@ -20,8 +20,12 @@ object canHandleError {
           handleError(throwable)
       }
 
-    @inline override def handleNonFatal[A, AA >: A](fa: => Future[A])(handleError: Throwable => AA): Future[AA] =
-      handleNonFatalWith[A, AA](fa)(err => Future(handleError(err)))
+    @inline override def handleNonFatal[A, AA >: A](fa: => Future[A])(handleError: Throwable => AA): Future[AA] = {
+      fa.recover {
+        case throwable: Throwable =>
+          handleError(throwable)
+      }
+    }
   }
 
   final class CanHandleErrorFuture(override implicit val EC0: ExecutionContext) extends FutureCanHandleError

--- a/modules/effectie-core/shared/src/main/scala/effectie/instances/future/canRecover.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/instances/future/canRecover.scala
@@ -27,9 +27,7 @@ object canRecover {
     )(
       handleError: PartialFunction[Throwable, AA]
     ): Future[AA] =
-      recoverFromNonFatalWith[A, AA](fa)(
-        handleError.andThen(Future(_))
-      )
+      fa.recover(handleError)
   }
 
   class CanRecoverFuture(override implicit val EC0: ExecutionContext) extends FutureCanRecover


### PR DESCRIPTION
Fix #584 - Make sure error handling for `Future` uses `Future`'s error handling methods