### PR TITLE
Fix `IORuntime` file-descriptor leak in `effectie-cats-effect3` tests

### DIFF
--- a/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/fromFutureSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/fromFutureSpec.scala
@@ -1,7 +1,6 @@
 package effectie.instances.ce3
 
 import cats.effect._
-import cats.effect.unsafe.IORuntime
 import effectie.core.FromFuture
 import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import extras.concurrent.testing.ConcurrentSupport
@@ -28,15 +27,16 @@ object fromFutureSpec extends Properties {
   def testToEffect: Property = for {
     a <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("a")
   } yield {
-    val compat                 = new CatsEffectIoCompatForFuture
+    val compat = new CatsEffectIoCompatForFuture
     import compat.ec
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
-    ConcurrentSupport.runAndShutdown(compat.es, waitFor300Millis) {
-      lazy val fa = Future(a)
-      val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
+      ConcurrentSupport.runAndShutdown(compat.es, waitFor300Millis) {
+        lazy val fa = Future(a)
+        val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
 
-      actual ==== a
+        actual ==== a
+      }
     }
   }
 

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/fxSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/fxSpec.scala
@@ -3,11 +3,9 @@ package effectie.instances.ce3
 import cats.Eq
 import cats.data.EitherT
 import cats.effect._
-import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import effectie.SomeControlThrowable
 import effectie.core._
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.specs.MonadSpec
 import effectie.specs.fxSpec.FxSpecs
 import effectie.syntax.error._
@@ -1687,40 +1685,38 @@ object fxSpec extends Properties {
 
     object OnNonFatalSpec {
 
-      def testOnNonFatal_IO_onNonFatalWithShouldRecoverFromNonFatal: Result = {
+      def testOnNonFatal_IO_onNonFatalWithShouldRecoverFromNonFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = new RuntimeException("Something's wrong")
+          val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+          val expected          = 123.some
+          var actual            = none[Int] // scalafix:ok DisableSyntax.var
 
-        val expectedException = new RuntimeException("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
-        val expected          = 123.some
-        var actual            = none[Int] // scalafix:ok DisableSyntax.var
+          val result =
+            try {
+              val r = Fx[IO]
+                .onNonFatalWith(fa) {
+                  case NonFatal(`expectedException`) =>
+                    IO.delay {
+                      actual = expected
+                    } *> IO.unit
+                }
+                .unsafeRunSync()
 
-        val result =
-          try {
-            val r = Fx[IO]
-              .onNonFatalWith(fa) {
-                case NonFatal(`expectedException`) =>
-                  IO.delay {
-                    actual = expected
-                  } *> IO.unit
-              }
-              .unsafeRunSync()
+              new AssertionError(s"Should have thrown an exception, but it was ${r.toString}.")
+            } catch {
+              case ex: Throwable =>
+                ex
+            }
 
-            new AssertionError(s"Should have thrown an exception, but it was ${r.toString}.")
-          } catch {
-            case ex: Throwable =>
-              ex
-          }
-
-        Result.all(
-          List(
-            result ==== expectedException,
-            actual ==== expected,
+          Result.all(
+            List(
+              result ==== expectedException,
+              actual ==== expected,
+            )
           )
-        )
-      }
+        }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = {
@@ -1756,33 +1752,31 @@ object fxSpec extends Properties {
 
       }
 
-      def testOnNonFatal_IO_onNonFatalWithShouldReturnSuccessfulResult: Result = {
+      def testOnNonFatal_IO_onNonFatalWithShouldReturnSuccessfulResult: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedResult = 999
+          val fa             = run[IO, Int](expectedResult)
 
-        val expectedResult = 999
-        val fa             = run[IO, Int](expectedResult)
+          val expected = none[Int]
+          var actual   = none[Int] // scalafix:ok DisableSyntax.var
 
-        val expected = none[Int]
-        var actual   = none[Int] // scalafix:ok DisableSyntax.var
+          val result = Fx[IO]
+            .onNonFatalWith(fa) {
+              case NonFatal(_) =>
+                IO.delay {
+                  actual = 123.some
+                } *> IO.unit
+            }
+            .unsafeRunSync()
 
-        val result = Fx[IO]
-          .onNonFatalWith(fa) {
-            case NonFatal(_) =>
-              IO.delay {
-                actual = 123.some
-              } *> IO.unit
-          }
-          .unsafeRunSync()
-
-        Result.all(
-          List(
-            result ==== expectedResult,
-            actual ==== expected,
+          Result.all(
+            List(
+              result ==== expectedResult,
+              actual ==== expected,
+            )
           )
-        )
-      }
+        }
 
     }
 

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/testing/IoAppUtils.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/instances/ce3/testing/IoAppUtils.scala
@@ -3,9 +3,6 @@ package effectie.instances.ce3.testing
 import cats.effect.unsafe.{IORuntime, IORuntimeConfig}
 import hedgehog.core.Result
 
-import java.util.concurrent.ExecutorService
-import scala.annotation.nowarn
-
 /** @author Kevin Lee
   * @since 2021-07-22
   */
@@ -16,40 +13,34 @@ object IoAppUtils {
     finally runtime.shutdown()
   }
 
-  def computeWorkerThreadCount: Int = {
-    val num = Math.max(2, Runtime.getRuntime.availableProcessors())
-    println(s"Worker thread count: ${num.toString}")
-    num
+  def withNewRuntime(test: IORuntime => Result): Result = {
+    val rt = runtime()
+    try test(rt)
+    finally rt.shutdown()
   }
 
-  @nowarn
-  def runtime(es: ExecutorService): IORuntime = runtime()
+  private def runtime(): IORuntime = {
 
-  def runtime(): IORuntime = {
-    lazy val runtime: IORuntime = {
+    val (compute, poller, compDown) =
+      IORuntime.createWorkStealingComputeThreadPool()
 
-      val (compute, poller, compDown) =
-        IORuntime.createWorkStealingComputeThreadPool()
+    val (blocking, blockDown) =
+      IORuntime.createDefaultBlockingExecutionContext()
 
-      val (blocking, blockDown) =
-        IORuntime.createDefaultBlockingExecutionContext()
+    val (scheduler, schedDown) =
+      IORuntime.createDefaultScheduler()
 
-      val (scheduler, schedDown) =
-        IORuntime.createDefaultScheduler()
-
-      IORuntime(
-        compute,
-        blocking,
-        scheduler,
-        List(poller),
-        { () =>
-          compDown()
-          blockDown()
-          schedDown()
-        },
-        IORuntimeConfig(),
-      )
-    }
-    runtime
+    IORuntime(
+      compute,
+      blocking,
+      scheduler,
+      List(poller),
+      { () =>
+        compDown()
+        blockDown()
+        schedDown()
+      },
+      IORuntimeConfig(),
+    )
   }
 }

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/syntax/fxSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-2/effectie/syntax/fxSpec.scala
@@ -1,12 +1,9 @@
 package effectie.syntax
 
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import effectie.core.{Fx, FxCtor}
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.instances.ce3.fx._
-import effectie.instances.ce3.testing.IoAppUtils
 import effectie.syntax.fx._
 import effectie.testing.tools.expectThrowable
 import effectie.testing.types.SomeThrowableError
@@ -87,9 +84,6 @@ object fxSpec extends Properties {
   }
 
   object IoSpec {
-
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = IoAppUtils.runtime(compat.es)
 
     @SuppressWarnings(Array("org.wartremover.warts.Any", "org.wartremover.warts.Nothing"))
     def testAll: Property =

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/fromFutureSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/fromFutureSpec.scala
@@ -1,7 +1,6 @@
 package effectie.instances.ce3
 
 import cats.effect.*
-import cats.effect.unsafe.IORuntime
 import effectie.core.FromFuture
 import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.instances.ce3.fromFuture.given
@@ -27,15 +26,16 @@ object fromFutureSpec extends Properties {
   def testToEffect: Property = for {
     a <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("a")
   } yield {
-    val compat          = new CatsEffectIoCompatForFuture
+    val compat = new CatsEffectIoCompatForFuture
     import compat.ec
-    given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
-    ConcurrentSupport.runAndShutdown(compat.es, WaitFor(300.milliseconds)) {
-      lazy val fa = Future(a)
-      val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
+      ConcurrentSupport.runAndShutdown(compat.es, WaitFor(300.milliseconds)) {
+        lazy val fa = Future(a)
+        val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
 
-      actual ==== a
+        actual ==== a
+      }
     }
   }
 

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/fxSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/fxSpec.scala
@@ -2,13 +2,11 @@ package effectie.instances.ce3
 
 import cats.data.EitherT
 import cats.effect.*
-import cats.effect.unsafe.IORuntime
 import cats.instances.either.*
 import cats.syntax.all.*
 import cats.{Eq, Functor, Show}
 import effectie.SomeControlThrowable
 import effectie.core.Fx
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.specs.MonadSpec
 import effectie.instances.ce3.fx.given
 import effectie.specs.fxSpec.FxSpecs
@@ -1720,10 +1718,7 @@ object FxSpec extends Properties {
 
     object OnNonFatalSpec {
 
-      def testOnNonFatal_IO_onNonFatalWithShouldRecoverFromNonFatal: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testOnNonFatal_IO_onNonFatalWithShouldRecoverFromNonFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedException = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedException))
@@ -1789,10 +1784,7 @@ object FxSpec extends Properties {
 
       }
 
-      def testOnNonFatal_IO_onNonFatalWithShouldReturnSuccessfulResult: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testOnNonFatal_IO_onNonFatalWithShouldReturnSuccessfulResult: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedResult = 999
         val fa             = run[IO, Int](expectedResult)

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/testing/IoAppUtils.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/instances/ce3/testing/IoAppUtils.scala
@@ -3,9 +3,6 @@ package effectie.instances.ce3.testing
 import cats.effect.unsafe.{IORuntime, IORuntimeConfig}
 import hedgehog.core.Result
 
-import java.util.concurrent.ExecutorService
-import scala.annotation.nowarn
-
 /** @author Kevin Lee
   * @since 2021-07-22
   */
@@ -16,40 +13,34 @@ object IoAppUtils {
     finally runtime.shutdown()
   }
 
-  def computeWorkerThreadCount: Int = {
-    val num = Math.max(2, Runtime.getRuntime.availableProcessors())
-    println(s"Worker thread count: ${num.toString}")
-    num
+  def withNewRuntime(test: IORuntime => Result): Result = {
+    val rt = runtime()
+    try test(rt)
+    finally rt.shutdown()
   }
 
-  @nowarn
-  def runtime(es: ExecutorService): IORuntime = runtime()
+  private def runtime(): IORuntime = {
 
-  def runtime(): IORuntime = {
-    lazy val runtime: IORuntime = {
+    val (compute, poller, compDown) =
+      IORuntime.createWorkStealingComputeThreadPool()
 
-      val (compute, poller, compDown) =
-        IORuntime.createWorkStealingComputeThreadPool()
+    val (blocking, blockDown) =
+      IORuntime.createDefaultBlockingExecutionContext()
 
-      val (blocking, blockDown) =
-        IORuntime.createDefaultBlockingExecutionContext()
+    val (scheduler, schedDown) =
+      IORuntime.createDefaultScheduler()
 
-      val (scheduler, schedDown) =
-        IORuntime.createDefaultScheduler()
-
-      IORuntime(
-        compute,
-        blocking,
-        scheduler,
-        List(poller),
-        { () =>
-          compDown()
-          blockDown()
-          schedDown()
-        },
-        IORuntimeConfig(),
-      )
-    }
-    runtime
+    IORuntime(
+      compute,
+      blocking,
+      scheduler,
+      List(poller),
+      { () =>
+        compDown()
+        blockDown()
+        schedDown()
+      },
+      IORuntimeConfig(),
+    )
   }
 }

--- a/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/syntax/fxSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala-3/effectie/syntax/fxSpec.scala
@@ -3,11 +3,8 @@ package effectie.syntax
 import cats.*
 import cats.syntax.all.*
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import effectie.core.{Fx, FxCtor}
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.instances.ce3.fx.given
-import effectie.instances.ce3.testing
 import effectie.syntax.fx.*
 import effectie.testing.tools.expectThrowable
 import effectie.testing.types.SomeThrowableError
@@ -85,9 +82,6 @@ object fxSpec extends Properties {
   }
 
   object IoSpec {
-
-    val compat          = new CatsEffectIoCompatForFuture
-    given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
     def testAll: Property =
       for {

--- a/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/fromFutureSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/fromFutureSpec.scala
@@ -1,7 +1,6 @@
 package effectie.instances.ce3.f
 
 import cats.effect._
-import cats.effect.unsafe.IORuntime
 import effectie.core.FromFuture
 import effectie.instances.ce3.testing
 import extras.concurrent.testing.ConcurrentSupport
@@ -30,15 +29,16 @@ object FromFutureSpec extends Properties {
     def testToEffect: Property = for {
       a <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("a")
     } yield {
-      val compat                 = new effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
+      val compat = new effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
       import compat.ec
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
-      ConcurrentSupport.runAndShutdown(compat.es, waitFor300Millis) {
-        lazy val fa = Future(a)
-        val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
+        ConcurrentSupport.runAndShutdown(compat.es, waitFor300Millis) {
+          lazy val fa = Future(a)
+          val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
 
-        actual ==== a
+          actual ==== a
+        }
       }
     }
   }

--- a/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/fxSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/ce3/f/fxSpec.scala
@@ -2,12 +2,10 @@ package effectie.instances.ce3.f
 
 import cats.data.EitherT
 import cats.effect._
-import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import cats.Eq
 import effectie.SomeControlThrowable
 import effectie.core._
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.instances.ce3.testing
 import effectie.specs.MonadSpec
 import effectie.specs.fxSpec.FxSpecs
@@ -1689,40 +1687,38 @@ object fxSpec extends Properties {
 
     object OnNonFatalSpec {
 
-      def testOnNonFatal_IO_onNonFatalWithShouldRecoverFromNonFatal: Result = {
+      def testOnNonFatal_IO_onNonFatalWithShouldRecoverFromNonFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = new RuntimeException("Something's wrong")
+          val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+          val expected          = 123.some
+          var actual            = none[Int] // scalafix:ok DisableSyntax.var
 
-        val expectedException = new RuntimeException("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
-        val expected          = 123.some
-        var actual            = none[Int] // scalafix:ok DisableSyntax.var
+          val result =
+            try {
+              val r = Fx[IO]
+                .onNonFatalWith(fa) {
+                  case NonFatal(`expectedException`) =>
+                    IO.delay {
+                      actual = expected
+                    } *> IO.unit
+                }
+                .unsafeRunSync()
 
-        val result =
-          try {
-            val r = Fx[IO]
-              .onNonFatalWith(fa) {
-                case NonFatal(`expectedException`) =>
-                  IO.delay {
-                    actual = expected
-                  } *> IO.unit
-              }
-              .unsafeRunSync()
+              new AssertionError(s"Should have thrown an exception, but it was ${r.toString}.")
+            } catch {
+              case ex: Throwable =>
+                ex
+            }
 
-            new AssertionError(s"Should have thrown an exception, but it was ${r.toString}.")
-          } catch {
-            case ex: Throwable =>
-              ex
-          }
-
-        Result.all(
-          List(
-            result ==== expectedException,
-            actual ==== expected,
+          Result.all(
+            List(
+              result ==== expectedException,
+              actual ==== expected,
+            )
           )
-        )
-      }
+        }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = {
@@ -1758,33 +1754,31 @@ object fxSpec extends Properties {
 
       }
 
-      def testOnNonFatal_IO_onNonFatalWithShouldReturnSuccessfulResult: Result = {
+      def testOnNonFatal_IO_onNonFatalWithShouldReturnSuccessfulResult: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedResult = 999
+          val fa             = run[IO, Int](expectedResult)
 
-        val expectedResult = 999
-        val fa             = run[IO, Int](expectedResult)
+          val expected = none[Int]
+          var actual   = none[Int] // scalafix:ok DisableSyntax.var
 
-        val expected = none[Int]
-        var actual   = none[Int] // scalafix:ok DisableSyntax.var
+          val result = Fx[IO]
+            .onNonFatalWith(fa) {
+              case NonFatal(_) =>
+                IO.delay {
+                  actual = 123.some
+                } *> IO.unit
+            }
+            .unsafeRunSync()
 
-        val result = Fx[IO]
-          .onNonFatalWith(fa) {
-            case NonFatal(_) =>
-              IO.delay {
-                actual = 123.some
-              } *> IO.unit
-          }
-          .unsafeRunSync()
-
-        Result.all(
-          List(
-            result ==== expectedResult,
-            actual ==== expected,
+          Result.all(
+            List(
+              result ==== expectedResult,
+              actual ==== expected,
+            )
           )
-        )
-      }
+        }
 
     }
 

--- a/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/instances/ce3/canHandleErrorSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/instances/ce3/canHandleErrorSpec.scala
@@ -3,7 +3,6 @@ package effectie.instances.ce3
 import canHandleError._
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.SomeControlThrowable
@@ -11,14 +10,12 @@ import effectie.core._
 import effectie.syntax.error._
 import effectie.syntax.fx._
 import effectie.testing.types.SomeError
-import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.ErrorLogger
 import extras.hedgehog.ce3.syntax.runner._
 import fxCtor._
 import hedgehog._
 import hedgehog.runner._
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -174,26 +171,24 @@ object canHandleErrorSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
+  def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      try {
+        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
 
-    try {
-      val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -220,26 +215,24 @@ object canHandleErrorSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
+  def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      try {
+        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: SomeControlThrowable =>
+          ex.getMessage ==== fatalExpcetion.getMessage
 
-    try {
-      val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: SomeControlThrowable =>
-        ex.getMessage ==== fatalExpcetion.getMessage
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -276,29 +269,27 @@ object canHandleErrorSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
+  def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      try {
+        val actual =
+          CanHandleError[IO]
+            .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+            .unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
 
-    try {
-      val actual =
-        CanHandleError[IO]
-          .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-          .unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -338,30 +329,28 @@ object canHandleErrorSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
+  def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      try {
+        val actual =
+          CanHandleError[IO]
+            .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+            .value
+            .unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
 
-    try {
-      val actual =
-        CanHandleError[IO]
-          .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-          .value
-          .unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result =
     withIO { implicit ticker =>
@@ -402,26 +391,24 @@ object canHandleErrorSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
+  def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+      try {
+        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
 
-    try {
-      val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -446,26 +433,24 @@ object canHandleErrorSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
+  def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      try {
+        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
 
-    try {
-      val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -502,29 +487,27 @@ object canHandleErrorSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
+  def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+      try {
+        val actual =
+          CanHandleError[IO]
+            .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+            .unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
 
-    try {
-      val actual =
-        CanHandleError[IO]
-          .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-          .unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -563,30 +546,28 @@ object canHandleErrorSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
+  def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      val fatalExpcetion = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-    val fatalExpcetion = SomeControlThrowable("Something's wrong")
-    val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+      try {
+        val actual =
+          CanHandleError[IO]
+            .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+            .value
+            .unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== fatalExpcetion
 
-    try {
-      val actual =
-        CanHandleError[IO]
-          .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-          .value
-          .unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== fatalExpcetion
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 

--- a/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/instances/ce3/canRecoverSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/instances/ce3/canRecoverSpec.scala
@@ -3,12 +3,10 @@ package effectie.instances.ce3
 import canRecover._
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.SomeControlThrowable
 import effectie.core._
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.syntax.error._
 import effectie.syntax.fx._
 import effectie.testing.types.SomeError
@@ -170,27 +168,25 @@ object canRecoverSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
+  def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      val expectedException = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-    val expectedException = SomeControlThrowable("Something's wrong")
-    val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+      val io = CanRecover[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedException
 
-    val io = CanRecover[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
-    try {
-      val actual = io.unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== expectedException
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -224,29 +220,27 @@ object canRecoverSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
+  def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      val expectedException = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-    val expectedException = SomeControlThrowable("Something's wrong")
-    val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+      val io = CanRecover[IO].recoverFromNonFatalWith(fa) {
+        case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+      }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedException
 
-    val io = CanRecover[IO].recoverFromNonFatalWith(fa) {
-      case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
     }
-    try {
-      val actual = io.unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== expectedException
-
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-    }
-
-  }
 
   def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult: Result =
     withIO { implicit ticker =>
@@ -294,29 +288,27 @@ object canRecoverSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
+  def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      val expectedException = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-    val expectedException = SomeControlThrowable("Something's wrong")
-    val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+      val io = CanRecover[IO].recoverEitherFromNonFatalWith(fa) {
+        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+      }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedException
 
-    val io = CanRecover[IO].recoverEitherFromNonFatalWith(fa) {
-      case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
     }
-    try {
-      val actual = io.unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== expectedException
-
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-    }
-
-  }
 
   def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult: Result =
     withIO { implicit ticker =>
@@ -367,29 +359,27 @@ object canRecoverSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
+  def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      val expectedException = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-    val expectedException = SomeControlThrowable("Something's wrong")
-    val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
+      val io = CanRecover[IO].recoverEitherTFromNonFatalWith(fa) {
+        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+      }
+      try {
+        val actual = io.value.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedException
 
-    val io = CanRecover[IO].recoverEitherTFromNonFatalWith(fa) {
-      case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
+
     }
-    try {
-      val actual = io.value.unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== expectedException
-
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-    }
-
-  }
 
   def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult: Result =
     withIO { implicit ticker =>
@@ -437,27 +427,25 @@ object canRecoverSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
+  def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      val expectedException = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-    val expectedException = SomeControlThrowable("Something's wrong")
-    val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+      val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedException
 
-    val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
-    try {
-      val actual = io.unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== expectedException
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -484,27 +472,25 @@ object canRecoverSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
+  def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      val expectedException = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-    val expectedException = SomeControlThrowable("Something's wrong")
-    val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+      val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedException
 
-    val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
-    try {
-      val actual = io.unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== expectedException
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+      }
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -545,30 +531,28 @@ object canRecoverSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
+  def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      val expectedException = SomeControlThrowable("Something's wrong")
+      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-    val expectedException = SomeControlThrowable("Something's wrong")
-    val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+      val io =
+        CanRecover[IO].recoverEitherFromNonFatal(fa) {
+          case err => SomeError.someThrowable(err).asLeft[Int]
+        }
+      try {
+        val actual = io.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedException
 
-    val io =
-      CanRecover[IO].recoverEitherFromNonFatal(fa) {
-        case err => SomeError.someThrowable(err).asLeft[Int]
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-    try {
-      val actual = io.unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== expectedException
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -615,30 +599,28 @@ object canRecoverSpec extends Properties {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
+  def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result =
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      val expectedException = SomeControlThrowable("Something's wrong")
+      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-    val expectedException = SomeControlThrowable("Something's wrong")
-    val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
+      val io =
+        CanRecover[IO].recoverEitherTFromNonFatal(fa) {
+          case err => SomeError.someThrowable(err).asLeft[Int]
+        }
+      try {
+        val actual = io.value.unsafeRunSync()
+        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+      } catch {
+        case ex: ControlThrowable =>
+          ex ==== expectedException
 
-    val io =
-      CanRecover[IO].recoverEitherTFromNonFatal(fa) {
-        case err => SomeError.someThrowable(err).asLeft[Int]
+        case ex: Throwable =>
+          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-    try {
-      val actual = io.value.unsafeRunSync()
-      Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-    } catch {
-      case ex: ControlThrowable =>
-        ex ==== expectedException
 
-      case ex: Throwable =>
-        Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
     }
-
-  }
 
   def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 

--- a/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/instances/ce3/fromFutureSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/instances/ce3/fromFutureSpec.scala
@@ -1,7 +1,6 @@
 package effectie.instances.ce3
 
 import cats.effect._
-import cats.effect.unsafe.IORuntime
 import effectie.core.FromFuture
 import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import extras.concurrent.testing.ConcurrentSupport
@@ -28,15 +27,16 @@ object fromFutureSpec extends Properties {
   def testToEffect: Property = for {
     a <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("a")
   } yield {
-    val compat                 = new CatsEffectIoCompatForFuture
+    val compat = new CatsEffectIoCompatForFuture
     import compat.ec
-    implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
-    ConcurrentSupport.runAndShutdown(compat.es, waitFor300Millis) {
-      lazy val fa = Future(a)
-      val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
+      ConcurrentSupport.runAndShutdown(compat.es, waitFor300Millis) {
+        lazy val fa = Future(a)
+        val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
 
-      actual ==== a
+        actual ==== a
+      }
     }
   }
 

--- a/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/instances/ce3/fxSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/instances/ce3/fxSpec.scala
@@ -3,22 +3,18 @@ package effectie.instances.ce3
 import cats.Eq
 import cats.data.EitherT
 import cats.effect._
-import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import effectie.SomeControlThrowable
 import effectie.core._
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.specs.MonadSpec
 import effectie.specs.fxSpec.FxSpecs
 import effectie.syntax.error._
 import effectie.testing.types.SomeError
-import extras.concurrent.testing.ConcurrentSupport
 import extras.hedgehog.ce3.syntax.runner._
 import fx._
 import hedgehog._
 import hedgehog.runner._
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -555,26 +551,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
+      def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+          try {
+            val actual = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: SomeControlThrowable =>
+              ex.getMessage ==== fatalExpcetion.getMessage
 
-        try {
-          val actual = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -596,10 +590,7 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -637,26 +628,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
+      def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+          try {
+            val actual = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: SomeControlThrowable =>
+              ex.getMessage ==== fatalExpcetion.getMessage
 
-        try {
-          val actual = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -688,26 +677,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
+      def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+          try {
+            val actual = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: SomeControlThrowable =>
+              ex.getMessage ==== fatalExpcetion.getMessage
 
-        try {
-          val actual = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -749,26 +736,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
+      def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+          try {
+            val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -795,26 +780,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
+      def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+          try {
+            val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: SomeControlThrowable =>
+              ex.getMessage ==== fatalExpcetion.getMessage
 
-        try {
-          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result =
         withIO { implicit ticker =>
@@ -852,29 +835,27 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
+      def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+          try {
+            val actual =
+              Fx[IO]
+                .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+                .unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual =
-            Fx[IO]
-              .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-              .unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result =
         withIO { implicit ticker =>
@@ -915,30 +896,28 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
+      def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+          try {
+            val actual =
+              Fx[IO]
+                .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+                .value
+                .unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual =
-            Fx[IO]
-              .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-              .value
-              .unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result =
         withIO { implicit ticker =>
@@ -979,26 +958,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
+      def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+          try {
+            val actual = Fx[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual = Fx[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1023,26 +1000,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
+      def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+          try {
+            val actual = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1079,29 +1054,27 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
+      def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+          try {
+            val actual =
+              Fx[IO]
+                .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+                .unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual =
-            Fx[IO]
-              .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-              .unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1140,30 +1113,28 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
+      def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+          try {
+            val actual =
+              Fx[IO]
+                .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+                .value
+                .unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual =
-            Fx[IO]
-              .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-              .value
-              .unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1203,27 +1174,25 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+          val io = Fx[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io = Fx[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1257,29 +1226,27 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+          val io = Fx[IO].recoverFromNonFatalWith(fa) {
+            case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+          }
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io = Fx[IO].recoverFromNonFatalWith(fa) {
-          case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
+
         }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
-
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-        }
-
-      }
 
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult: Result =
         withIO { implicit ticker =>
@@ -1327,29 +1294,27 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+          val io = Fx[IO].recoverEitherFromNonFatalWith(fa) {
+            case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          }
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io = Fx[IO].recoverEitherFromNonFatalWith(fa) {
-          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
+
         }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
-
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-        }
-
-      }
 
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult: Result =
         withIO { implicit ticker =>
@@ -1401,29 +1366,27 @@ object fxSpec extends Properties {
         }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
+          val io = Fx[IO].recoverEitherTFromNonFatalWith(fa) {
+            case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          }
+          try {
+            val actual = io.value.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io = Fx[IO].recoverEitherTFromNonFatalWith(fa) {
-          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
+
         }
-        try {
-          val actual = io.value.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
-
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-        }
-
-      }
 
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult: Result =
         withIO { implicit ticker =>
@@ -1471,27 +1434,25 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+          val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1518,27 +1479,25 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+          val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1579,30 +1538,28 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+          val io =
+            Fx[IO].recoverEitherFromNonFatal(fa) {
+              case err => SomeError.someThrowable(err).asLeft[Int]
+            }
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io =
-          Fx[IO].recoverEitherFromNonFatal(fa) {
-            case err => SomeError.someThrowable(err).asLeft[Int]
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
           }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1649,30 +1606,28 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
+          val io =
+            Fx[IO].recoverEitherTFromNonFatal(fa) {
+              case err => SomeError.someThrowable(err).asLeft[Int]
+            }
+          try {
+            val actual = io.value.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io =
-          Fx[IO].recoverEitherTFromNonFatal(fa) {
-            case err => SomeError.someThrowable(err).asLeft[Int]
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
           }
-        try {
-          val actual = io.value.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1703,102 +1658,96 @@ object fxSpec extends Properties {
 
     object OnNonFatalSpec {
 
-      def testOnNonFatal_IO_onNonFatalWithShouldRecoverFromNonFatal: Result = {
+      def testOnNonFatal_IO_onNonFatalWithShouldRecoverFromNonFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = new RuntimeException("Something's wrong")
+          val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+          val expected          = 123.some
+          var actual            = none[Int] // scalafix:ok DisableSyntax.var
 
-        val expectedException = new RuntimeException("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
-        val expected          = 123.some
-        var actual            = none[Int] // scalafix:ok DisableSyntax.var
+          val result =
+            try {
+              val r = Fx[IO]
+                .onNonFatalWith(fa) {
+                  case NonFatal(`expectedException`) =>
+                    IO.delay {
+                      actual = expected
+                    } *> IO.unit
+                }
+                .unsafeRunSync()
+              new AssertionError(s"Should have thrown an exception, but it was ${r.toString}.")
+            } catch {
+              case ex: Throwable =>
+                ex
+            }
 
-        val result =
-          try {
-            val r = Fx[IO]
-              .onNonFatalWith(fa) {
-                case NonFatal(`expectedException`) =>
-                  IO.delay {
-                    actual = expected
-                  } *> IO.unit
-              }
-              .unsafeRunSync()
-            new AssertionError(s"Should have thrown an exception, but it was ${r.toString}.")
-          } catch {
-            case ex: Throwable =>
-              ex
-          }
-
-        Result.all(
-          List(
-            result ==== expectedException,
-            actual ==== expected,
+          Result.all(
+            List(
+              result ==== expectedException,
+              actual ==== expected,
+            )
           )
-        )
-      }
+        }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = {
+      def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+          var actual            = none[Int] // scalafix:ok DisableSyntax.var
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
-        var actual            = none[Int] // scalafix:ok DisableSyntax.var
-
-        val io = Fx[IO].onNonFatalWith(fa) {
-          case NonFatal(`expectedException`) =>
-            IO.delay {
-              actual = 123.some
-              ()
-            } *> IO.unit
-        }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            Result.all(
-              List(
-                actual ==== none[Int],
-                ex ==== expectedException,
-              )
-            )
-
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-        }
-
-      }
-
-      def testOnNonFatal_IO_onNonFatalWithShouldReturnSuccessfulResult: Result = {
-
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
-        val expectedResult = 999
-        val fa             = run[IO, Int](expectedResult)
-
-        val expected = none[Int]
-        var actual   = none[Int] // scalafix:ok DisableSyntax.var
-
-        val result = Fx[IO]
-          .onNonFatalWith(fa) {
-            case NonFatal(_) =>
+          val io = Fx[IO].onNonFatalWith(fa) {
+            case NonFatal(`expectedException`) =>
               IO.delay {
                 actual = 123.some
+                ()
               } *> IO.unit
           }
-          .unsafeRunSync()
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              Result.all(
+                List(
+                  actual ==== none[Int],
+                  ex ==== expectedException,
+                )
+              )
 
-        Result.all(
-          List(
-            result ==== expectedResult,
-            actual ==== expected,
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
+
+        }
+
+      def testOnNonFatal_IO_onNonFatalWithShouldReturnSuccessfulResult: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
+
+          val expectedResult = 999
+          val fa             = run[IO, Int](expectedResult)
+
+          val expected = none[Int]
+          var actual   = none[Int] // scalafix:ok DisableSyntax.var
+
+          val result = Fx[IO]
+            .onNonFatalWith(fa) {
+              case NonFatal(_) =>
+                IO.delay {
+                  actual = 123.some
+                } *> IO.unit
+            }
+            .unsafeRunSync()
+
+          Result.all(
+            List(
+              result ==== expectedResult,
+              actual ==== expected,
+            )
           )
-        )
-      }
+        }
 
     }
 

--- a/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/instances/ce3/testing/IoAppUtils.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/instances/ce3/testing/IoAppUtils.scala
@@ -3,9 +3,6 @@ package effectie.instances.ce3.testing
 import cats.effect.unsafe.{IORuntime, IORuntimeConfig}
 import hedgehog.core.Result
 
-import java.util.concurrent.ExecutorService
-import scala.annotation.nowarn
-
 /** @author Kevin Lee
   * @since 2021-07-22
   */
@@ -16,39 +13,33 @@ object IoAppUtils {
     finally runtime.shutdown()
   }
 
-  def computeWorkerThreadCount: Int = {
-    val num = Math.max(2, Runtime.getRuntime.availableProcessors())
-    println(s"Worker thread count: ${num.toString}")
-    num
+  def withNewRuntime(test: IORuntime => Result): Result = {
+    val rt = runtime()
+    try test(rt)
+    finally rt.shutdown()
   }
 
-  @nowarn
-  def runtime(es: ExecutorService): IORuntime = runtime()
+  private def runtime(): IORuntime = {
 
-  def runtime(): IORuntime = {
-    lazy val runtime: IORuntime = {
+    val (executionContext, compDown) =
+      IORuntime.createDefaultBlockingExecutionContext("test-execution-context")
 
-      val (executionContext, compDown) =
-        IORuntime.createDefaultBlockingExecutionContext("test-execution-context")
+    val (blocking, blockDown) =
+      IORuntime.createDefaultBlockingExecutionContext()
 
-      val (blocking, blockDown) =
-        IORuntime.createDefaultBlockingExecutionContext()
+    val (scheduler, schedDown) =
+      IORuntime.createDefaultScheduler()
 
-      val (scheduler, schedDown) =
-        IORuntime.createDefaultScheduler()
-
-      IORuntime(
-        executionContext,
-        blocking,
-        scheduler,
-        { () =>
-          compDown()
-          blockDown()
-          schedDown()
-        },
-        IORuntimeConfig(),
-      )
-    }
-    runtime
+    IORuntime(
+      executionContext,
+      blocking,
+      scheduler,
+      { () =>
+        compDown()
+        blockDown()
+        schedDown()
+      },
+      IORuntimeConfig(),
+    )
   }
 }

--- a/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/syntax/errorSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/syntax/errorSpec.scala
@@ -2,11 +2,9 @@ package effectie.syntax
 
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import effectie.SomeControlThrowable
 import effectie.core.Fx
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.instances.ce3.fx._
 import effectie.instances.ce3.testing
 import effectie.syntax.error._
@@ -18,7 +16,6 @@ import extras.hedgehog.ce3.syntax.runner._
 import hedgehog._
 import hedgehog.runner._
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -154,26 +151,24 @@ object CanCatchSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
+    def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        try {
+          val actual = fa.catchNonFatalThrowable.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
 
-      try {
-        val actual = fa.catchNonFatalThrowable.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -195,10 +190,7 @@ object CanCatchSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+    def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -236,26 +228,24 @@ object CanCatchSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
+    def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        try {
+          val actual = fa.catchNonFatalEither(SomeError.someThrowable).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
 
-      try {
-        val actual = fa.catchNonFatalEither(SomeError.someThrowable).unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -287,26 +277,24 @@ object CanCatchSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
+    def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        try {
+          val actual = fa.catchNonFatalEitherT(SomeError.someThrowable).value.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
 
-      try {
-        val actual = fa.catchNonFatalEitherT(SomeError.someThrowable).value.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -749,26 +737,24 @@ object CanHandleErrorSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
+    def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        try {
+          val actual = fa.handleNonFatalWith(_ => IO.pure(123)).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual = fa.handleNonFatalWith(_ => IO.pure(123)).unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -793,26 +779,24 @@ object CanHandleErrorSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
+    def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        try {
+          val actual = fa.handleNonFatalWith(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
 
-      try {
-        val actual = fa.handleNonFatalWith(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -847,28 +831,26 @@ object CanHandleErrorSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
+    def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        try {
+          val actual =
+            fa.handleEitherNonFatalWith(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual =
-          fa.handleEitherNonFatalWith(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-            .unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -906,29 +888,27 @@ object CanHandleErrorSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
+    def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        try {
+          val actual =
+            fa.handleEitherTNonFatalWith(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+              .value
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual =
-          fa.handleEitherTNonFatalWith(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-            .value
-            .unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result =
       withIO { implicit ticker =>
@@ -966,26 +946,24 @@ object CanHandleErrorSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
+    def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        try {
+          val actual = fa.handleNonFatal(_ => 123).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual = fa.handleNonFatal(_ => 123).unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1009,26 +987,24 @@ object CanHandleErrorSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
+    def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        try {
+          val actual = fa.handleNonFatal(_ => 123.asRight[SomeError]).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual = fa.handleNonFatal(_ => 123.asRight[SomeError]).unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1062,28 +1038,26 @@ object CanHandleErrorSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
+    def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        try {
+          val actual =
+            fa.handleEitherNonFatal(err => SomeError.someThrowable(err).asLeft[Int])
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual =
-          fa.handleEitherNonFatal(err => SomeError.someThrowable(err).asLeft[Int])
-            .unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1117,29 +1091,27 @@ object CanHandleErrorSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
+    def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        try {
+          val actual =
+            fa.handleEitherTNonFatal(err => SomeError.someThrowable(err).asLeft[Int])
+              .value
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual =
-          fa.handleEitherTNonFatal(err => SomeError.someThrowable(err).asLeft[Int])
-            .value
-            .unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1833,27 +1805,25 @@ object CanRecoverSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+        val io = fa.recoverFromNonFatalWith { case NonFatal(`expectedException`) => IO.pure(123) }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io = fa.recoverFromNonFatalWith { case NonFatal(`expectedException`) => IO.pure(123) }
-      try {
-        val actual = io.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1884,29 +1854,27 @@ object CanRecoverSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+        val io = fa.recoverFromNonFatalWith {
+          case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+        }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io = fa.recoverFromNonFatalWith {
-        case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
       }
-      try {
-        val actual = io.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
-
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-      }
-
-    }
 
     def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult: Result =
       withIO { implicit ticker =>
@@ -1950,29 +1918,27 @@ object CanRecoverSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+        val io = fa.recoverEitherFromNonFatalWith {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io = fa.recoverEitherFromNonFatalWith {
-        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
       }
-      try {
-        val actual = io.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
-
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-      }
-
-    }
 
     def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult: Result =
       withIO { implicit ticker =>
@@ -2016,29 +1982,27 @@ object CanRecoverSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
+        val io = fa.recoverEitherTFromNonFatalWith {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+        try {
+          val actual = io.value.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io = fa.recoverEitherTFromNonFatalWith {
-        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
       }
-      try {
-        val actual = io.value.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
-
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-      }
-
-    }
 
     def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult: Result =
       withIO { implicit ticker =>
@@ -2079,27 +2043,25 @@ object CanRecoverSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+        val io = fa.recoverFromNonFatal { case NonFatal(`expectedException`) => 123 }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io = fa.recoverFromNonFatal { case NonFatal(`expectedException`) => 123 }
-      try {
-        val actual = io.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -2123,27 +2085,25 @@ object CanRecoverSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+        val io = fa.recoverFromNonFatal { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io = fa.recoverFromNonFatal { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
-      try {
-        val actual = io.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -2180,30 +2140,28 @@ object CanRecoverSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+        val io =
+          fa.recoverEitherFromNonFatal {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io =
-        fa.recoverEitherFromNonFatal {
-          case err => SomeError.someThrowable(err).asLeft[Int]
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-      try {
-        val actual = io.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -2242,30 +2200,28 @@ object CanRecoverSyntaxSpec {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
+        val io =
+          fa.recoverEitherTFromNonFatal {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+        try {
+          val actual = io.value.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io =
-        fa.recoverEitherTFromNonFatal {
-          case err => SomeError.someThrowable(err).asLeft[Int]
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-      try {
-        val actual = io.value.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -2850,10 +2806,7 @@ object OnNonFatalSyntaxSpec {
 
     }
 
-    def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+    def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Int](throwThrowable[Int](expectedException))

--- a/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/syntax/fxSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-2/effectie/syntax/fxSpec.scala
@@ -1,12 +1,9 @@
 package effectie.syntax
 
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import effectie.core.{Fx, FxCtor}
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.instances.ce3.fx._
-import effectie.instances.ce3.testing.IoAppUtils
 import effectie.syntax.fx._
 import effectie.testing.tools.expectThrowable
 import effectie.testing.types.SomeThrowableError
@@ -87,10 +84,6 @@ object fxSpec extends Properties {
   }
 
   object IoSpec {
-
-    val compat                 = new CatsEffectIoCompatForFuture
-    implicit val rt: IORuntime = IoAppUtils.runtime(compat.es)
-
     @SuppressWarnings(Array("org.wartremover.warts.Any", "org.wartremover.warts.Nothing"))
     def testAll: Property =
       for {

--- a/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/instances/ce3/canCatchSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/instances/ce3/canCatchSpec.scala
@@ -3,7 +3,6 @@ package effectie.instances.ce3
 import cats.*
 import cats.data.EitherT
 import cats.effect.*
-import cats.effect.unsafe.IORuntime
 import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.SomeControlThrowable
@@ -11,12 +10,10 @@ import effectie.core.*
 import effectie.syntax.error.*
 import effectie.syntax.fx.*
 import effectie.testing.types.SomeError
-import extras.concurrent.testing.ConcurrentSupport
 import extras.hedgehog.ce3.syntax.runner._
 import hedgehog.*
 import hedgehog.runner.*
 
-import java.util.concurrent.ExecutorService
 
 /** @author Kevin Lee
   * @since 2020-07-31
@@ -100,10 +97,7 @@ object canCatchSpec extends Properties {
       actual.completeAs(expected)
     }
 
-    def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -140,10 +134,7 @@ object canCatchSpec extends Properties {
       actual.completeAs(expected)
     }
 
-    def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -180,10 +171,7 @@ object canCatchSpec extends Properties {
       actual.completeAs(expected)
     }
 
-    def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -230,10 +218,7 @@ object canCatchSpec extends Properties {
       actual.completeAs(expected)
     }
 
-    def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))

--- a/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/instances/ce3/canHandleErrorSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/instances/ce3/canHandleErrorSpec.scala
@@ -3,7 +3,6 @@ package effectie.instances.ce3
 import cats.*
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.testing.types.SomeError
@@ -11,12 +10,10 @@ import effectie.core.*
 import effectie.syntax.error.*
 import effectie.syntax.fx.*
 import effectie.SomeControlThrowable
-import extras.concurrent.testing.ConcurrentSupport
 import extras.hedgehog.ce3.syntax.runner._
 import hedgehog.*
 import hedgehog.runner.*
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -169,10 +166,7 @@ object canHandleErrorSpec extends Properties {
       actual.completeAs(expected)
     }
 
-    def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -214,10 +208,7 @@ object canHandleErrorSpec extends Properties {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -269,10 +260,7 @@ object canHandleErrorSpec extends Properties {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -330,10 +318,7 @@ object canHandleErrorSpec extends Properties {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -391,10 +376,7 @@ object canHandleErrorSpec extends Properties {
       actual.completeAs(expected)
     }
 
-    def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -434,10 +416,7 @@ object canHandleErrorSpec extends Properties {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -489,10 +468,7 @@ object canHandleErrorSpec extends Properties {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -549,10 +525,7 @@ object canHandleErrorSpec extends Properties {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))

--- a/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/instances/ce3/canRecoverSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/instances/ce3/canRecoverSpec.scala
@@ -3,12 +3,10 @@ package effectie.instances.ce3
 import cats.*
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.instances.all.*
 import cats.syntax.all.*
 import effectie.SomeControlThrowable
 import effectie.core.*
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.syntax.error.*
 import effectie.syntax.fx.*
 import effectie.testing.types.SomeError
@@ -170,10 +168,7 @@ object canRecoverSpec extends Properties {
       actual.completeAs(expected)
     }
 
-    def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Int](throwThrowable[Int](expectedException))
@@ -223,10 +218,7 @@ object canRecoverSpec extends Properties {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
@@ -292,10 +284,7 @@ object canRecoverSpec extends Properties {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
@@ -365,10 +354,7 @@ object canRecoverSpec extends Properties {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
@@ -434,10 +420,7 @@ object canRecoverSpec extends Properties {
       actual.completeAs(expected)
     }
 
-    def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Int](throwThrowable[Int](expectedException))
@@ -480,10 +463,7 @@ object canRecoverSpec extends Properties {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
@@ -540,10 +520,7 @@ object canRecoverSpec extends Properties {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
@@ -609,10 +586,7 @@ object canRecoverSpec extends Properties {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))

--- a/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/instances/ce3/fromFutureSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/instances/ce3/fromFutureSpec.scala
@@ -1,7 +1,6 @@
 package effectie.instances.ce3
 
 import cats.effect.*
-import cats.effect.unsafe.IORuntime
 import effectie.core.FromFuture
 import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.instances.ce3.fromFuture.given
@@ -27,15 +26,16 @@ object fromFutureSpec extends Properties {
   def testToEffect: Property = for {
     a <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("a")
   } yield {
-    val compat          = new CatsEffectIoCompatForFuture
+    val compat = new CatsEffectIoCompatForFuture
     import compat.ec
-    given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
-    ConcurrentSupport.runAndShutdown(compat.es, WaitFor(300.milliseconds)) {
-      lazy val fa = Future(a)
-      val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
+    testing.IoAppUtils.withNewRuntime { implicit rt =>
+      ConcurrentSupport.runAndShutdown(compat.es, WaitFor(300.milliseconds)) {
+        lazy val fa = Future(a)
+        val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
 
-      actual ==== a
+        actual ==== a
+      }
     }
   }
 

--- a/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/instances/ce3/fxSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/instances/ce3/fxSpec.scala
@@ -2,24 +2,20 @@ package effectie.instances.ce3
 
 import cats.data.EitherT
 import cats.effect.*
-import cats.effect.unsafe.IORuntime
 import cats.instances.either.*
 import cats.syntax.all.*
 import cats.{Eq, Functor, Show}
 import effectie.SomeControlThrowable
 import effectie.core.Fx
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.specs.MonadSpec
 import effectie.instances.ce3.fx.given
 import effectie.specs.fxSpec.FxSpecs
 import effectie.syntax.error.*
 import effectie.testing.types.{SomeError, SomeThrowableError}
-import extras.concurrent.testing.ConcurrentSupport
 import extras.hedgehog.ce3.syntax.runner.*
 import hedgehog.*
 import hedgehog.runner.*
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -611,10 +607,7 @@ object FxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
-
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+      def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -649,10 +642,7 @@ object FxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
-
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+      def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -690,10 +680,7 @@ object FxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
-
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+      def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -741,10 +728,7 @@ object FxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
-
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+      def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -799,10 +783,7 @@ object FxSpec extends Properties {
         actual.completeAs(expected)
       }
 
-      def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
-
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+      def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -844,10 +825,7 @@ object FxSpec extends Properties {
         actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
-      def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
-
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+      def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -900,10 +878,7 @@ object FxSpec extends Properties {
         actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
-      def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
-
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+      def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -962,10 +937,7 @@ object FxSpec extends Properties {
         actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
-      def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
-
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+      def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -1023,10 +995,7 @@ object FxSpec extends Properties {
         actual.completeAs(expected)
       }
 
-      def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
-
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+      def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -1066,10 +1035,7 @@ object FxSpec extends Properties {
         actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
-      def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
-
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+      def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1121,10 +1087,7 @@ object FxSpec extends Properties {
         actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
-      def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
-
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+      def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1181,10 +1144,7 @@ object FxSpec extends Properties {
         actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
-      def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
-
-        val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-        given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+      def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -1244,10 +1204,7 @@ object FxSpec extends Properties {
         actual.completeAs(expected)
       }
 
-      def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedException = SomeControlThrowable("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedException))
@@ -1297,10 +1254,7 @@ object FxSpec extends Properties {
         actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
-      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedException = SomeControlThrowable("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
@@ -1366,10 +1320,7 @@ object FxSpec extends Properties {
         actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
-      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedException = SomeControlThrowable("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
@@ -1440,10 +1391,7 @@ object FxSpec extends Properties {
           actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
         }
 
-      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedException = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
@@ -1509,10 +1457,7 @@ object FxSpec extends Properties {
         actual.completeAs(expected)
       }
 
-      def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedException = SomeControlThrowable("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedException))
@@ -1555,10 +1500,7 @@ object FxSpec extends Properties {
         actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
-      def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedException = SomeControlThrowable("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
@@ -1615,10 +1557,7 @@ object FxSpec extends Properties {
         actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
-      def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedException = SomeControlThrowable("Something's wrong")
         val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
@@ -1684,10 +1623,7 @@ object FxSpec extends Properties {
         actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
       }
 
-      def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedException = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
@@ -1738,10 +1674,7 @@ object FxSpec extends Properties {
 
     object OnNonFatalSpec {
 
-      def testOnNonFatal_IO_onNonFatalWithShouldRecoverFromNonFatal: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testOnNonFatal_IO_onNonFatalWithShouldRecoverFromNonFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedException = new RuntimeException("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedException))
@@ -1773,10 +1706,7 @@ object FxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedException = SomeControlThrowable("Something's wrong")
         val fa                = run[IO, Int](throwThrowable[Int](expectedException))
@@ -1807,10 +1737,7 @@ object FxSpec extends Properties {
 
       }
 
-      def testOnNonFatal_IO_onNonFatalWithShouldReturnSuccessfulResult: Result = {
-
-        val compat          = new CatsEffectIoCompatForFuture
-        given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+      def testOnNonFatal_IO_onNonFatalWithShouldReturnSuccessfulResult: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val expectedResult = 999
         val fa             = run[IO, Int](expectedResult)

--- a/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/instances/ce3/testing/IoAppUtils.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/instances/ce3/testing/IoAppUtils.scala
@@ -3,8 +3,6 @@ package effectie.instances.ce3.testing
 import cats.effect.unsafe.{IORuntime, IORuntimeConfig}
 import hedgehog.core.Result
 
-import java.util.concurrent.ExecutorService
-
 /** @author Kevin Lee
   * @since 2021-07-22
   */
@@ -15,38 +13,33 @@ object IoAppUtils {
     finally runtime.shutdown()
   }
 
-  def computeWorkerThreadCount: Int = {
-    val num = Math.max(2, Runtime.getRuntime.availableProcessors())
-    println(s"Worker thread count: ${num.toString}")
-    num
+  def withNewRuntime(test: IORuntime => Result): Result = {
+    val rt = runtime()
+    try test(rt)
+    finally rt.shutdown()
   }
 
-  def runtime(es: ExecutorService): IORuntime = runtime()
+  private def runtime(): IORuntime = {
 
-  def runtime(): IORuntime = {
-    lazy val runtime: IORuntime = {
+    val (executionContext, compDown) =
+      IORuntime.createDefaultBlockingExecutionContext("test-execution-context")
 
-      val (executionContext, compDown) =
-        IORuntime.createDefaultBlockingExecutionContext("test-execution-context")
+    val (blocking, blockDown) =
+      IORuntime.createDefaultBlockingExecutionContext()
 
-      val (blocking, blockDown) =
-        IORuntime.createDefaultBlockingExecutionContext()
+    val (scheduler, schedDown) =
+      IORuntime.createDefaultScheduler()
 
-      val (scheduler, schedDown) =
-        IORuntime.createDefaultScheduler()
-
-      IORuntime(
-        executionContext,
-        blocking,
-        scheduler,
-        { () =>
-          compDown()
-          blockDown()
-          schedDown()
-        },
-        IORuntimeConfig(),
-      )
-    }
-    runtime
+    IORuntime(
+      executionContext,
+      blocking,
+      scheduler,
+      { () =>
+        compDown()
+        blockDown()
+        schedDown()
+      },
+      IORuntimeConfig(),
+    )
   }
 }

--- a/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/syntax/errorSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/syntax/errorSpec.scala
@@ -2,10 +2,8 @@ package effectie.syntax
 
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.syntax.all.*
 import cats.Functor
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.syntax.fx.*
 import effectie.syntax.error.*
 import effectie.instances.ce3.testing
@@ -18,7 +16,6 @@ import extras.hedgehog.ce3.syntax.runner._
 import hedgehog.*
 import hedgehog.runner.*
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -155,10 +152,7 @@ object CanCatchSyntaxSpec {
       actual.completeAs(expected) and actual2.completeAs(expected)
     }
 
-    def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -197,10 +191,7 @@ object CanCatchSyntaxSpec {
       actual.completeAs(expected) and actual2.completeAs(expected)
     }
 
-    def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -239,10 +230,7 @@ object CanCatchSyntaxSpec {
       actual.completeAs(expected) and actual2.completeAs(expected)
     }
 
-    def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -292,10 +280,7 @@ object CanCatchSyntaxSpec {
       actual.completeAs(expected) and actual2.completeAs(expected)
     }
 
-    def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -799,10 +784,7 @@ object CanHandleErrorSyntaxSpec {
       actual.completeAs(expected) and actual2.completeAs(expected)
     }
 
-    def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -845,10 +827,7 @@ object CanHandleErrorSyntaxSpec {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -902,10 +881,7 @@ object CanHandleErrorSyntaxSpec {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -966,10 +942,7 @@ object CanHandleErrorSyntaxSpec {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -1033,10 +1006,7 @@ object CanHandleErrorSyntaxSpec {
       actual.completeAs(expected) and actual2.completeAs(expected)
     }
 
-    def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -1077,10 +1047,7 @@ object CanHandleErrorSyntaxSpec {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1134,10 +1101,7 @@ object CanHandleErrorSyntaxSpec {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -1196,10 +1160,7 @@ object CanHandleErrorSyntaxSpec {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      given rt: IORuntime     = testing.IoAppUtils.runtime(es)
+    def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val fatalExpcetion = SomeControlThrowable("Something's wrong")
       val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
@@ -1993,10 +1954,7 @@ object CanRecoverSyntaxSpec {
       actual.completeAs(expected) and actual2.completeAs(expected)
     }
 
-    def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Int](throwThrowable[Int](expectedException))
@@ -2048,10 +2006,7 @@ object CanRecoverSyntaxSpec {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
@@ -2121,10 +2076,7 @@ object CanRecoverSyntaxSpec {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
@@ -2194,10 +2146,7 @@ object CanRecoverSyntaxSpec {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
@@ -2269,10 +2218,7 @@ object CanRecoverSyntaxSpec {
       actual.completeAs(expected) and actual2.completeAs(expected)
     }
 
-    def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Int](throwThrowable[Int](expectedException))
@@ -2316,10 +2262,7 @@ object CanRecoverSyntaxSpec {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
@@ -2376,10 +2319,7 @@ object CanRecoverSyntaxSpec {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
@@ -2443,10 +2383,7 @@ object CanRecoverSyntaxSpec {
       actualFailedResult.completeAs(expectedFailedResult) and actualSuccessResult.completeAs(expectedSuccessResult)
     }
 
-    def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
-
-      val compat          = new CatsEffectIoCompatForFuture
-      given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+    def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
@@ -3142,10 +3079,7 @@ object OnNonFatalSyntaxSpec {
 
     }
 
-    def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+    def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
       val expectedException = SomeControlThrowable("Something's wrong")
       val fa                = run[IO, Int](throwThrowable[Int](expectedException))

--- a/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/syntax/fxSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala-3/effectie/syntax/fxSpec.scala
@@ -3,11 +3,8 @@ package effectie.syntax
 import cats.*
 import cats.syntax.all.*
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import effectie.core.{Fx, FxCtor}
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.instances.ce3.fx.given
-import effectie.instances.ce3.testing
 import effectie.syntax.fx.*
 import effectie.testing.tools.expectThrowable
 import effectie.testing.types.SomeThrowableError
@@ -85,10 +82,6 @@ object fxSpec extends Properties {
   }
 
   object IoSpec {
-
-    val compat          = new CatsEffectIoCompatForFuture
-    given rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
     def testAll: Property =
       for {
         before <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("before")

--- a/modules/effectie-cats-effect3/native/src/test/scala/effectie/instances/ce3/f/canCatchSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala/effectie/instances/ce3/f/canCatchSpec.scala
@@ -11,14 +11,11 @@ import effectie.syntax.error._
 import effectie.syntax.fx._
 import effectie.testing.types._
 import effectie.instances.ce3.testing
-import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.ErrorLogger
 import extras.hedgehog.ce3.syntax.runner._
 import effectie.instances.ce3.f.fxCtor._
 import hedgehog._
 import hedgehog.runner._
-
-import java.util.concurrent.ExecutorService
 
 /** @author Kevin Lee
   * @since 2020-07-31
@@ -110,10 +107,7 @@ object canCatchSpec extends Properties {
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-
-      testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -153,9 +147,7 @@ object canCatchSpec extends Properties {
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -195,9 +187,7 @@ object canCatchSpec extends Properties {
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
@@ -246,9 +236,7 @@ object canCatchSpec extends Properties {
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
-
-      val es: ExecutorService = ConcurrentSupport.newExecutorService(2)
-      testing.IoAppUtils.runWithRuntime(testing.IoAppUtils.runtime(es)) { implicit rt =>
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))

--- a/modules/effectie-cats-effect3/native/src/test/scala/effectie/instances/ce3/f/canHandleErrorSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala/effectie/instances/ce3/f/canHandleErrorSpec.scala
@@ -4,7 +4,6 @@ import canHandleError._
 import cats._
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.SomeControlThrowable
@@ -20,7 +19,6 @@ import fxCtor._
 import hedgehog._
 import hedgehog.runner._
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -335,26 +333,24 @@ object canHandleErrorSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
+    def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        try {
+          val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -381,26 +377,24 @@ object canHandleErrorSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
+    def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        try {
+          val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: SomeControlThrowable =>
+            ex.getMessage ==== fatalExpcetion.getMessage
 
-      try {
-        val actual = CanHandleError[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: SomeControlThrowable =>
-          ex.getMessage ==== fatalExpcetion.getMessage
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -437,29 +431,27 @@ object canHandleErrorSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
+    def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        try {
+          val actual =
+            CanHandleError[IO]
+              .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual =
-          CanHandleError[IO]
-            .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-            .unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -499,30 +491,28 @@ object canHandleErrorSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
+    def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        try {
+          val actual =
+            CanHandleError[IO]
+              .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+              .value
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual =
-          CanHandleError[IO]
-            .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-            .value
-            .unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result =
       withIO { implicit ticker =>
@@ -563,26 +553,24 @@ object canHandleErrorSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
+    def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+        try {
+          val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -607,26 +595,24 @@ object canHandleErrorSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
+    def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        try {
+          val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual = CanHandleError[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -663,29 +649,27 @@ object canHandleErrorSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
+    def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+        try {
+          val actual =
+            CanHandleError[IO]
+              .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual =
-          CanHandleError[IO]
-            .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-            .unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -724,30 +708,28 @@ object canHandleErrorSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
+    def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+        val fatalExpcetion = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-      val fatalExpcetion = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+        try {
+          val actual =
+            CanHandleError[IO]
+              .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+              .value
+              .unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== fatalExpcetion
 
-      try {
-        val actual =
-          CanHandleError[IO]
-            .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-            .value
-            .unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== fatalExpcetion
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 

--- a/modules/effectie-cats-effect3/native/src/test/scala/effectie/instances/ce3/f/canRecoverSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala/effectie/instances/ce3/f/canRecoverSpec.scala
@@ -3,12 +3,10 @@ package effectie.instances.ce3.f
 import canRecover._
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.instances.all._
 import cats.syntax.all._
 import effectie.SomeControlThrowable
 import effectie.core._
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.syntax.error._
 import effectie.syntax.fx._
 import effectie.instances.ce3.testing
@@ -177,27 +175,25 @@ object canRecoverSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+        val io = CanRecover[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io = CanRecover[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
-      try {
-        val actual = io.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -231,29 +227,27 @@ object canRecoverSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+        val io = CanRecover[IO].recoverFromNonFatalWith(fa) {
+          case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+        }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io = CanRecover[IO].recoverFromNonFatalWith(fa) {
-        case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
       }
-      try {
-        val actual = io.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
-
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-      }
-
-    }
 
     def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult: Result =
       withIO { implicit ticker =>
@@ -301,29 +295,27 @@ object canRecoverSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+        val io = CanRecover[IO].recoverEitherFromNonFatalWith(fa) {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io = CanRecover[IO].recoverEitherFromNonFatalWith(fa) {
-        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
       }
-      try {
-        val actual = io.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
-
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-      }
-
-    }
 
     def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult: Result =
       withIO { implicit ticker =>
@@ -374,29 +366,27 @@ object canRecoverSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
+        val io = CanRecover[IO].recoverEitherTFromNonFatalWith(fa) {
+          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+        }
+        try {
+          val actual = io.value.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io = CanRecover[IO].recoverEitherTFromNonFatalWith(fa) {
-        case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
+
       }
-      try {
-        val actual = io.value.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
-
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-      }
-
-    }
 
     def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult: Result =
       withIO { implicit ticker =>
@@ -444,27 +434,25 @@ object canRecoverSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+        val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
-      try {
-        val actual = io.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -491,27 +479,25 @@ object canRecoverSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+        val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io = CanRecover[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
-      try {
-        val actual = io.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+        }
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -552,30 +538,28 @@ object canRecoverSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa                = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+        val io =
+          CanRecover[IO].recoverEitherFromNonFatal(fa) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+        try {
+          val actual = io.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io =
-        CanRecover[IO].recoverEitherFromNonFatal(fa) {
-          case err => SomeError.someThrowable(err).asLeft[Int]
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-      try {
-        val actual = io.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -622,30 +606,28 @@ object canRecoverSpec extends Properties {
     }
 
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-    def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
+    def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result =
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-      val compat                 = new CatsEffectIoCompatForFuture
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+        val expectedException = SomeControlThrowable("Something's wrong")
+        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-      val expectedException = SomeControlThrowable("Something's wrong")
-      val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
+        val io =
+          CanRecover[IO].recoverEitherTFromNonFatal(fa) {
+            case err => SomeError.someThrowable(err).asLeft[Int]
+          }
+        try {
+          val actual = io.value.unsafeRunSync()
+          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+        } catch {
+          case ex: ControlThrowable =>
+            ex ==== expectedException
 
-      val io =
-        CanRecover[IO].recoverEitherTFromNonFatal(fa) {
-          case err => SomeError.someThrowable(err).asLeft[Int]
+          case ex: Throwable =>
+            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-      try {
-        val actual = io.value.unsafeRunSync()
-        Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-      } catch {
-        case ex: ControlThrowable =>
-          ex ==== expectedException
 
-        case ex: Throwable =>
-          Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
       }
-
-    }
 
     def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 

--- a/modules/effectie-cats-effect3/native/src/test/scala/effectie/instances/ce3/f/fromFutureSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala/effectie/instances/ce3/f/fromFutureSpec.scala
@@ -1,7 +1,6 @@
 package effectie.instances.ce3.f
 
 import cats.effect._
-import cats.effect.unsafe.IORuntime
 import effectie.core.FromFuture
 import effectie.instances.ce3.testing
 import extras.concurrent.testing.ConcurrentSupport
@@ -30,15 +29,16 @@ object FromFutureSpec extends Properties {
     def testToEffect: Property = for {
       a <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("a")
     } yield {
-      val compat                 = new effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
+      val compat = new effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
       import compat.ec
-      implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
 
-      ConcurrentSupport.runAndShutdown(compat.es, waitFor300Millis) {
-        lazy val fa = Future(a)
-        val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
+      testing.IoAppUtils.withNewRuntime { implicit rt =>
+        ConcurrentSupport.runAndShutdown(compat.es, waitFor300Millis) {
+          lazy val fa = Future(a)
+          val actual  = FromFuture[IO].toEffect(fa).unsafeRunSync()
 
-        actual ==== a
+          actual ==== a
+        }
       }
     }
   }

--- a/modules/effectie-cats-effect3/native/src/test/scala/effectie/instances/ce3/f/fxSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala/effectie/instances/ce3/f/fxSpec.scala
@@ -2,24 +2,20 @@ package effectie.instances.ce3.f
 
 import cats.data.EitherT
 import cats.effect._
-import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import cats.Eq
 import effectie.SomeControlThrowable
 import effectie.core._
-import effectie.instances.ce3.compat.CatsEffectIoCompatForFuture
 import effectie.instances.ce3.testing
 import effectie.specs.MonadSpec
 import effectie.specs.fxSpec.FxSpecs
 import effectie.syntax.error._
 import effectie.testing.types.SomeError
-import extras.concurrent.testing.ConcurrentSupport
 import extras.hedgehog.ce3.syntax.runner._
 import fx._
 import hedgehog._
 import hedgehog.runner._
 
-import java.util.concurrent.ExecutorService
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** @author Kevin Lee
@@ -558,26 +554,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result = {
+      def testCanCatch_IO_catchNonFatalThrowableShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+          try {
+            val actual = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: SomeControlThrowable =>
+              ex.getMessage ==== fatalExpcetion.getMessage
 
-        try {
-          val actual = Fx[IO].catchNonFatalThrowable(fa).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanCatch_IO_catchNonFatalThrowableShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -599,10 +593,7 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = {
-
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+      def testCanCatch_IO_catchNonFatalShouldNotCatchFatal: Result = testing.IoAppUtils.withNewRuntime { implicit rt =>
 
         val fatalExpcetion = SomeControlThrowable("Something's wrong")
         val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
@@ -640,26 +631,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result = {
+      def testCanCatch_IO_catchNonFatalEitherShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+          try {
+            val actual = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: SomeControlThrowable =>
+              ex.getMessage ==== fatalExpcetion.getMessage
 
-        try {
-          val actual = Fx[IO].catchNonFatalEither(fa)(SomeError.someThrowable).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanCatch_IO_catchNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -691,26 +680,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result = {
+      def testCanCatch_IO_catchNonFatalEitherTShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+          try {
+            val actual = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: SomeControlThrowable =>
+              ex.getMessage ==== fatalExpcetion.getMessage
 
-        try {
-          val actual = Fx[IO].catchNonFatalEitherT(fa)(SomeError.someThrowable).value.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanCatch_IO_catchNonFatalEitherTShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -752,26 +739,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result = {
+      def testCanHandleError_IO_handleNonFatalWithShouldNotHandleFatalWith: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+          try {
+            val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123)).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -798,26 +783,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result = {
+      def testCanHandleError_IO_handleNonFatalWithEitherShouldNotHandleFatalWith: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+          try {
+            val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: SomeControlThrowable =>
+              ex.getMessage ==== fatalExpcetion.getMessage
 
-        try {
-          val actual = Fx[IO].handleNonFatalWith(fa)(_ => IO.pure(123.asRight[SomeError])).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: SomeControlThrowable =>
-            ex.getMessage ==== fatalExpcetion.getMessage
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleNonFatalWithEitherShouldReturnSuccessfulResult: Result =
         withIO { implicit ticker =>
@@ -855,29 +838,27 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result = {
+      def testCanHandleError_IO_handleEitherNonFatalWithShouldNotHandleFatalWith: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+          try {
+            val actual =
+              Fx[IO]
+                .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+                .unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual =
-            Fx[IO]
-              .handleEitherNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-              .unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleEitherNonFatalWithShouldReturnSuccessfulResult: Result =
         withIO { implicit ticker =>
@@ -918,30 +899,28 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result = {
+      def testCanHandleError_IO_handleEitherTNonFatalWithShouldNotHandleFatalWith: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+          try {
+            val actual =
+              Fx[IO]
+                .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
+                .value
+                .unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual =
-            Fx[IO]
-              .handleEitherTNonFatalWith(fa)(err => IO.pure(SomeError.someThrowable(err).asLeft[Int]))
-              .value
-              .unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleEitherTNonFatalWithShouldReturnSuccessfulResult: Result =
         withIO { implicit ticker =>
@@ -982,26 +961,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result = {
+      def testCanHandleError_IO_handleNonFatalShouldNotHandleFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Int](throwThrowable[Int](fatalExpcetion))
+          try {
+            val actual = Fx[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual = Fx[IO].handleNonFatal(fa)(_ => 123).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1026,26 +1003,24 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result = {
+      def testCanHandleError_IO_handleNonFatalEitherShouldNotHandleFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+          try {
+            val actual = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual = Fx[IO].handleNonFatal(fa)(_ => 123.asRight[SomeError]).unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1082,29 +1057,27 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result = {
+      def testCanHandleError_IO_handleEitherNonFatalShouldNotHandleFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa             = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion))
+          try {
+            val actual =
+              Fx[IO]
+                .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+                .unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual =
-            Fx[IO]
-              .handleEitherNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-              .unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleEitherNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1143,30 +1116,28 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result = {
+      def testCanHandleError_IO_handleEitherTNonFatalShouldNotHandleFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val es: ExecutorService    = ConcurrentSupport.newExecutorService(2)
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(es)
+          val fatalExpcetion = SomeControlThrowable("Something's wrong")
+          val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
 
-        val fatalExpcetion = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](fatalExpcetion)))
+          try {
+            val actual =
+              Fx[IO]
+                .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
+                .value
+                .unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== fatalExpcetion
 
-        try {
-          val actual =
-            Fx[IO]
-              .handleEitherTNonFatal(fa)(err => SomeError.someThrowable(err).asLeft[Int])
-              .value
-              .unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== fatalExpcetion
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanHandleError_IO_handleEitherTNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1206,27 +1177,25 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverFromNonFatalWithShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+          val io = Fx[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io = Fx[IO].recoverFromNonFatalWith(fa) { case NonFatal(`expectedException`) => IO.pure(123) }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanRecover_IO_recoverFromNonFatalWithShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1260,29 +1229,27 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverFromNonFatalWithEitherShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+          val io = Fx[IO].recoverFromNonFatalWith(fa) {
+            case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+          }
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io = Fx[IO].recoverFromNonFatalWith(fa) {
-          case NonFatal(`expectedException`) => IO.pure(123.asRight[SomeError])
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
+
         }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
-
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-        }
-
-      }
 
       def testCanRecover_IO_recoverFromNonFatalWithEitherShouldReturnSuccessfulResult: Result =
         withIO { implicit ticker =>
@@ -1330,29 +1297,27 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverEitherFromNonFatalWithShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+          val io = Fx[IO].recoverEitherFromNonFatalWith(fa) {
+            case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          }
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io = Fx[IO].recoverEitherFromNonFatalWith(fa) {
-          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
+
         }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
-
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-        }
-
-      }
 
       def testCanRecover_IO_recoverEitherFromNonFatalWithShouldReturnSuccessfulResult: Result =
         withIO { implicit ticker =>
@@ -1404,29 +1369,27 @@ object fxSpec extends Properties {
         }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
+          val io = Fx[IO].recoverEitherTFromNonFatalWith(fa) {
+            case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+          }
+          try {
+            val actual = io.value.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io = Fx[IO].recoverEitherTFromNonFatalWith(fa) {
-          case err => IO.pure(SomeError.someThrowable(err).asLeft[Int])
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
+
         }
-        try {
-          val actual = io.value.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
-
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-        }
-
-      }
 
       def testCanRecover_IO_recoverEitherTFromNonFatalWithShouldReturnSuccessfulResult: Result =
         withIO { implicit ticker =>
@@ -1474,27 +1437,25 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverFromNonFatalShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa                = run[IO, Int](throwThrowable[Int](expectedException))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+          val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123 }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanRecover_IO_recoverFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1521,27 +1482,25 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverFromNonFatalEitherShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+          val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io = Fx[IO].recoverFromNonFatal(fa) { case NonFatal(`expectedException`) => 123.asRight[SomeError] }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanRecover_IO_recoverFromNonFatalEitherShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1582,30 +1541,28 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverEitherFromNonFatalShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException))
+          val io =
+            Fx[IO].recoverEitherFromNonFatal(fa) {
+              case err => SomeError.someThrowable(err).asLeft[Int]
+            }
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io =
-          Fx[IO].recoverEitherFromNonFatal(fa) {
-            case err => SomeError.someThrowable(err).asLeft[Int]
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
           }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanRecover_IO_recoverEitherFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1652,30 +1609,28 @@ object fxSpec extends Properties {
       }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result = {
+      def testCanRecover_IO_recoverEitherTFromNonFatalShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa = EitherT(run[IO, Either[SomeError, Int]](throwThrowable[Either[SomeError, Int]](expectedException)))
+          val io =
+            Fx[IO].recoverEitherTFromNonFatal(fa) {
+              case err => SomeError.someThrowable(err).asLeft[Int]
+            }
+          try {
+            val actual = io.value.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              ex ==== expectedException
 
-        val io =
-          Fx[IO].recoverEitherTFromNonFatal(fa) {
-            case err => SomeError.someThrowable(err).asLeft[Int]
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
           }
-        try {
-          val actual = io.value.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            ex ==== expectedException
 
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
         }
-
-      }
 
       def testCanRecover_IO_recoverEitherTFromNonFatalShouldReturnSuccessfulResult: Result = withIO { implicit ticker =>
 
@@ -1706,102 +1661,96 @@ object fxSpec extends Properties {
 
     object OnNonFatalSpec {
 
-      def testOnNonFatal_IO_onNonFatalWithShouldRecoverFromNonFatal: Result = {
+      def testOnNonFatal_IO_onNonFatalWithShouldRecoverFromNonFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = new RuntimeException("Something's wrong")
+          val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+          val expected          = 123.some
+          var actual            = none[Int] // scalafix:ok DisableSyntax.var
 
-        val expectedException = new RuntimeException("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
-        val expected          = 123.some
-        var actual            = none[Int] // scalafix:ok DisableSyntax.var
+          val result =
+            try {
+              val r = Fx[IO]
+                .onNonFatalWith(fa) {
+                  case NonFatal(`expectedException`) =>
+                    IO.delay {
+                      actual = expected
+                    } *> IO.unit
+                }
+                .unsafeRunSync()
+              new AssertionError(s"Should have thrown an exception, but it was ${r.toString}.")
+            } catch {
+              case ex: Throwable =>
+                ex
+            }
 
-        val result =
-          try {
-            val r = Fx[IO]
-              .onNonFatalWith(fa) {
-                case NonFatal(`expectedException`) =>
-                  IO.delay {
-                    actual = expected
-                  } *> IO.unit
-              }
-              .unsafeRunSync()
-            new AssertionError(s"Should have thrown an exception, but it was ${r.toString}.")
-          } catch {
-            case ex: Throwable =>
-              ex
-          }
-
-        Result.all(
-          List(
-            result ==== expectedException,
-            actual ==== expected,
+          Result.all(
+            List(
+              result ==== expectedException,
+              actual ==== expected,
+            )
           )
-        )
-      }
+        }
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result = {
+      def testOnNonFatal_IO_onNonFatalWithShouldNotCatchFatal: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
 
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
+          val expectedException = SomeControlThrowable("Something's wrong")
+          val fa                = run[IO, Int](throwThrowable[Int](expectedException))
+          var actual            = none[Int] // scalafix:ok DisableSyntax.var
 
-        val expectedException = SomeControlThrowable("Something's wrong")
-        val fa                = run[IO, Int](throwThrowable[Int](expectedException))
-        var actual            = none[Int] // scalafix:ok DisableSyntax.var
-
-        val io = Fx[IO].onNonFatalWith(fa) {
-          case NonFatal(`expectedException`) =>
-            IO.delay {
-              actual = 123.some
-              ()
-            } *> IO.unit
-        }
-        try {
-          val actual = io.unsafeRunSync()
-          Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
-        } catch {
-          case ex: ControlThrowable =>
-            Result.all(
-              List(
-                actual ==== none[Int],
-                ex ==== expectedException,
-              )
-            )
-
-          case ex: Throwable =>
-            Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
-        }
-
-      }
-
-      def testOnNonFatal_IO_onNonFatalWithShouldReturnSuccessfulResult: Result = {
-
-        val compat                 = new CatsEffectIoCompatForFuture
-        implicit val rt: IORuntime = testing.IoAppUtils.runtime(compat.es)
-
-        val expectedResult = 999
-        val fa             = run[IO, Int](expectedResult)
-
-        val expected = none[Int]
-        var actual   = none[Int] // scalafix:ok DisableSyntax.var
-
-        val result = Fx[IO]
-          .onNonFatalWith(fa) {
-            case NonFatal(_) =>
+          val io = Fx[IO].onNonFatalWith(fa) {
+            case NonFatal(`expectedException`) =>
               IO.delay {
                 actual = 123.some
+                ()
               } *> IO.unit
           }
-          .unsafeRunSync()
+          try {
+            val actual = io.unsafeRunSync()
+            Result.failure.log(s"The expected fatal exception was not thrown. actual: ${actual.toString}")
+          } catch {
+            case ex: ControlThrowable =>
+              Result.all(
+                List(
+                  actual ==== none[Int],
+                  ex ==== expectedException,
+                )
+              )
 
-        Result.all(
-          List(
-            result ==== expectedResult,
-            actual ==== expected,
+            case ex: Throwable =>
+              Result.failure.log(s"Unexpected Throwable: ${ex.toString}")
+          }
+
+        }
+
+      def testOnNonFatal_IO_onNonFatalWithShouldReturnSuccessfulResult: Result =
+        testing.IoAppUtils.withNewRuntime { implicit rt =>
+
+          val expectedResult = 999
+          val fa             = run[IO, Int](expectedResult)
+
+          val expected = none[Int]
+          var actual   = none[Int] // scalafix:ok DisableSyntax.var
+
+          val result = Fx[IO]
+            .onNonFatalWith(fa) {
+              case NonFatal(_) =>
+                IO.delay {
+                  actual = 123.some
+                } *> IO.unit
+            }
+            .unsafeRunSync()
+
+          Result.all(
+            List(
+              result ==== expectedResult,
+              actual ==== expected,
+            )
           )
-        )
-      }
+        }
 
     }
 


### PR DESCRIPTION
# Fix `IORuntime` file-descriptor leak in `effectie-cats-effect3` tests

Test specs created a new IORuntime per test or property iteration via IoAppUtils.runtime(...) and never shut it down. Since cats-effect 3.7, each JVM runtime's work-stealing pool owns kqueue selector file descriptors per worker thread, so a full test run leaked hundreds of runtimes and could fail with "java.io.IOException: Too many open files" in low-ulimit sessions. The runtime(es) overload also silently ignored its ExecutorService argument, so the executors created for it leaked as well.

- `IoAppUtils` now owns the runtime lifecycle: the new `withNewRuntime(test)` creates a runtime and guarantees `shutdown()` via `try/finally`. `runtime()` is `private`, and the argument-ignoring `runtime(es)` overload and the unused `computeWorkerThreadCount` are removed
- All call sites (JVM and Native) now run inside `IoAppUtils.withNewRuntime { implicit rt => ... }`, keeping the per-test runtime isolation while releasing threads and file descriptors when each test ends
- `Executor` services and object-level runtime vals that existed only to feed the ignored parameter are removed, along with their now-unused imports