### PR TITLE
Close #702: Update Scala, sbt, sbt plugins and libraries, and remove unused plugins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
-          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
-          - { name: "Scala 3", version: "3.3.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 2", version: "2.12.20", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 2", version: "2.13.18", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 3", version: "3.3.5",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
-          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
-#          - { name: "Scala 3", version: "3.3.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 2", version: "2.12.20", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 2", version: "2.13.18", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
+#          - { name: "Scala 3", version: "3.3.5",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.13.16",  binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 2", version: "2.13.18",  binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
-          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
-          - { name: "Scala 3", version: "3.3.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 2", version: "2.12.20", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 2", version: "2.13.18", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 3", version: "3.3.5",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v7
@@ -66,7 +66,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 2", version: "2.13.18", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/sbt-build-all.sh
+++ b/.github/workflows/sbt-build-all.sh
@@ -5,7 +5,7 @@ set -x
 if [ -z "$1" ]
   then
     echo "Missing parameters. Please enter the [Scala version]."
-    echo "sbt-build.sh 2.13.4"
+    echo "sbt-build.sh 2.13.18"
     exit 1
 else
   : ${CURRENT_BRANCH_NAME:?"CURRENT_BRANCH_NAME is missing."}

--- a/.github/workflows/sbt-build.sh
+++ b/.github/workflows/sbt-build.sh
@@ -5,7 +5,7 @@ set -x
 if [ -z "$2" ]
   then
     echo "Missing parameters. Please enter the [project] and [Scala version]."
-    echo "sbt-build.sh core 2.13.4"
+    echo "sbt-build.sh core 2.13.18"
     exit 1
 else
   : ${CURRENT_BRANCH_NAME:?"CURRENT_BRANCH_NAME is missing."}

--- a/build.sbt
+++ b/build.sbt
@@ -484,13 +484,13 @@ lazy val props =
     final val RepoName       = "effectie"
 
     final val Scala2Versions = List(
-      "2.13.16",
-      "2.12.18",
+      "2.13.18",
+      "2.12.20",
     )
     final val Scala2Version  = Scala2Versions.head
 //    final val Scala2Version  = Scala2Versions.last
 
-    final val Scala3Version = "3.3.3"
+    val Scala3Version = "3.3.5"
 
 //    final val ProjectScalaVersion = "2.12.13"
     val ProjectScalaVersion = Scala2Version
@@ -515,7 +515,7 @@ lazy val props =
 
     final val IncludeTest = "compile->compile;test->test"
 
-    final val hedgehogLatestVersion = "0.13.0"
+    val hedgehogLatestVersion = "0.13.1"
 
     val MunitVersion = "0.7.29"
 
@@ -526,16 +526,16 @@ lazy val props =
     val catsEffect2Version       = "2.4.1"
     val catsEffect2LatestVersion = "2.5.4"
 
-    val catsEffect3Version          = "3.3.14"
-    val catsEffect3ForNativeVersion = "3.7.0-RC1"
+    val catsEffect3Version          = "3.7.0"
+    val catsEffect3ForNativeVersion = "3.7.0"
 
     final val cats2_0_0Version       = "2.0.0"
     final val catsEffect2_0_0Version = "2.0.0"
 
     final val monixVersion3_3_0 = "3.3.0"
-    final val monixVersion      = "3.4.0"
+    final val monixVersion      = "3.4.1"
 
-    final val ExtrasVersion = "0.49.0"
+    val ExtrasVersion = "0.53.0"
 
     val ScalaJsMacrotaskExecutorVersion = "1.1.1"
 

--- a/modules/effectie-cats-effect2/js/src/test/scala/effectie/instances/ce2/canCatchSpec.scala
+++ b/modules/effectie-cats-effect2/js/src/test/scala/effectie/instances/ce2/canCatchSpec.scala
@@ -13,7 +13,6 @@ import effectie.testing.types._
 import fxCtor.ioFxCtor
 import munit.Assertions
 
-import scala.concurrent._
 import scala.concurrent.duration._
 
 /** @author Kevin Lee
@@ -21,7 +20,7 @@ import scala.concurrent.duration._
   */
 class canCatchSpec extends munit.FunSuite with FutureTools {
 
-  implicit val ec: ExecutionContext = globalExecutionContext
+  implicit val ec: scala.concurrent.ExecutionContext = globalExecutionContext
 
   override val munitTimeout: FiniteDuration = 200.milliseconds
 

--- a/modules/effectie-cats-effect2/js/src/test/scala/effectie/instances/ce2/f/onNonFatalSpec.scala
+++ b/modules/effectie-cats-effect2/js/src/test/scala/effectie/instances/ce2/f/onNonFatalSpec.scala
@@ -9,7 +9,6 @@ import effectie.testing.FutureTools
 import munit.Assertions
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.FiniteDuration
 import scala.util.control.{ControlThrowable, NonFatal}
 
 import scala.concurrent.duration._

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/testing/IoAppUtils.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/testing/IoAppUtils.scala
@@ -28,8 +28,8 @@ object IoAppUtils {
   def runtime(): IORuntime = {
     lazy val runtime: IORuntime = {
 
-      val (compute, compDown) =
-        IORuntime.createDefaultComputeThreadPool(runtime)
+      val (compute, poller, compDown) =
+        IORuntime.createWorkStealingComputeThreadPool()
 
       val (blocking, blockDown) =
         IORuntime.createDefaultBlockingExecutionContext()
@@ -41,6 +41,7 @@ object IoAppUtils {
         compute,
         blocking,
         scheduler,
+        List(poller),
         { () =>
           compDown()
           blockDown()

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/testing/IoAppUtils.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/testing/IoAppUtils.scala
@@ -4,6 +4,7 @@ import cats.effect.unsafe.{IORuntime, IORuntimeConfig}
 import hedgehog.core.Result
 
 import java.util.concurrent.ExecutorService
+import scala.annotation.nowarn
 
 /** @author Kevin Lee
   * @since 2021-07-22
@@ -21,13 +22,14 @@ object IoAppUtils {
     num
   }
 
+  @nowarn
   def runtime(es: ExecutorService): IORuntime = runtime()
 
   def runtime(): IORuntime = {
     lazy val runtime: IORuntime = {
 
-      val (compute, compDown) =
-        IORuntime.createDefaultComputeThreadPool(runtime)
+      val (compute, poller, compDown) =
+        IORuntime.createWorkStealingComputeThreadPool()
 
       val (blocking, blockDown) =
         IORuntime.createDefaultBlockingExecutionContext()
@@ -39,6 +41,7 @@ object IoAppUtils {
         compute,
         blocking,
         scheduler,
+        List(poller),
         { () =>
           compDown()
           blockDown()

--- a/modules/effectie-monix3/js/src/test/scala/effectie/instances/monix3/canCatchSpec.scala
+++ b/modules/effectie-monix3/js/src/test/scala/effectie/instances/monix3/canCatchSpec.scala
@@ -13,7 +13,6 @@ import effectie.testing.types._
 import fxCtor.taskFxCtor
 import munit.Assertions
 
-import scala.concurrent._
 import scala.concurrent.duration._
 
 import monix.eval.Task
@@ -23,7 +22,7 @@ import monix.eval.Task
   */
 class canCatchSpec extends munit.FunSuite with FutureTools {
 
-  implicit val ec: ExecutionContext = globalExecutionContext
+  implicit val ec: scala.concurrent.ExecutionContext = globalExecutionContext
 
   import monix.execution.Scheduler.Implicits.global
 

--- a/modules/effectie-time-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/ClockBasedTimeSourceSpec.scala
+++ b/modules/effectie-time-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/ClockBasedTimeSourceSpec.scala
@@ -55,7 +55,7 @@ object ClockBasedTimeSourceSpec extends Properties with ClockBased {
           .map { expected =>
             Result.diff(
               actual.toEpochMilli.milliseconds,
-              (expected.toEpochMilli.milliseconds +- 500.milliseconds),
+              (expected.toEpochMilli.milliseconds +- 700.milliseconds),
             )(
               _.isWithIn(_)
             )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.1
+sbt.version=1.12.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,28 +1,25 @@
 logLevel := sbt.Level.Warn
 
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.4.0")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.6.0")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.10.4")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.4.6")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.14.7")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.6.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.2")
-addSbtPlugin("org.scalameta" % "sbt-mdoc"      % "2.3.2")
-addSbtPlugin("io.kevinlee"   % "sbt-docusaur"  % "0.21.0")
 
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.18.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.20.2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.8")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.10")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 
-addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.3.2")
+addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.5.0")
 
-val sbtDevOopsVersion = "3.3.2"
+val sbtDevOopsVersion = "3.5.1"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)
 
 addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"    % sbtDevOopsVersion)
 
-addSbtPlugin("org.jetbrains.scala" % "sbt-idea-compiler-indices" % "1.0.13")
+addSbtPlugin("org.jetbrains.scala" % "sbt-idea-compiler-indices" % "1.0.16")


### PR DESCRIPTION
## Close #702: Update Scala, sbt, sbt plugins and libraries, and remove unused plugins

Upgrade Scala versions, libraries, sbt plugins, and toolchain across the build. cats-effect 3 is unified to a single 3.7.0 release for all platforms (previously a separate RC was used for Native). A few unused sbt plugins (sbt-coveralls, sbt-mdoc, sbt-docusaur) are dropped to slim down the plugin set. Suppress the new deprecation warning from `IORuntime.createDefaultComputeThreadPool` introduced by the cats-effect upgrade.

Scala:
- `Scala 2.13`: `2.13.16` => `2.13.18`
- `Scala 2.12`: `2.12.18` => `2.12.20`
- `Scala 3`: `3.3.3` => `3.3.5`

Libraries:
- `hedgehog`: `0.13.0` => `0.13.1`
- `cats-effect` 3: `3.3.14` => `3.7.0`
- `cats-effect` 3 (Native): `3.7.0-RC1` => `3.7.0`
- `monix`: `3.4.0` => `3.4.1`
- `extras`: `0.49.0` => `0.53.0`

Build tooling:
- `sbt`: `1.12.1` => `1.12.11`
- `sbt-wartremover`: `3.4.0` => `3.6.0`
- `sbt-scalafix`: `0.10.4` => `0.14.7`
- `sbt-scalafmt`: `2.4.6` => `2.6.1`
- `sbt-scalajs`: `1.18.2` => `1.20.2`
- `sbt-scala-native`: `0.5.8` => `0.5.10`
- `sbt-native-image`: `0.3.2` => `0.5.0`
- `sbt-devoops`: `3.3.2` => `3.5.1`
- `sbt-idea-compiler-indices`: `1.0.13` => `1.0.16`

Removed plugins:
- `sbt-coveralls`
- `sbt-mdoc`
- `sbt-docusaur`