### PR TITLE
effectie v2.4.0

### DIFF
--- a/changelogs/2.4.0.md
+++ b/changelogs/2.4.0.md
@@ -1,0 +1,34 @@
+## [2.4.0](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m6) - 2026-06-27
+
+
+## Internal Housekeeping
+
+### Update Scala, sbt, sbt plugins and libraries, and remove unused plugins (#702)
+
+#### Scala:
+- `Scala 2.13`: `2.13.16` => `2.13.18`
+- `Scala 2.12`: `2.12.18` => `2.12.20`
+- `Scala 3`: `3.3.3` => `3.3.5`
+
+#### Libraries:
+- `hedgehog`: `0.13.0` => `0.13.1`
+- `cats-effect` 3: `3.3.14` => `3.7.0`
+- `cats-effect` 3 (Native): `3.7.0-RC1` => `3.7.0`
+- `monix`: `3.4.0` => `3.4.1`
+- `extras`: `0.49.0` => `0.53.0`
+
+#### SBT and plugins:
+- `sbt`: `1.12.1` => `1.12.11`
+- `sbt-wartremover`: `3.4.0` => `3.6.0`
+- `sbt-scalafix`: `0.10.4` => `0.14.7`
+- `sbt-scalafmt`: `2.4.6` => `2.6.1`
+- `sbt-scalajs`: `1.18.2` => `1.20.2`
+- `sbt-scala-native`: `0.5.8` => `0.5.10`
+- `sbt-native-image`: `0.3.2` => `0.5.0`
+- `sbt-devoops`: `3.3.2` => `3.5.1`
+- `sbt-idea-compiler-indices`: `1.0.13` => `1.0.16`
+
+#### Remove plugins:
+- `sbt-coveralls`
+- `sbt-mdoc`
+- `sbt-docusaur`


### PR DESCRIPTION
# effectie v2.4.0
## [2.4.0](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m6) - 2026-06-27


## Internal Housekeeping

### Update Scala, sbt, sbt plugins and libraries, and remove unused plugins (#702)

#### Scala:
- `Scala 2.13`: `2.13.16` => `2.13.18`
- `Scala 2.12`: `2.12.18` => `2.12.20`
- `Scala 3`: `3.3.3` => `3.3.5`

#### Libraries:
- `hedgehog`: `0.13.0` => `0.13.1`
- `cats-effect` 3: `3.3.14` => `3.7.0`
- `cats-effect` 3 (Native): `3.7.0-RC1` => `3.7.0`
- `monix`: `3.4.0` => `3.4.1`
- `extras`: `0.49.0` => `0.53.0`

#### SBT and plugins:
- `sbt`: `1.12.1` => `1.12.11`
- `sbt-wartremover`: `3.4.0` => `3.6.0`
- `sbt-scalafix`: `0.10.4` => `0.14.7`
- `sbt-scalafmt`: `2.4.6` => `2.6.1`
- `sbt-scalajs`: `1.18.2` => `1.20.2`
- `sbt-scala-native`: `0.5.8` => `0.5.10`
- `sbt-native-image`: `0.3.2` => `0.5.0`
- `sbt-devoops`: `3.3.2` => `3.5.1`
- `sbt-idea-compiler-indices`: `1.0.13` => `1.0.16`

#### Remove plugins:
- `sbt-coveralls`
- `sbt-mdoc`
- `sbt-docusaur`
