### PR TITLE
effectie v2.0.0-beta14

### DIFF
--- a/changelogs/2.0.0-beta14.md
+++ b/changelogs/2.0.0-beta14.md
@@ -1,0 +1,38 @@
+## [2.0.0-beta14](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-10-01..2024-01-12) - 2024-01-12
+
+### New Feature
+* Add `effectie-time` module (#601)
+* [`effectie-time`] Add `TimeSource` (#602)
+  ```scala
+  TimeSource[F].currentTime()
+  TimeSource[F].realTime
+  TimeSource[F].realTimeTo
+  TimeSource[F].monotonic
+  TimeSource[F].monotonicTo
+  TimeSource[F].timeSpent(F[A])
+  ```
+* [`effectie-time`] Add `ApproxFiniteDuration` and `syntax` (#603)
+  ```scala
+  import scala.concurrent.duration._
+  import effectie.time.syntax._
+  
+  5.seconds +- 2.seconds
+  // ApproxFiniteDuration(5.seconds, 2.seconds)
+  
+  3.seconds.isWithIn(5.seconds +- 2.seconds)
+  // Boolean = true
+  
+  7.seconds.isWithIn(5.seconds +- 2.seconds)
+  // Boolean = true
+  
+  2.seconds.isWithIn(5.seconds +- 2.seconds)
+  // Boolean = false
+  
+  8.seconds.isWithIn(5.seconds +- 2.seconds)
+  // Boolean = false
+  ```
+* Add ~~`effectie-cats-effect2-time`~~ `effectie-time-cats-effect2` (#607)
+* [`effectie-cats-effect2-time`] Add `TimeSource` with `Clock` from `cats-effect` 2 (#608)
+* Add ~~`effectie-cats-effect3-time`~~ `effectie-time-cats-effect3` (#610)
+* [`effectie-cats-effect3-time`] Add `TimeSource` with `Clock` from `cats-effect` 3 (#611)
+* Rename `effectie-cats-effect2-time` to `effectie-time-cats-effect2` and `effectie-cats-effect3-time` to `effectie-time-cats-effect3` (#615)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta14"


### PR DESCRIPTION
# effectie v2.0.0-beta14
## [2.0.0-beta14](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-10-01..2024-01-12) - 2024-01-12

### New Feature
* Add `effectie-time` module (#601)
* [`effectie-time`] Add `TimeSource` (#602)
  ```scala
  TimeSource[F].currentTime()
  TimeSource[F].realTime
  TimeSource[F].realTimeTo
  TimeSource[F].monotonic
  TimeSource[F].monotonicTo
  TimeSource[F].timeSpent(F[A])
  ```
* [`effectie-time`] Add `ApproxFiniteDuration` and `syntax` (#603)
  ```scala
  import scala.concurrent.duration._
  import effectie.time.syntax._
  
  5.seconds +- 2.seconds
  // ApproxFiniteDuration(5.seconds, 2.seconds)
  
  3.seconds.isWithIn(5.seconds +- 2.seconds)
  // Boolean = true
  
  7.seconds.isWithIn(5.seconds +- 2.seconds)
  // Boolean = true
  
  2.seconds.isWithIn(5.seconds +- 2.seconds)
  // Boolean = false
  
  8.seconds.isWithIn(5.seconds +- 2.seconds)
  // Boolean = false
  ```
* Add ~~`effectie-cats-effect2-time`~~ `effectie-time-cats-effect2` (#607)
* [`effectie-cats-effect2-time`] Add `TimeSource` with `Clock` from `cats-effect` 2 (#608)
* Add ~~`effectie-cats-effect3-time`~~ `effectie-time-cats-effect3` (#610)
* [`effectie-cats-effect3-time`] Add `TimeSource` with `Clock` from `cats-effect` 3 (#611)
* Rename `effectie-cats-effect2-time` to `effectie-time-cats-effect2` and `effectie-cats-effect3-time` to `effectie-time-cats-effect3` (#615)
