### PR TITLE
Fix hanging cats-effect 3 "should not catch Fatal" tests

### DIFF
--- a/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/canCatchSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/canCatchSpec.scala
@@ -10,14 +10,11 @@ import effectie.core._
 import effectie.syntax.error._
 import effectie.syntax.fx._
 import effectie.testing.types._
-import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.ErrorLogger
 import extras.hedgehog.ce3.syntax.runner._
 import fxCtor._
 import hedgehog._
 import hedgehog.runner._
-
-import java.util.concurrent.ExecutorService
 
 /** @author Kevin Lee
   * @since 2020-07-31
@@ -106,23 +103,22 @@ object canCatchSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
 
-    val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
+    val fatalException = SomeControlThrowable("Something's wrong")
 
-    testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+    try {
+      /* `fa` is by-name, so throwing the fatal here happens synchronously while constructing the IO
+       * (before any IO value exists), the instant catchNonFatalThrowable forces it. The fatal therefore
+       * never enters cats-effect's run loop, so it cannot trip the process-global onFatalFailure latch
+       * (which otherwise hangs every fatal test after the first when run on a live IORuntime).
+       */
+      val actual = CanCatch[IO].catchNonFatalThrowable[Int](throwThrowable[IO[Int]](fatalException))
+      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+    } catch {
+      case ex: SomeControlThrowable =>
+        ex.getMessage ==== fatalException.getMessage
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
-
-      try {
-        val actual = CanCatch[IO].catchNonFatalThrowable(fa).unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
-
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-      }
+      case ex: Throwable =>
+        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
 
   }
@@ -149,22 +145,20 @@ object canCatchSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
 
-    val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-    testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+    val fatalException = SomeControlThrowable("Something's wrong")
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+    try {
+      /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: the by-name `fb` is forced
+       * synchronously, so the fatal is thrown during construction and never reaches the run loop.
+       */
+      val actual = CanCatch[IO].catchNonFatal(throwThrowable[IO[Int]](fatalException))(SomeError.someThrowable)
+      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+    } catch {
+      case ex: SomeControlThrowable =>
+        ex.getMessage ==== fatalException.getMessage
 
-      try {
-        val actual = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
-
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-      }
+      case ex: Throwable =>
+        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
 
   }
@@ -191,22 +185,21 @@ object canCatchSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
-    val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-    testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+    val fatalException = SomeControlThrowable("Something's wrong")
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+    try {
+      /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: the by-name `fab` is forced
+       * synchronously, so the fatal is thrown during construction and never reaches the run loop.
+       */
+      val actual = CanCatch[IO]
+        .catchNonFatalEither(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(SomeError.someThrowable)
+      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+    } catch {
+      case ex: SomeControlThrowable =>
+        ex.getMessage ==== fatalException.getMessage
 
-      try {
-        val actual = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
-
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-      }
+      case ex: Throwable =>
+        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
   }
 
@@ -242,22 +235,21 @@ object canCatchSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
-    val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-    testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+    val fatalException = SomeControlThrowable("Something's wrong")
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+    try {
+      /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: EitherT.apply evaluates its argument
+       * eagerly, so the fatal is thrown on this line during construction and never reaches the run loop.
+       */
+      val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
+      val actual = CanCatch[IO].catchNonFatalEitherT(fab)(SomeError.someThrowable).value
+      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+    } catch {
+      case ex: SomeControlThrowable =>
+        ex.getMessage ==== fatalException.getMessage
 
-      try {
-        val actual = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
-
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-      }
+      case ex: Throwable =>
+        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
 
   }

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/canHandleErrorSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/canHandleErrorSpec.scala
@@ -3,7 +3,6 @@ package effectie.instances.ce3
 import canHandleError._
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.SomeControlThrowable
@@ -11,14 +10,12 @@ import effectie.core._
 import effectie.syntax.error._
 import effectie.syntax.fx._
 import effectie.testing.types.SomeError
-import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.ErrorLogger
 import extras.hedgehog.ce3.syntax.runner._
 import fxCtor._
 import hedgehog._
 import hedgehog.runner._
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -176,18 +173,18 @@ object canHandleErrorSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+    val fatalException = SomeControlThrowable("Something's wrong")
 
     try {
-      val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+      /* `fa` is by-name and forced synchronously, so the fatal is thrown during construction
+       * (never inside an IO) and cannot trip cats-effect's process-global onFatalFailure latch
+       * that otherwise hangs every fatal test after the first on a live IORuntime.
+       */
+      val actual = CanHandleError[IO].handleNonFatalWith(throwThrowable[IO[Int]](fatalException))(_ => IO.pure(123))
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        ex ==== fatalException
 
       case ex: Throwable =>
         Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -222,18 +219,20 @@ object canHandleErrorSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+    val fatalException = SomeControlThrowable("Something's wrong")
 
     try {
-      val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+      /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+       * forced synchronously, thrown during construction, never reaches the run loop.
+       */
+      val actual = CanHandleError[IO]
+        .handleNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(_ =>
+          IO.pure(123.asRight[SomeError])
+        )
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: SomeControlThrowable =>
-        ex.getMessage ==== fatalExpcetion.getMessage
+        ex.getMessage ==== fatalException.getMessage
 
       case ex: Throwable =>
         Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -278,21 +277,21 @@ object canHandleErrorSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+    val fatalException = SomeControlThrowable("Something's wrong")
 
     try {
+      /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+       * forced synchronously, thrown during construction, never reaches the run loop.
+       */
       val actual =
         CanHandleError[IO]
-          .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-          .unsafeRunSync()
+          .handleEitherNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(err =>
+            IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          )
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        ex ==== fatalException
 
       case ex: Throwable =>
         Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -340,22 +339,21 @@ object canHandleErrorSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+    val fatalException = SomeControlThrowable("Something's wrong")
 
     try {
+      /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+       * forced synchronously, thrown during construction, never reaches the run loop.
+       */
+      val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
       val actual =
         CanHandleError[IO]
-          .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+          .handleEitherTNonFatalWith(fab)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
           .value
-          .unsafeRunSync()
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        ex ==== fatalException
 
       case ex: Throwable =>
         Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -404,18 +402,17 @@ object canHandleErrorSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+    val fatalException = SomeControlThrowable("Something's wrong")
 
     try {
-      val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+      /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+       * forced synchronously, thrown during construction, never reaches the run loop.
+       */
+      val actual = CanHandleError[IO].handleNonFatal(throwThrowable[IO[Int]](fatalException))(_ => 123)
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        ex ==== fatalException
 
       case ex: Throwable =>
         Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -448,18 +445,20 @@ object canHandleErrorSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+    val fatalException = SomeControlThrowable("Something's wrong")
 
     try {
-      val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+      /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+       * forced synchronously, thrown during construction, never reaches the run loop.
+       */
+      val actual =
+        CanHandleError[IO].handleNonFatal(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(_ =>
+          123.asRight[SomeError]
+        )
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        ex ==== fatalException
 
       case ex: Throwable =>
         Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -504,21 +503,21 @@ object canHandleErrorSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+    val fatalException = SomeControlThrowable("Something's wrong")
 
     try {
+      /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+       * forced synchronously, thrown during construction, never reaches the run loop.
+       */
       val actual =
         CanHandleError[IO]
-          .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-          .unsafeRunSync()
+          .handleEitherNonFatal(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(err =>
+            SomeError.someThrowable(err).asLeft[Int]
+          )
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        ex ==== fatalException
 
       case ex: Throwable =>
         Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -565,22 +564,21 @@ object canHandleErrorSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+    val fatalException = SomeControlThrowable("Something's wrong")
 
     try {
+      /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+       * forced synchronously, thrown during construction, never reaches the run loop.
+       */
+      val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
       val actual =
         CanHandleError[IO]
-          .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+          .handleEitherTNonFatal(fab)(err => SomeError.someThrowable(err).asLeft[Int])
           .value
-          .unsafeRunSync()
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        ex ==== fatalException
 
       case ex: Throwable =>
         Result.failure.log(s"Unexpected Throwable: ${ex.toString}")

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/canRecoverSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/canRecoverSpec.scala
@@ -3,12 +3,10 @@ package effectie.instances.ce3
 import canRecover._
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.SomeControlThrowable
 import effectie.core._
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.syntax.error._
 import effectie.syntax.fx._
 import effectie.testing.types.SomeError
@@ -172,15 +170,17 @@ object canRecoverSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
     val expectedException = SomeControlThrowable("Something's wrong")
-    val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-    val io = CanRecover[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
     try {
-      val actual = io.unsafeRunSync()
+      /* The first argument is by-name and forced synchronously, so the fatal is thrown during
+       * construction (never inside an IO) and cannot trip cats-effect's process-global
+       * onFatalFailure latch that otherwise hangs every fatal test after the first on a live
+       * IORuntime.
+       */
+      val actual = CanRecover[IO].recoverFromNonFatalWith(throwThrowable[IO[Int]](expectedException)) {
+        case NonFatal(`expectedException`) => IO.pure(123)
+      }
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
@@ -226,17 +226,16 @@ object canRecoverSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
     val expectedException = SomeControlThrowable("Something's wrong")
-    val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-    val io = CanRecover[IO].recoverFromNonFatalWith(fa) {
-      case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
-    }
     try {
-      val actual = io.unsafeRunSync()
+      /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+       * construction, never reaches the run loop.
+       */
+      val actual =
+        CanRecover[IO].recoverFromNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+          case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+        }
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
@@ -296,17 +295,16 @@ object canRecoverSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
     val expectedException = SomeControlThrowable("Something's wrong")
-    val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-    val io = CanRecover[IO].recoverEitherFromNonFatalWith(fa) {
-      case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-    }
     try {
-      val actual = io.unsafeRunSync()
+      /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+       * construction, never reaches the run loop.
+       */
+      val actual =
+        CanRecover[IO].recoverEitherFromNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
@@ -369,17 +367,18 @@ object canRecoverSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
     val expectedException = SomeControlThrowable("Something's wrong")
-    val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-    val io = CanRecover[IO].recoverEitherTFromNonFatalWith(fa) {
-      case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-    }
     try {
-      val actual = io.value.unsafeRunSync()
+      /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+       * construction, never reaches the run loop.
+       */
+      val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+      val actual = CanRecover[IO]
+        .recoverEitherTFromNonFatalWith(fab) {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+        .value
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
@@ -439,15 +438,15 @@ object canRecoverSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
     val expectedException = SomeControlThrowable("Something's wrong")
-    val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-    val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
     try {
-      val actual = io.unsafeRunSync()
+      /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+       * construction, never reaches the run loop.
+       */
+      val actual = CanRecover[IO].recoverFromNonFatal(throwThrowable[IO[Int]](expectedException)) {
+        case NonFatal(`expectedException`) => 123
+      }
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
@@ -486,15 +485,15 @@ object canRecoverSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
     val expectedException = SomeControlThrowable("Something's wrong")
-    val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-    val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
     try {
-      val actual = io.unsafeRunSync()
+      /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+       * construction, never reaches the run loop.
+       */
+      val actual = CanRecover[IO].recoverFromNonFatal(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+        case NonFatal(`expectedException`) => 123.asRight[SomeError]
+      }
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
@@ -547,18 +546,16 @@ object canRecoverSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
     val expectedException = SomeControlThrowable("Something's wrong")
-    val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-    val io =
-      CanRecover[IO].recoverEitherFromNonFatal(fa) {
-        case err => SomeError.someThrowable(err).asLeft[Int]
-      }
     try {
-      val actual = io.unsafeRunSync()
+      /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+       * construction, never reaches the run loop.
+       */
+      val actual =
+        CanRecover[IO].recoverEitherFromNonFatal(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+          case err => SomeError.someThrowable(err).asLeft[Int]
+        }
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>
@@ -617,18 +614,18 @@ object canRecoverSpec extends Properties {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
     val expectedException = SomeControlThrowable("Something's wrong")
-    val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-    val io =
-      CanRecover[IO].recoverEitherTFromNonFatal(fa) {
-        case err => SomeError.someThrowable(err).asLeft[Int]
-      }
     try {
-      val actual = io.value.unsafeRunSync()
+      /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+       * construction, never reaches the run loop.
+       */
+      val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+      val actual = CanRecover[IO]
+        .recoverEitherTFromNonFatal(fab) {
+          case err => SomeError.someThrowable(err).asLeft[Int]
+        }
+        .value
       Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
     } catch {
       case ex: ControlThrowable =>

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/fxSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/fxSpec.scala
@@ -12,13 +12,11 @@ import effectie.specs.MonadSpec
 import effectie.specs.fxSpec.FxSpecs
 import effectie.syntax.error._
 import effectie.testing.types.SomeError
-import extras.concurrent.testing.ConcurrentSupport
 import extras.hedgehog.ce3.syntax.runner._
 import fx._
 import hedgehog._
 import hedgehog.runner._
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -557,18 +555,18 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+          /* `fa` is by-name and forced synchronously, so the fatal is thrown during construction
+           * (never inside an IO) and cannot trip cats-effect's process-global onFatalFailure latch
+           * that otherwise hangs every fatal test after the first on a live IORuntime.
+           */
+          val actual = Fx[IO].catchNonFatalThrowable(throwThrowable[IO[Int]](fatalException))
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -598,18 +596,17 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val actual =
+            Fx[IO].catchNonFatal(throwThrowable[IO[Int]](fatalException))(SomeError.someThrowable)
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -639,18 +636,19 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val actual =
+            Fx[IO]
+              .catchNonFatalEither(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(SomeError.someThrowable)
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -690,18 +688,17 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
+          val actual = Fx[IO].catchNonFatalEitherT(fab)(SomeError.someThrowable).value
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -751,18 +748,17 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val actual =
+            Fx[IO].handleNonFatalWith(throwThrowable[IO[Int]](fatalException))(_ => IO.pure(123))
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -797,18 +793,21 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val actual =
+            Fx[IO]
+              .handleNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(_ =>
+                IO.pure(123.asRight[SomeError])
+              )
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -854,21 +853,21 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
           val actual =
             Fx[IO]
-              .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-              .unsafeRunSync()
+              .handleEitherNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(err =>
+                IO.pure(SomeError.someThrowable(err).asLeft[Int])
+              )
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -917,22 +916,21 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
           val actual =
             Fx[IO]
-              .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+              .handleEitherTNonFatalWith(fab)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
               .value
-              .unsafeRunSync()
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -981,18 +979,16 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val actual = Fx[IO].handleNonFatal(throwThrowable[IO[Int]](fatalException))(_ => 123)
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1025,18 +1021,19 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val actual =
+            Fx[IO]
+              .handleNonFatal(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(_ => 123.asRight[SomeError])
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1081,21 +1078,21 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
           val actual =
             Fx[IO]
-              .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-              .unsafeRunSync()
+              .handleEitherNonFatal(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(err =>
+                SomeError.someThrowable(err).asLeft[Int]
+              )
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1142,22 +1139,21 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
           val actual =
             Fx[IO]
-              .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+              .handleEitherTNonFatal(fab)(err => SomeError.someThrowable(err).asLeft[Int])
               .value
-              .unsafeRunSync()
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1205,15 +1201,14 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-        val io = Fx[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val actual = Fx[IO].recoverFromNonFatalWith(throwThrowable[IO[Int]](expectedException)) {
+            case NonFatal(`expectedException`) => IO.pure(123)
+          }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1259,17 +1254,14 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val io = Fx[IO].recoverFromNonFatalWith(fa) {
-          case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
-        }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val actual = Fx[IO].recoverFromNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+          }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1329,17 +1321,16 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val io = Fx[IO].recoverEitherFromNonFatalWith(fa) {
-          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-        }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val actual = Fx[IO]
+            .recoverEitherFromNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+              case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            }
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1403,17 +1394,17 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-        val io = Fx[IO].recoverEitherTFromNonFatalWith(fa) {
-          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-        }
         try {
-          val actual = io.value.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+          val actual = Fx[IO]
+            .recoverEitherTFromNonFatalWith(fab) {
+              case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            }
+            .value
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1473,15 +1464,14 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val actual = Fx[IO].recoverFromNonFatal(throwThrowable[IO[Int]](expectedException)) {
+            case NonFatal(`expectedException`) => 123
+          }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1520,15 +1510,14 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val actual = Fx[IO].recoverFromNonFatal(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case NonFatal(`expectedException`) => 123.asRight[SomeError]
+          }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1581,18 +1570,14 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val io =
-          Fx[IO].recoverEitherFromNonFatal(fa) {
+        try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val actual = Fx[IO].recoverEitherFromNonFatal(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
             case err => SomeError.someThrowable(err).asLeft[Int]
           }
-        try {
-          val actual = io.unsafeRunSync()
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1651,18 +1636,17 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-        val io =
-          Fx[IO].recoverEitherTFromNonFatal(fa) {
-            case err => SomeError.someThrowable(err).asLeft[Int]
-          }
         try {
-          val actual = io.value.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during construction,
+           * never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+          val actual = Fx[IO]
+            .recoverEitherTFromNonFatal(fab) {
+              case err => SomeError.someThrowable(err).asLeft[Int]
+            }
+            .value
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1723,6 +1707,7 @@ object fxSpec extends Properties {
                   } *> IO.unit
               }
               .unsafeRunSync()
+
             new AssertionError(s"Should have thrown an exception, but it was ${r.toString}.")
           } catch {
             case ex: Throwable =>
@@ -1740,23 +1725,22 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
-        var actual            = none[Int] // scalafix:ok DisableSyntax.var
 
-        val io = Fx[IO].onNonFatalWith(fa) {
-          case NonFatal(`expectedException`) =>
-            IO.delay {
-              actual = 123.some
-              ()
-            } *> IO.unit
-        }
+        var actual = none[Int] // scalafix:ok DisableSyntax.var
+
         try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          /* See catchNonFatalThrowableShouldNotCatchFatal: the by-name receiver is forced synchronously,
+           * so the fatal is thrown during construction and never reaches the run loop. */
+          val _ = Fx[IO].onNonFatalWith(throwThrowable[IO[Int]](expectedException)) {
+            case NonFatal(`expectedException`) =>
+              IO.delay {
+                actual = 123.some
+                ()
+              } *> IO.unit
+          }
+
+          Result.failure.log("The expected fatal exception was not thrown.")
         } catch {
           case ex: ControlThrowable =>
             Result.all(

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/syntax/errorSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/syntax/errorSpec.scala
@@ -2,13 +2,10 @@ package effectie.syntax
 
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import effectie.SomeControlThrowable
 import effectie.core.Fx
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.instances.ce3.fx._
-import effectie.instances.ce3.testing
 import effectie.syntax.error._
 import effectie.syntax.fx._
 import effectie.testing.types.SomeError
@@ -18,7 +15,6 @@ import extras.hedgehog.ce3.syntax.runner._
 import hedgehog._
 import hedgehog.runner._
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -156,18 +152,19 @@ object CanCatchSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.catchNonFatalThrowable.unsafeRunSync()
+        /* `fa` is by-name and forced synchronously, so the fatal is thrown during construction
+         * (never inside an IO) and cannot trip cats-effect's process-global onFatalFailure latch
+         * that otherwise hangs every fatal test after the first on a live IORuntime.
+         */
+        val fa     = throwThrowable[IO[Int]](fatalException)
+        val actual = fa.catchNonFatalThrowable
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -197,18 +194,18 @@ object CanCatchSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.catchNonFatal(SomeError.someThrowable).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Int]](fatalException)
+        val actual = fa.catchNonFatal(SomeError.someThrowable)
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -238,18 +235,18 @@ object CanCatchSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.catchNonFatalEither(SomeError.someThrowable).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](fatalException)
+        val actual = fa.catchNonFatalEither(SomeError.someThrowable)
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -289,18 +286,18 @@ object CanCatchSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.catchNonFatalEitherT(SomeError.someThrowable).value.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
+        val actual = fa.catchNonFatalEitherT(SomeError.someThrowable).value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -751,18 +748,18 @@ object CanHandleErrorSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.handleNonFatalWith(_ => IO.pure(123)).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Int]](fatalException)
+        val actual = fa.handleNonFatalWith(_ => IO.pure(123))
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -795,18 +792,18 @@ object CanHandleErrorSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.handleNonFatalWith(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](fatalException)
+        val actual = fa.handleNonFatalWith(_ => IO.pure(123.asRight[SomeError]))
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -849,20 +846,19 @@ object CanHandleErrorSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](fatalException)
         val actual =
           fa.handleEitherNonFatalWith(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-            .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -908,21 +904,19 @@ object CanHandleErrorSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
         val actual =
-          fa.handleEitherTNonFatalWith(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-            .value
-            .unsafeRunSync()
+          fa.handleEitherTNonFatalWith(err => IO.pure(SomeError.someThrowable(err).asLeft[Int])).value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -968,18 +962,18 @@ object CanHandleErrorSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.handleNonFatal(_ => 123).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Int]](fatalException)
+        val actual = fa.handleNonFatal(_ => 123)
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1011,18 +1005,18 @@ object CanHandleErrorSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.handleNonFatal(_ => 123.asRight[SomeError]).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](fatalException)
+        val actual = fa.handleNonFatal(_ => 123.asRight[SomeError])
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1064,20 +1058,19 @@ object CanHandleErrorSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](fatalException)
         val actual =
           fa.handleEitherNonFatal(err => SomeError.someThrowable(err).asLeft[Int])
-            .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1119,21 +1112,19 @@ object CanHandleErrorSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
         val actual =
-          fa.handleEitherTNonFatal(err => SomeError.someThrowable(err).asLeft[Int])
-            .value
-            .unsafeRunSync()
+          fa.handleEitherTNonFatal(err => SomeError.someThrowable(err).asLeft[Int]).value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1835,15 +1826,14 @@ object CanRecoverSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-      val io = fa.recoverFromNonFatalWith { case NonFatal(`expectedException`) => IO.pure(123) }
       try {
-        val actual = io.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Int]](expectedException)
+        val actual = fa.recoverFromNonFatalWith { case NonFatal(`expectedException`) => IO.pure(123) }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -1886,17 +1876,16 @@ object CanRecoverSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io = fa.recoverFromNonFatalWith {
-        case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
-      }
       try {
-        val actual = io.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](expectedException)
+        val actual = fa.recoverFromNonFatalWith {
+          case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+        }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -1952,17 +1941,16 @@ object CanRecoverSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io = fa.recoverEitherFromNonFatalWith {
-        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-      }
       try {
-        val actual = io.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](expectedException)
+        val actual = fa.recoverEitherFromNonFatalWith {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2018,17 +2006,16 @@ object CanRecoverSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-      val io = fa.recoverEitherTFromNonFatalWith {
-        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-      }
       try {
-        val actual = io.value.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+        val actual = fa.recoverEitherTFromNonFatalWith {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }.value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2081,15 +2068,14 @@ object CanRecoverSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-      val io = fa.recoverFromNonFatal { case NonFatal(`expectedException`) => 123 }
       try {
-        val actual = io.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Int]](expectedException)
+        val actual = fa.recoverFromNonFatal { case NonFatal(`expectedException`) => 123 }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2125,15 +2111,14 @@ object CanRecoverSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io = fa.recoverFromNonFatal { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
       try {
-        val actual = io.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](expectedException)
+        val actual = fa.recoverFromNonFatal { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2182,18 +2167,17 @@ object CanRecoverSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io =
-        fa.recoverEitherFromNonFatal {
-          case err => SomeError.someThrowable(err).asLeft[Int]
-        }
       try {
-        val actual = io.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](expectedException)
+        val actual =
+          fa.recoverEitherFromNonFatal {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2244,18 +2228,17 @@ object CanRecoverSyntaxSpec {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-      val io =
-        fa.recoverEitherTFromNonFatal {
-          case err => SomeError.someThrowable(err).asLeft[Int]
-        }
       try {
-        val actual = io.value.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+        val actual =
+          fa.recoverEitherTFromNonFatal {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }.value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2852,15 +2835,15 @@ object OnNonFatalSyntaxSpec {
 
     def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
-      var actual            = none[Int] // scalafix:ok DisableSyntax.var
+
+      var actual = none[Int] // scalafix:ok DisableSyntax.var
 
       try {
-        val r = fa
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val r = throwThrowable[IO[Int]](expectedException)
           .onNonFatalWith {
             case NonFatal(`expectedException`) =>
               IO {
@@ -2868,7 +2851,6 @@ object OnNonFatalSyntaxSpec {
                 ()
               } *> IO.unit
           }
-          .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${r.toString}")
       } catch {
         case ex: ControlThrowable =>

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/canCatchSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/canCatchSpec.scala
@@ -3,7 +3,6 @@ package effectie.instances.ce3
 import cats.*
 import cats.data.EitherT
 import cats.effect.*
-import cats.effect.unsafe.IORuntime
 import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.SomeControlThrowable
@@ -11,12 +10,9 @@ import effectie.core.*
 import effectie.syntax.error.*
 import effectie.syntax.fx.*
 import effectie.testing.types.SomeError
-import extras.concurrent.testing.ConcurrentSupport
 import extras.hedgehog.ce3.syntax.runner._
 import hedgehog.*
 import hedgehog.runner.*
-
-import java.util.concurrent.ExecutorService
 
 /** @author Kevin Lee
   * @since 2020-07-31
@@ -102,18 +98,19 @@ object canCatchSpec extends Properties {
 
     def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = CanCatch[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+        /* `fa` is by-name, so throwing the fatal here happens synchronously while constructing the IO
+         * (before any IO value exists), the instant catchNonFatalThrowable forces it. The fatal therefore
+         * never enters cats-effect's run loop, so it cannot trip the process-global onFatalFailure latch
+         * (which otherwise hangs every fatal test after the first when run on a live IORuntime).
+         */
+        val actual = CanCatch[IO].catchNonFatalThrowable[Int](throwThrowable[IO[Int]](fatalException))
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -142,18 +139,17 @@ object canCatchSpec extends Properties {
 
     def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: the by-name `fb` is forced
+         * synchronously, so the fatal is thrown during construction and never reaches the run loop.
+         */
+        val actual = CanCatch[IO].catchNonFatal(throwThrowable[IO[Int]](fatalException))(SomeError.someThrowable)
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -182,18 +178,18 @@ object canCatchSpec extends Properties {
 
     def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: the by-name `fab` is forced
+         * synchronously, so the fatal is thrown during construction and never reaches the run loop.
+         */
+        val actual = CanCatch[IO]
+          .catchNonFatalEither(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(SomeError.someThrowable)
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -232,18 +228,18 @@ object canCatchSpec extends Properties {
 
     def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: EitherT.apply evaluates its argument
+         * eagerly, so the fatal is thrown on this line during construction and never reaches the run loop.
+         */
+        val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
+        val actual = CanCatch[IO].catchNonFatalEitherT(fab)(SomeError.someThrowable).value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/canHandleErrorSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/canHandleErrorSpec.scala
@@ -3,7 +3,6 @@ package effectie.instances.ce3
 import cats.*
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.testing.types.SomeError
@@ -11,12 +10,10 @@ import effectie.core.*
 import effectie.syntax.error.*
 import effectie.syntax.fx.*
 import effectie.SomeControlThrowable
-import extras.concurrent.testing.ConcurrentSupport
 import extras.hedgehog.ce3.syntax.runner._
 import hedgehog.*
 import hedgehog.runner.*
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -171,18 +168,18 @@ object canHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+        /* `fa` is by-name and forced synchronously, so the fatal is thrown during construction
+         * (never inside an IO) and cannot trip cats-effect's process-global onFatalFailure latch
+         * that otherwise hangs every fatal test after the first on a live IORuntime.
+         */
+        val actual = CanHandleError[IO].handleNonFatalWith(throwThrowable[IO[Int]](fatalException))(_ => IO.pure(123))
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -216,18 +213,20 @@ object canHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val actual = CanHandleError[IO]
+          .handleNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(_ =>
+            IO.pure(123.asRight[SomeError])
+          )
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -271,21 +270,21 @@ object canHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
         val actual =
           CanHandleError[IO]
-            .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-            .unsafeRunSync()
+            .handleEitherNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(err =>
+              IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            )
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -332,22 +331,21 @@ object canHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
         val actual =
           CanHandleError[IO]
-            .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+            .handleEitherTNonFatalWith(fab)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
             .value
-            .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -393,18 +391,17 @@ object canHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val actual = CanHandleError[IO].handleNonFatal(throwThrowable[IO[Int]](fatalException))(_ => 123)
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -436,18 +433,20 @@ object canHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val actual =
+          CanHandleError[IO].handleNonFatal(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(_ =>
+            123.asRight[SomeError]
+          )
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -491,21 +490,21 @@ object canHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
         val actual =
           CanHandleError[IO]
-            .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-            .unsafeRunSync()
+            .handleEitherNonFatal(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(err =>
+              SomeError.someThrowable(err).asLeft[Int]
+            )
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -551,22 +550,21 @@ object canHandleErrorSpec extends Properties {
 
     def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
         val actual =
           CanHandleError[IO]
-            .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+            .handleEitherTNonFatal(fab)(err => SomeError.someThrowable(err).asLeft[Int])
             .value
-            .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/canRecoverSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/canRecoverSpec.scala
@@ -3,12 +3,10 @@ package effectie.instances.ce3
 import cats.*
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.SomeControlThrowable
 import effectie.core.*
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.syntax.error.*
 import effectie.syntax.fx.*
 import effectie.testing.types.SomeError
@@ -172,15 +170,17 @@ object canRecoverSpec extends Properties {
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-      val io = CanRecover[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
       try {
-        val actual = io.unsafeRunSync()
+        /* The first argument is by-name and forced synchronously, so the fatal is thrown during
+         * construction (never inside an IO) and cannot trip cats-effect's process-global
+         * onFatalFailure latch that otherwise hangs every fatal test after the first on a live
+         * IORuntime.
+         */
+        val actual = CanRecover[IO].recoverFromNonFatalWith(throwThrowable[IO[Int]](expectedException)) {
+          case NonFatal(`expectedException`) => IO.pure(123)
+        }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -225,17 +225,16 @@ object canRecoverSpec extends Properties {
 
     def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io = CanRecover[IO].recoverFromNonFatalWith(fa) {
-        case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
-      }
       try {
-        val actual = io.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val actual =
+          CanRecover[IO].recoverFromNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+          }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -294,17 +293,16 @@ object canRecoverSpec extends Properties {
 
     def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io = CanRecover[IO].recoverEitherFromNonFatalWith(fa) {
-        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-      }
       try {
-        val actual = io.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val actual =
+          CanRecover[IO].recoverEitherFromNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -367,17 +365,18 @@ object canRecoverSpec extends Properties {
 
     def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-      val io = CanRecover[IO].recoverEitherTFromNonFatalWith(fa) {
-        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-      }
       try {
-        val actual = io.value.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+        val actual = CanRecover[IO]
+          .recoverEitherTFromNonFatalWith(fab) {
+            case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          }
+          .value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -436,15 +435,15 @@ object canRecoverSpec extends Properties {
 
     def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-      val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
       try {
-        val actual = io.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val actual = CanRecover[IO].recoverFromNonFatal(throwThrowable[IO[Int]](expectedException)) {
+          case NonFatal(`expectedException`) => 123
+        }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -482,15 +481,16 @@ object canRecoverSpec extends Properties {
 
     def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
       try {
-        val actual = io.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val actual =
+          CanRecover[IO].recoverFromNonFatal(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case NonFatal(`expectedException`) => 123.asRight[SomeError]
+          }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -542,18 +542,16 @@ object canRecoverSpec extends Properties {
 
     def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io =
-        CanRecover[IO].recoverEitherFromNonFatal(fa) {
-          case err => SomeError.someThrowable(err).asLeft[Int]
-        }
       try {
-        val actual = io.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val actual =
+          CanRecover[IO].recoverEitherFromNonFatal(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -611,18 +609,18 @@ object canRecoverSpec extends Properties {
 
     def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-      val io =
-        CanRecover[IO].recoverEitherTFromNonFatal(fa) {
-          case err => SomeError.someThrowable(err).asLeft[Int]
-        }
       try {
-        val actual = io.value.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+        val actual = CanRecover[IO]
+          .recoverEitherTFromNonFatal(fab) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+          .value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/fxSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/fxSpec.scala
@@ -14,12 +14,10 @@ import effectie.instances.ce3.fx.given
 import effectie.specs.fxSpec.FxSpecs
 import effectie.syntax.error.*
 import effectie.testing.types.{SomeError, SomeThrowableError}
-import extras.concurrent.testing.ConcurrentSupport
 import extras.hedgehog.ce3.syntax.runner.*
 import hedgehog.*
 import hedgehog.runner.*
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -613,18 +611,18 @@ object FxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
 
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+          /* `fa` is by-name and forced synchronously, so the fatal is thrown during construction
+           * (never inside an IO) and cannot trip cats-effect's process-global onFatalFailure latch
+           * that otherwise hangs every fatal test after the first on a live IORuntime.
+           */
+          val actual = Fx[IO].catchNonFatalThrowable(throwThrowable[IO[Int]](fatalException))
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -651,18 +649,17 @@ object FxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
 
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual =
+            Fx[IO].catchNonFatal(throwThrowable[IO[Int]](fatalException))(SomeError.someThrowable)
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -692,18 +689,18 @@ object FxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO]
+            .catchNonFatalEither(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(SomeError.someThrowable)
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -743,18 +740,17 @@ object FxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
+          val actual = Fx[IO].catchNonFatalEitherT(fab)(SomeError.someThrowable).value
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -801,18 +797,17 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
 
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual =
+            Fx[IO].handleNonFatalWith(throwThrowable[IO[Int]](fatalException))(_ => IO.pure(123))
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -846,18 +841,20 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
 
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO]
+            .handleNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(_ =>
+              IO.pure(123.asRight[SomeError])
+            )
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -902,21 +899,21 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
 
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
           val actual =
             Fx[IO]
-              .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-              .unsafeRunSync()
+              .handleEitherNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(err =>
+                IO.pure(SomeError.someThrowable(err).asLeft[Int])
+              )
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -964,22 +961,21 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
 
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
           val actual =
             Fx[IO]
-              .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+              .handleEitherTNonFatalWith(fab)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
               .value
-              .unsafeRunSync()
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1025,18 +1021,16 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
 
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO].handleNonFatal(throwThrowable[IO[Int]](fatalException))(_ => 123)
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1068,18 +1062,18 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
 
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO]
+            .handleNonFatal(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(_ => 123.asRight[SomeError])
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1123,21 +1117,21 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
 
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
           val actual =
             Fx[IO]
-              .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-              .unsafeRunSync()
+              .handleEitherNonFatal(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(err =>
+                SomeError.someThrowable(err).asLeft[Int]
+              )
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1183,22 +1177,21 @@ object FxSpec extends Properties {
 
       def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
 
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
           val actual =
             Fx[IO]
-              .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+              .handleEitherTNonFatal(fab)(err => SomeError.someThrowable(err).asLeft[Int])
               .value
-              .unsafeRunSync()
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1246,15 +1239,14 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
 
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-        val io = Fx[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO].recoverFromNonFatalWith(throwThrowable[IO[Int]](expectedException)) {
+            case NonFatal(`expectedException`) => IO.pure(123)
+          }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1299,17 +1291,14 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
 
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val io = Fx[IO].recoverFromNonFatalWith(fa) {
-          case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
-        }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO].recoverFromNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+          }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1368,17 +1357,15 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
 
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val io = Fx[IO].recoverEitherFromNonFatalWith(fa) {
-          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-        }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual =
+            Fx[IO].recoverEitherFromNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+              case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1442,17 +1429,17 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
 
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-        val io = Fx[IO].recoverEitherTFromNonFatalWith(fa) {
-          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-        }
         try {
-          val actual = io.value.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+          val actual = Fx[IO]
+            .recoverEitherTFromNonFatalWith(fab) {
+              case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            }
+            .value
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1511,15 +1498,14 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
 
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO].recoverFromNonFatal(throwThrowable[IO[Int]](expectedException)) {
+            case NonFatal(`expectedException`) => 123
+          }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1557,15 +1543,14 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
 
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO].recoverFromNonFatal(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case NonFatal(`expectedException`) => 123.asRight[SomeError]
+          }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1617,18 +1602,15 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
 
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val io =
-          Fx[IO].recoverEitherFromNonFatal(fa) {
-            case err => SomeError.someThrowable(err).asLeft[Int]
-          }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual =
+            Fx[IO].recoverEitherFromNonFatal(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+              case err => SomeError.someThrowable(err).asLeft[Int]
+            }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1686,18 +1668,18 @@ object FxSpec extends Properties {
 
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
 
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-        val io =
-          Fx[IO].recoverEitherTFromNonFatal(fa) {
-            case err => SomeError.someThrowable(err).asLeft[Int]
-          }
         try {
-          val actual = io.value.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+          val actual =
+            Fx[IO]
+              .recoverEitherTFromNonFatal(fab) {
+                case err => SomeError.someThrowable(err).asLeft[Int]
+              }
+              .value
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1758,6 +1740,7 @@ object FxSpec extends Properties {
                   } *> IO.unit
               }
               .unsafeRunSync()
+
             new AssertionError(s"Should have thrown an exception, but it was ${r.toString}.")
           } catch {
             case ex: Throwable =>
@@ -1775,23 +1758,22 @@ object FxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = {
 
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
-        var actual            = none[Int] // scalafix:ok DisableSyntax.var
 
-        val io = Fx[IO].onNonFatalWith(fa) {
-          case NonFatal(`expectedException`) =>
-            IO.delay {
-              actual = 123.some
-              ()
-            } *> IO.unit
-        }
+        var actual = none[Int] // scalafix:ok DisableSyntax.var
+
         try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          /* See catchNonFatalThrowableShouldNotCatchFatal: the by-name receiver is forced synchronously,
+           * so the fatal is thrown during construction and never reaches the run loop. */
+          val _ = Fx[IO].onNonFatalWith(throwThrowable[IO[Int]](expectedException)) {
+            case NonFatal(`expectedException`) =>
+              IO.delay {
+                actual = 123.some
+                ()
+              } *> IO.unit
+          }
+
+          Result.failure.log("The expected fatal exception was not thrown.")
         } catch {
           case ex: ControlThrowable =>
             Result.all(

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/syntax/errorSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/syntax/errorSpec.scala
@@ -2,13 +2,10 @@ package effectie.syntax
 
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.syntax.all.*
 import cats.Functor
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.syntax.fx.*
 import effectie.syntax.error.*
-import effectie.instances.ce3.testing
 import effectie.testing.types.*
 import effectie.core.Fx
 import effectie.SomeControlThrowable
@@ -18,7 +15,6 @@ import extras.hedgehog.ce3.syntax.runner._
 import hedgehog.*
 import hedgehog.runner.*
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -157,18 +153,19 @@ object CanCatchSyntaxSpec {
 
     def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.catchNonFatalThrowable.unsafeRunSync()
+        /* `fa` is by-name and forced synchronously, so the fatal is thrown during construction
+         * (never inside an IO) and cannot trip cats-effect's process-global onFatalFailure latch
+         * that otherwise hangs every fatal test after the first on a live IORuntime.
+         */
+        val fa     = throwThrowable[IO[Int]](fatalException)
+        val actual = fa.catchNonFatalThrowable
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -199,18 +196,18 @@ object CanCatchSyntaxSpec {
 
     def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.catchNonFatal(SomeError.someThrowable).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Int]](fatalException)
+        val actual = fa.catchNonFatal(SomeError.someThrowable)
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -241,18 +238,18 @@ object CanCatchSyntaxSpec {
 
     def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.catchNonFatalEither(SomeError.someThrowable).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](fatalException)
+        val actual = fa.catchNonFatalEither(SomeError.someThrowable)
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -294,18 +291,18 @@ object CanCatchSyntaxSpec {
 
     def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.catchNonFatalEitherT(SomeError.someThrowable).value.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
+        val actual = fa.catchNonFatalEitherT(SomeError.someThrowable).value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -801,18 +798,18 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.handleNonFatalWith(_ => IO.pure(123)).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Int]](fatalException)
+        val actual = fa.handleNonFatalWith(_ => IO.pure(123))
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -847,18 +844,18 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.handleNonFatalWith(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](fatalException)
+        val actual = fa.handleNonFatalWith(_ => IO.pure(123.asRight[SomeError]))
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -904,20 +901,19 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](fatalException)
         val actual =
           fa.handleEitherNonFatalWith(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-            .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -968,21 +964,19 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
         val actual =
-          fa.handleEitherTNonFatalWith(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-            .value
-            .unsafeRunSync()
+          fa.handleEitherTNonFatalWith(err => IO.pure(SomeError.someThrowable(err).asLeft[Int])).value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1035,18 +1029,18 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.handleNonFatal(_ => 123).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Int]](fatalException)
+        val actual = fa.handleNonFatal(_ => 123)
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1079,18 +1073,18 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = fa.handleNonFatal(_ => 123.asRight[SomeError]).unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](fatalException)
+        val actual = fa.handleNonFatal(_ => 123.asRight[SomeError])
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1136,20 +1130,19 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](fatalException)
         val actual =
           fa.handleEitherNonFatal(err => SomeError.someThrowable(err).asLeft[Int])
-            .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1198,21 +1191,19 @@ object CanHandleErrorSyntaxSpec {
 
     def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
         val actual =
-          fa.handleEitherTNonFatal(err => SomeError.someThrowable(err).asLeft[Int])
-            .value
-            .unsafeRunSync()
+          fa.handleEitherTNonFatal(err => SomeError.someThrowable(err).asLeft[Int]).value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1995,15 +1986,14 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-      val io = fa.recoverFromNonFatalWith { case NonFatal(`expectedException`) => IO.pure(123) }
       try {
-        val actual = io.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Int]](expectedException)
+        val actual = fa.recoverFromNonFatalWith { case NonFatal(`expectedException`) => IO.pure(123) }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2050,17 +2040,16 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io = fa.recoverFromNonFatalWith {
-        case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
-      }
       try {
-        val actual = io.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](expectedException)
+        val actual = fa.recoverFromNonFatalWith {
+          case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+        }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2123,17 +2112,16 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io = fa.recoverEitherFromNonFatalWith {
-        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-      }
       try {
-        val actual = io.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](expectedException)
+        val actual = fa.recoverEitherFromNonFatalWith {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2196,17 +2184,16 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-      val io = fa.recoverEitherTFromNonFatalWith {
-        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-      }
       try {
-        val actual = io.value.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+        val actual = fa.recoverEitherTFromNonFatalWith {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }.value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2271,15 +2258,14 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-      val io = fa.recoverFromNonFatal { case NonFatal(`expectedException`) => 123 }
       try {
-        val actual = io.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Int]](expectedException)
+        val actual = fa.recoverFromNonFatal { case NonFatal(`expectedException`) => 123 }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2318,15 +2304,14 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io = fa.recoverFromNonFatal { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
       try {
-        val actual = io.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](expectedException)
+        val actual = fa.recoverFromNonFatal { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2378,18 +2363,17 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io =
-        fa.recoverEitherFromNonFatal {
-          case err => SomeError.someThrowable(err).asLeft[Int]
-        }
       try {
-        val actual = io.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = throwThrowable[IO[Either[SomeError, Int]]](expectedException)
+        val actual =
+          fa.recoverEitherFromNonFatal {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -2445,18 +2429,17 @@ object CanRecoverSyntaxSpec {
 
     def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
 
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-      val io =
-        fa.recoverEitherTFromNonFatal {
-          case err => SomeError.someThrowable(err).asLeft[Int]
-        }
       try {
-        val actual = io.value.unsafeRunSync()
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fa     = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+        val actual =
+          fa.recoverEitherTFromNonFatal {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }.value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -3144,15 +3127,15 @@ object OnNonFatalSyntaxSpec {
 
     def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
-      var actual            = none[Int] // scalafix:ok DisableSyntax.var
+
+      var actual = none[Int] // scalafix:ok DisableSyntax.var
 
       try {
-        val r = fa
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal.
+         * Forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val r = throwThrowable[IO[Int]](expectedException)
           .onNonFatalWith {
             case NonFatal(`expectedException`) =>
               IO {
@@ -3160,7 +3143,6 @@ object OnNonFatalSyntaxSpec {
                 ()
               } *> IO.unit
           }
-          .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${r.toString}")
       } catch {
         case ex: ControlThrowable =>

--- a/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/canCatchSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/canCatchSpec.scala
@@ -10,15 +10,11 @@ import effectie.core._
 import effectie.syntax.error._
 import effectie.syntax.fx._
 import effectie.testing.types._
-import effectie.instances.ce3.testing
-import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.ErrorLogger
 import extras.hedgehog.ce3.syntax.runner._
 import effectie.instances.ce3.f.fxCtor._
 import hedgehog._
 import hedgehog.runner._
-
-import java.util.concurrent.ExecutorService
 
 /** @author Kevin Lee
   * @since 2020-07-31
@@ -111,23 +107,22 @@ object canCatchSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
+      val fatalException = SomeControlThrowable("Something's wrong")
 
-      testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+      try {
+        /* `fa` is by-name, so throwing the fatal here happens synchronously while constructing the IO
+         * (before any IO value exists), the instant catchNonFatalThrowable forces it. The fatal therefore
+         * never enters cats-effect's run loop, so it cannot trip the process-global onFatalFailure latch
+         * (which otherwise hangs every fatal test after the first when run on a live IORuntime).
+         */
+        val actual = CanCatch[IO].catchNonFatalThrowable[Int](throwThrowable[IO[Int]](fatalException))
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: SomeControlThrowable =>
+          ex.getMessage ==== fatalException.getMessage
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
-
-        try {
-          val actual = CanCatch[IO].catchNonFatalThrowable(fa).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
-
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-        }
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
 
     }
@@ -154,22 +149,20 @@ object canCatchSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+      val fatalException = SomeControlThrowable("Something's wrong")
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      try {
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: the by-name `fb` is forced
+         * synchronously, so the fatal is thrown during construction and never reaches the run loop.
+         */
+        val actual = CanCatch[IO].catchNonFatal(throwThrowable[IO[Int]](fatalException))(SomeError.someThrowable)
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: SomeControlThrowable =>
+          ex.getMessage ==== fatalException.getMessage
 
-        try {
-          val actual = CanCatch[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
-
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-        }
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
 
     }
@@ -196,22 +189,21 @@ object canCatchSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+      val fatalException = SomeControlThrowable("Something's wrong")
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      try {
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: the by-name `fab` is forced
+         * synchronously, so the fatal is thrown during construction and never reaches the run loop.
+         */
+        val actual = CanCatch[IO]
+          .catchNonFatalEither(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(SomeError.someThrowable)
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: SomeControlThrowable =>
+          ex.getMessage ==== fatalException.getMessage
 
-        try {
-          val actual = CanCatch[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
-
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-        }
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
     }
 
@@ -247,22 +239,21 @@ object canCatchSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+      val fatalException = SomeControlThrowable("Something's wrong")
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      try {
+        /* See testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: EitherT.apply evaluates its argument
+         * eagerly, so the fatal is thrown on this line during construction and never reaches the run loop.
+         */
+        val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
+        val actual = CanCatch[IO].catchNonFatalEitherT(fab)(SomeError.someThrowable).value
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: SomeControlThrowable =>
+          ex.getMessage ==== fatalException.getMessage
 
-        try {
-          val actual = CanCatch[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
-
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-        }
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
 
     }

--- a/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/canHandleErrorSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/canHandleErrorSpec.scala
@@ -4,7 +4,6 @@ import canHandleError._
 import cats._
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.SomeControlThrowable
@@ -12,7 +11,6 @@ import effectie.core._
 import effectie.syntax.error._
 import effectie.syntax.fx._
 import effectie.testing.types.SomeError
-import effectie.instances.ce3.testing
 import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
 import extras.hedgehog.ce3.syntax.runner._
@@ -20,7 +18,6 @@ import fxCtor._
 import hedgehog._
 import hedgehog.runner._
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -337,18 +334,18 @@ object canHandleErrorSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+        /* `fa` is by-name and forced synchronously, so the fatal is thrown during construction
+         * (never inside an IO) and cannot trip cats-effect's process-global onFatalFailure latch
+         * that otherwise hangs every fatal test after the first on a live IORuntime.
+         */
+        val actual = CanHandleError[IO].handleNonFatalWith(throwThrowable[IO[Int]](fatalException))(_ => IO.pure(123))
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -383,18 +380,20 @@ object canHandleErrorSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val actual = CanHandleError[IO]
+          .handleNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(_ =>
+            IO.pure(123.asRight[SomeError])
+          )
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          ex.getMessage ==== fatalException.getMessage
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -439,21 +438,21 @@ object canHandleErrorSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
         val actual =
           CanHandleError[IO]
-            .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-            .unsafeRunSync()
+            .handleEitherNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(err =>
+              IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            )
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -501,22 +500,21 @@ object canHandleErrorSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
         val actual =
           CanHandleError[IO]
-            .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+            .handleEitherTNonFatalWith(fab)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
             .value
-            .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -565,18 +563,17 @@ object canHandleErrorSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val actual = CanHandleError[IO].handleNonFatal(throwThrowable[IO[Int]](fatalException))(_ => 123)
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -609,18 +606,20 @@ object canHandleErrorSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
-        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val actual =
+          CanHandleError[IO].handleNonFatal(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(_ =>
+            123.asRight[SomeError]
+          )
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -665,21 +664,21 @@ object canHandleErrorSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
         val actual =
           CanHandleError[IO]
-            .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-            .unsafeRunSync()
+            .handleEitherNonFatal(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(err =>
+              SomeError.someThrowable(err).asLeft[Int]
+            )
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -726,22 +725,21 @@ object canHandleErrorSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      val fatalException = SomeControlThrowable("Something's wrong")
 
       try {
+        /* See testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith:
+         * forced synchronously, thrown during construction, never reaches the run loop.
+         */
+        val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
         val actual =
           CanHandleError[IO]
-            .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+            .handleEitherTNonFatal(fab)(err => SomeError.someThrowable(err).asLeft[Int])
             .value
-            .unsafeRunSync()
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          ex ==== fatalException
 
         case ex: Throwable =>
           Result.failure.log(s"Unexpected Throwable: ${ex.toString}")

--- a/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/canRecoverSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/canRecoverSpec.scala
@@ -3,15 +3,12 @@ package effectie.instances.ce3.f
 import canRecover._
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.SomeControlThrowable
 import effectie.core._
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.syntax.error._
 import effectie.syntax.fx._
-import effectie.instances.ce3.testing
 import effectie.testing.types.SomeError
 import extras.concurrent.testing.types.ErrorLogger
 import extras.hedgehog.ce3.syntax.runner._
@@ -179,15 +176,17 @@ object canRecoverSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-      val io = CanRecover[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
       try {
-        val actual = io.unsafeRunSync()
+        /* The first argument is by-name and forced synchronously, so the fatal is thrown during
+         * construction (never inside an IO) and cannot trip cats-effect's process-global
+         * onFatalFailure latch that otherwise hangs every fatal test after the first on a live
+         * IORuntime.
+         */
+        val actual = CanRecover[IO].recoverFromNonFatalWith(throwThrowable[IO[Int]](expectedException)) {
+          case NonFatal(`expectedException`) => IO.pure(123)
+        }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -233,17 +232,16 @@ object canRecoverSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io = CanRecover[IO].recoverFromNonFatalWith(fa) {
-        case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
-      }
       try {
-        val actual = io.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val actual =
+          CanRecover[IO].recoverFromNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+          }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -303,17 +301,16 @@ object canRecoverSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io = CanRecover[IO].recoverEitherFromNonFatalWith(fa) {
-        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-      }
       try {
-        val actual = io.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val actual =
+          CanRecover[IO].recoverEitherFromNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -376,17 +373,18 @@ object canRecoverSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-      val io = CanRecover[IO].recoverEitherTFromNonFatalWith(fa) {
-        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-      }
       try {
-        val actual = io.value.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+        val actual = CanRecover[IO]
+          .recoverEitherTFromNonFatalWith(fab) {
+            case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          }
+          .value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -446,15 +444,15 @@ object canRecoverSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-      val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
       try {
-        val actual = io.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val actual = CanRecover[IO].recoverFromNonFatal(throwThrowable[IO[Int]](expectedException)) {
+          case NonFatal(`expectedException`) => 123
+        }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -493,15 +491,16 @@ object canRecoverSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
       try {
-        val actual = io.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val actual =
+          CanRecover[IO].recoverFromNonFatal(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case NonFatal(`expectedException`) => 123.asRight[SomeError]
+          }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -554,18 +553,16 @@ object canRecoverSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val io =
-        CanRecover[IO].recoverEitherFromNonFatal(fa) {
-          case err => SomeError.someThrowable(err).asLeft[Int]
-        }
       try {
-        val actual = io.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val actual =
+          CanRecover[IO].recoverEitherFromNonFatal(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>
@@ -624,18 +621,18 @@ object canRecoverSpec extends Properties {
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
       val expectedException = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-      val io =
-        CanRecover[IO].recoverEitherTFromNonFatal(fa) {
-          case err => SomeError.someThrowable(err).asLeft[Int]
-        }
       try {
-        val actual = io.value.unsafeRunSync()
+        /* See recoverFromNonFatalWithShouldNotCatchFatal: forced synchronously, thrown during
+         * construction, never reaches the run loop.
+         */
+        val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+        val actual = CanRecover[IO]
+          .recoverEitherTFromNonFatal(fab) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+          .value
         Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
       } catch {
         case ex: ControlThrowable =>

--- a/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/fxSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/fxSpec.scala
@@ -13,13 +13,11 @@ import effectie.specs.MonadSpec
 import effectie.specs.fxSpec.FxSpecs
 import effectie.syntax.error._
 import effectie.testing.types.SomeError
-import extras.concurrent.testing.ConcurrentSupport
 import extras.hedgehog.ce3.syntax.runner._
 import fx._
 import hedgehog._
 import hedgehog.runner._
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -560,18 +558,18 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+          /* `fa` is by-name and forced synchronously, so the fatal is thrown during construction
+           * (never inside an IO) and cannot trip cats-effect's process-global onFatalFailure latch
+           * that otherwise hangs every fatal test after the first on a live IORuntime.
+           */
+          val actual = Fx[IO].catchNonFatalThrowable(throwThrowable[IO[Int]](fatalException))
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -601,18 +599,17 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].catchNonFatal(fa)(SomeError.someThrowable).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual =
+            Fx[IO].catchNonFatal(throwThrowable[IO[Int]](fatalException))(SomeError.someThrowable)
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -642,18 +639,19 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual =
+            Fx[IO]
+              .catchNonFatalEither(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(SomeError.someThrowable)
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -693,18 +691,17 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
+          val actual = Fx[IO].catchNonFatalEitherT(fab)(SomeError.someThrowable).value
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -754,18 +751,17 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual =
+            Fx[IO].handleNonFatalWith(throwThrowable[IO[Int]](fatalException))(_ => IO.pure(123))
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -800,18 +796,21 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual =
+            Fx[IO]
+              .handleNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(_ =>
+                IO.pure(123.asRight[SomeError])
+              )
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            ex.getMessage ==== fatalException.getMessage
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -857,21 +856,21 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
           val actual =
             Fx[IO]
-              .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-              .unsafeRunSync()
+              .handleEitherNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(err =>
+                IO.pure(SomeError.someThrowable(err).asLeft[Int])
+              )
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -920,22 +919,21 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
           val actual =
             Fx[IO]
-              .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+              .handleEitherTNonFatalWith(fab)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
               .value
-              .unsafeRunSync()
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -984,18 +982,16 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO].handleNonFatal(throwThrowable[IO[Int]](fatalException))(_ => 123)
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1028,18 +1024,19 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
-          val actual = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual =
+            Fx[IO]
+              .handleNonFatal(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(_ => 123.asRight[SomeError])
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1084,21 +1081,21 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
           val actual =
             Fx[IO]
-              .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-              .unsafeRunSync()
+              .handleEitherNonFatal(throwThrowable[IO[Either[SomeError, Int]]](fatalException))(err =>
+                SomeError.someThrowable(err).asLeft[Int]
+              )
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1145,22 +1142,21 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
-
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        val fatalException = SomeControlThrowable("Something's wrong")
 
         try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](fatalException))
           val actual =
             Fx[IO]
-              .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+              .handleEitherTNonFatal(fab)(err => SomeError.someThrowable(err).asLeft[Int])
               .value
-              .unsafeRunSync()
+
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            ex ==== fatalException
 
           case ex: Throwable =>
             Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
@@ -1208,15 +1204,14 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-        val io = Fx[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO].recoverFromNonFatalWith(throwThrowable[IO[Int]](expectedException)) {
+            case NonFatal(`expectedException`) => IO.pure(123)
+          }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1262,17 +1257,14 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val io = Fx[IO].recoverFromNonFatalWith(fa) {
-          case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
-        }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO].recoverFromNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+          }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1332,17 +1324,15 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val io = Fx[IO].recoverEitherFromNonFatalWith(fa) {
-          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-        }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual =
+            Fx[IO].recoverEitherFromNonFatalWith(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+              case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1406,17 +1396,17 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-        val io = Fx[IO].recoverEitherTFromNonFatalWith(fa) {
-          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
-        }
         try {
-          val actual = io.value.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+          val actual = Fx[IO]
+            .recoverEitherTFromNonFatalWith(fab) {
+              case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            }
+            .value
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1476,15 +1466,14 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO].recoverFromNonFatal(throwThrowable[IO[Int]](expectedException)) {
+            case NonFatal(`expectedException`) => 123
+          }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1523,15 +1512,14 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
         try {
-          val actual = io.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO].recoverFromNonFatal(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
+            case NonFatal(`expectedException`) => 123.asRight[SomeError]
+          }
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1584,18 +1572,14 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val io =
-          Fx[IO].recoverEitherFromNonFatal(fa) {
+        try {
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val actual = Fx[IO].recoverEitherFromNonFatal(throwThrowable[IO[Either[SomeError, Int]]](expectedException)) {
             case err => SomeError.someThrowable(err).asLeft[Int]
           }
-        try {
-          val actual = io.unsafeRunSync()
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1654,18 +1638,17 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-        val io =
-          Fx[IO].recoverEitherTFromNonFatal(fa) {
-            case err => SomeError.someThrowable(err).asLeft[Int]
-          }
         try {
-          val actual = io.value.unsafeRunSync()
+          /* See catchNonFatalThrowableShouldNotCatchFatal: forced synchronously, thrown during
+           * construction, never reaches the run loop. */
+          val fab    = EitherT(throwThrowable[IO[Either[SomeError, Int]]](expectedException))
+          val actual = Fx[IO]
+            .recoverEitherTFromNonFatal(fab) {
+              case err => SomeError.someThrowable(err).asLeft[Int]
+            }
+            .value
           Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
         } catch {
           case ex: ControlThrowable =>
@@ -1726,6 +1709,7 @@ object fxSpec extends Properties {
                   } *> IO.unit
               }
               .unsafeRunSync()
+
             new AssertionError(s"Should have thrown an exception, but it was ${r.toString}.")
           } catch {
             case ex: Throwable =>
@@ -1743,23 +1727,22 @@ object fxSpec extends Properties {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = {
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
         val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
-        var actual            = none[Int] // scalafix:ok DisableSyntax.var
 
-        val io = Fx[IO].onNonFatalWith(fa) {
-          case NonFatal(`expectedException`) =>
-            IO.delay {
-              actual = 123.some
-              ()
-            } *> IO.unit
-        }
+        var actual = none[Int] // scalafix:ok DisableSyntax.var
+
         try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          /* See catchNonFatalThrowableShouldNotCatchFatal: the by-name receiver is forced synchronously,
+           * so the fatal is thrown during construction and never reaches the run loop. */
+          val _ = Fx[IO].onNonFatalWith(throwThrowable[IO[Int]](expectedException)) {
+            case NonFatal(`expectedException`) =>
+              IO.delay {
+                actual = 123.some
+                ()
+              } *> IO.unit
+          }
+
+          Result.failure.log("The expected fatal exception was not thrown.")
         } catch {
           case ex: ControlThrowable =>
             Result.all(

--- a/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/onNonFatalSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/onNonFatalSpec.scala
@@ -84,23 +84,21 @@ object onNonFatalSpec extends Properties {
       var actual = none[Int] // scalafix:ok DisableSyntax.var
 
       try {
-        runIO {
-
-          val fa = run[IO, Int](throwThrowable[Int](expectedException))
-
+        /* `fa` is by-name and forced synchronously by onNonFatalWith, so the fatal is thrown during
+         * construction (never inside an IO) and cannot trip cats-effect's process-global onFatalFailure
+         * latch that otherwise hangs every fatal test after the first on a live IORuntime.
+         */
+        val _ =
           OnNonFatal[IO]
-            .onNonFatalWith(fa) {
+            .onNonFatalWith(throwThrowable[IO[Int]](expectedException)) {
               case NonFatal(`expectedException`) =>
                 IO.delay {
                   actual = 123.some
                   ()
                 } *> IO.unit
             }
-            .map { actual =>
-              Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-            }
 
-        }
+        Result.failure.log("The expected fatal exception was not thrown.")
       } catch {
         case ex: ControlThrowable =>
           Result.all(

--- a/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/onNonFatalSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/onNonFatalSpec.scala
@@ -84,23 +84,21 @@ object onNonFatalSpec extends Properties {
       var actual = none[Int] // scalafix:ok DisableSyntax.var
 
       try {
-        runIO {
-
-          val fa = run[IO, Int](throwThrowable[Int](expectedException))
-
+        /* `fa` is by-name and forced synchronously by onNonFatalWith, so the fatal is thrown during
+         * construction (never inside an IO) and cannot trip cats-effect's process-global onFatalFailure
+         * latch that otherwise hangs every fatal test after the first on a live IORuntime.
+         */
+        val _ =
           OnNonFatal[IO]
-            .onNonFatalWith(fa) {
+            .onNonFatalWith(throwThrowable[IO[Int]](expectedException)) {
               case NonFatal(`expectedException`) =>
                 IO.delay {
                   actual = 123.some
                   ()
                 } *> IO.unit
             }
-            .map { actual =>
-              Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-            }
 
-        }
+        Result.failure.log("The expected fatal exception was not thrown.")
       } catch {
         case ex: ControlThrowable =>
           Result.all(


### PR DESCRIPTION
## Fix hanging cats-effect 3 "should not catch Fatal" tests

The `...ShouldNotCatchFatal` / `...ShouldNotHandleFatal` / `...ShouldNotRecoverFromFatal` tests in the JVM `effectie-cats-effect3` specs could hang indefinitely.

These tests threw a fatal `SomeControlThrowable` inside an `IO` and ran it on a live `IORuntime` via `unsafeRunSync()`. cats-effect routes a fatal error to a process-global one-shot latch (`IORuntime.globalFatalFailureHandled`): only the first fatal in the JVM notifies the blocked `unsafeRunSync`, so every subsequent fatal test blocked forever. This is independent of the cats-effect 3 version.

Since these tests only assert that the combinators do not catch a fatal `Throwable`, the fatal is now thrown while constructing the by-name argument (forced synchronously, never inside an `IO`) and caught with a plain `try`/`catch`. No runtime is created, so the process-global latch is never involved and the tests cannot hang.

- Rewrote the fatal subtests across `canCatch`, `canHandleError`, `canRecover`, `fx`, `error`, and `onNonFatal` specs (scala-2, scala-3, and the `f` variant where present).
- Removed the now-unused `IORuntime` / executor scaffolding and imports.