### PR TITLE
effectie v2.0.0-beta13

### DIFF
--- a/changelogs/2.0.0-beta13.md
+++ b/changelogs/2.0.0-beta13.md
@@ -1,0 +1,29 @@
+## [2.0.0-beta13](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-09-10..2023-09-30) - 2023-10-01
+
+### Changes
+* `CanHandleError[Future]` and `CanRecover[Future]` should use `Future`'s `recover` and `recoverWith`. (#584)
+* `CanHandleError[Try].handleNonFatal` and `CanRecover[Try].recoverFromNonFatal` should use `Try`'s `recover` (#586)
+
+### New Feature
+* `rethrowIfLeft` and `rethrowTIfLeft` `syntax` for `F[Either[A, B]]` and `EitherT[F, A, B]` (#588)
+  ```scala
+  val fa: IO[Either[Throwable, Int]] = pureOf[IO](Right(1))
+  fa.rethrowIfLeft
+  // IO[Int] = IO(1)
+  ```
+  ```scala
+  val fa: IO[Either[Throwable, Int]] = pureOf[IO](Left(new RuntimeException("Error")))
+  fa.rethrowIfLeft
+  // IO[Int] = RaiseError(RuntimeException("ERROR"))
+  ```
+  
+  ```scala
+  val fa: EitherT[IO, Throwable, Int] = pureOf[IO](Right(1)).eitherT
+  fa.rethrowTIfLeft
+  // IO[Int] = IO(1)
+  ```
+  ```scala
+  val fa: EitherT[IO, Throwable, Int] = pureOf[IO](Left(new RuntimeException("Error"))).eitherT
+  fa.rethrowTIfLeft
+  // IO[Int] = RaiseError(RuntimeException("ERROR"))
+  ```

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta13"


### PR DESCRIPTION
# effectie v2.0.0-beta13
## [2.0.0-beta13](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-09-10..2023-09-30) - 2023-10-01

### Changes
* `CanHandleError[Future]` and `CanRecover[Future]` should use `Future`'s `recover` and `recoverWith`. (#584)
* `CanHandleError[Try].handleNonFatal` and `CanRecover[Try].recoverFromNonFatal` should use `Try`'s `recover` (#586)

### New Feature
* `rethrowIfLeft` and `rethrowTIfLeft` `syntax` for `F[Either[A, B]]` and `EitherT[F, A, B]` (#588)
  ```scala
  val fa: IO[Either[Throwable, Int]] = pureOf[IO](Right(1))
  fa.rethrowIfLeft
  // IO[Int] = IO(1)
  ```
  ```scala
  val fa: IO[Either[Throwable, Int]] = pureOf[IO](Left(new RuntimeException("Error")))
  fa.rethrowIfLeft
  // IO[Int] = RaiseError(RuntimeException("ERROR"))
  ```
  
  ```scala
  val fa: EitherT[IO, Throwable, Int] = pureOf[IO](Right(1)).eitherT
  fa.rethrowTIfLeft
  // IO[Int] = IO(1)
  ```
  ```scala
  val fa: EitherT[IO, Throwable, Int] = pureOf[IO](Left(new RuntimeException("Error"))).eitherT
  fa.rethrowTIfLeft
  // IO[Int] = RaiseError(RuntimeException("ERROR"))
  ```
