### PR TITLE
Update GitHub Actions: Upgrade Node.js version for docs to `22.21.0`

### DIFF
--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -18,7 +18,7 @@ jobs:
         scala:
           - { version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
         node:
-          - { version: "18.13.0" }
+          - { version: "22.21.0" }
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -17,7 +17,7 @@ jobs:
         scala:
           - { version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
         node:
-          - { version: "18.13.0" }
+          - { version: "22.21.0" }
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Update GitHub Actions: Upgrade Node.js version for docs to `22.21.0`