### PR TITLE
Update docs: Set categories to `collapsed` by default in `_category_.json`

### DIFF
--- a/docs/latest-ce3/cats-effect3/_category_.json
+++ b/docs/latest-ce3/cats-effect3/_category_.json
@@ -2,5 +2,5 @@
   "label": "Effectie - Cats Effect 3",
   "position": 4,
   "collapsible": true,
-  "collapsed": false
+  "collapsed": true
 }

--- a/docs/latest/cats-effect2/_category_.json
+++ b/docs/latest/cats-effect2/_category_.json
@@ -2,5 +2,5 @@
   "label": "Effectie - Cats Effect 2",
   "position": 2,
   "collapsible": true,
-  "collapsed": false
+  "collapsed": true
 }

--- a/docs/latest/monix3/_category_.json
+++ b/docs/latest/monix3/_category_.json
@@ -2,5 +2,5 @@
   "label": "Effectie - Monix",
   "position": 3,
   "collapsible": true,
-  "collapsed": false
+  "collapsed": true
 }


### PR DESCRIPTION
Update docs: Set categories to `collapsed` by default in `_category_.json`