### PR TITLE
effectie v2.1.0

### DIFF
--- a/changelogs/2.1.0.md
+++ b/changelogs/2.1.0.md
@@ -1,0 +1,46 @@
+## [2.1.0](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m2) - 2025-10-22
+
+
+## Done
+
+* Scala.js support is broken (#631)
+
+  To Support Scala.js,
+  * Scala `2.12.13` -> `2.12.18`
+  * Scala `2.13.10` -> `2.13.16`
+  * Scala `3.1.3` -> `3.3.3`
+  * `sbt-wartremover`: `3.1.0` -> `3.4.0`
+  * `sbt-scoverage`: `2.0.7` -> `2.4.0`
+  * `sbt-scalajs`: `1.9.0` -> `1.18.2`
+  * `sbt-scalajs-crossproject`: `1.1.0` -> `1.3.2`
+***
+* Upgrade Scala 3 to 3.1.3 (#644)
+
+***
+* Update `effectie.instances.ce2.f.fxCtor.syncFxCtor.pureOrError` for consistency (#658)
+
+  The current implementation is
+  ```scala
+  def pureOrError[A](a: => A): F[A] = Sync[F].catchNonFatal(a)
+  ```
+  So it behaves differently in `cats-effect` and `monix`.
+  
+  So, when there's no error, in `cats-effect` it's the same as `pureOf`, whereas in `monix` it's the same as `effectOf`.
+  
+  However, the behaviour should be the same for both `cats-effect` and `monix`.
+
+## Fixed:
+
+* Fix the broken test: `effectie.instances.future.fxSpec.FutureSpec.testFromEffectWithPure` (#646)
+
+  ```
+  [info] - effectie.instances.id.fxSpec.test Fx[Future].fromEffect(pureOf): Falsified after 4 passed tests
+  [info] > before: -2050500731
+  [info] > after: 265141147
+  [info] > === Not Equal ===
+  [info] > --- lhs ---
+  [info] > 265141147
+  [info] > --- rhs ---
+  [info] > -2050500731
+  [info] > testAfterFrom
+  ```


### PR DESCRIPTION
# effectie v2.1.0
## [2.1.0](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m2) - 2025-10-22


## Done

* Scala.js support is broken (#631)

  To Support Scala.js,
  * Scala `2.12.13` -> `2.12.18`
  * Scala `2.13.10` -> `2.13.16`
  * Scala `3.1.3` -> `3.3.3`
  * `sbt-wartremover`: `3.1.0` -> `3.4.0`
  * `sbt-scoverage`: `2.0.7` -> `2.4.0`
  * `sbt-scalajs`: `1.9.0` -> `1.18.2`
  * `sbt-scalajs-crossproject`: `1.1.0` -> `1.3.2`
***
* Upgrade Scala 3 to 3.1.3 (#644)

***
* Update `effectie.instances.ce2.f.fxCtor.syncFxCtor.pureOrError` for consistency (#658)

  The current implementation is
  ```scala
  def pureOrError[A](a: => A): F[A] = Sync[F].catchNonFatal(a)
  ```
  So it behaves differently in `cats-effect` and `monix`.
  
  So, when there's no error, in `cats-effect` it's the same as `pureOf`, whereas in `monix` it's the same as `effectOf`.
  
  However, the behaviour should be the same for both `cats-effect` and `monix`.

## Fixed:

* Fix the broken test: `effectie.instances.future.fxSpec.FutureSpec.testFromEffectWithPure` (#646)

  ```
  [info] - effectie.instances.id.fxSpec.test Fx[Future].fromEffect(pureOf): Falsified after 4 passed tests
  [info] > before: -2050500731
  [info] > after: 265141147
  [info] > === Not Equal ===
  [info] > --- lhs ---
  [info] > 265141147
  [info] > --- rhs ---
  [info] > -2050500731
  [info] > testAfterFrom
  ```
