### PR TITLE
Close #586 - `CanHandleError[Try].handleNonFatal` and `CanRecover[Try].recoverFromNonFatal` should use `Try`'s `recover`

### DIFF
--- a/modules/effectie-core/shared/src/main/scala/effectie/instances/tries/canHandleError.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/instances/tries/canHandleError.scala
@@ -20,7 +20,10 @@ object canHandleError {
       }
 
     @inline override def handleNonFatal[A, AA >: A](fa: => Try[A])(handleError: Throwable => AA): Try[AA] =
-      handleNonFatalWith[A, AA](fa)(err => Try(handleError(err)))
+      fa.recover {
+        case throwable: Throwable =>
+          handleError(throwable)
+      }
   }
 
   implicit object canHandleErrorTry extends TryCanHandleError

--- a/modules/effectie-core/shared/src/main/scala/effectie/instances/tries/canRecover.scala
+++ b/modules/effectie-core/shared/src/main/scala/effectie/instances/tries/canRecover.scala
@@ -24,9 +24,7 @@ object canRecover {
     )(
       handleError: PartialFunction[Throwable, AA]
     ): Try[AA] =
-      recoverFromNonFatalWith[A, AA](fa)(
-        handleError.andThen(Try(_))
-      )
+      fa.recover(handleError)
   }
 
   implicit object canRecoverTry extends TryCanRecover


### PR DESCRIPTION
Close #586 - `CanHandleError[Try].handleNonFatal` and `CanRecover[Try].recoverFromNonFatal` should use `Try`'s `recover`