### PR TITLE
Fix #669: Some library used only in `Test` is wrongly scoped as a `Compile` library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ lazy val core = module(ProjectName("core"), crossProject(JVMPlatform, JSPlatform
   .settings(
     description := "Effect Utils - Core",
     libraryDependencies ++= List(
-      libs.extrasCore.value,
+      libs.extrasCore.value % Test,
       libs.libCatsCore(props.catsVersion).value % Test,
     ) ++ (
       if (scalaVersion.value.startsWith("2.12"))


### PR DESCRIPTION
## Fix #669: Some library used only in `Test` is wrongly scoped as a `Compile` library

- `extras-core` was scoped as `Compile`, and it's now scoped as `Test`