### PR TITLE
effectie v2.1.1

### DIFF
--- a/changelogs/2.1.1.md
+++ b/changelogs/2.1.1.md
@@ -1,0 +1,7 @@
+## [2.1.1](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m3) - 2025-10-28
+
+
+## Fixed:
+
+* Some library used only in `Test` is wrongly scoped as a `Compile` library (#669)
+  * `extras-core` was scoped as `Compile`, and it's now scoped as `Test`


### PR DESCRIPTION
# effectie v2.1.1
## [2.1.1](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m3) - 2025-10-28


## Fixed:

* Some library used only in `Test` is wrongly scoped as a `Compile` library (#669)
  * `extras-core` was scoped as `Compile`, and it's now scoped as `Test`
