### PR TITLE
Verify resources are actually closed across `Try`, `Future` and cats-effect

### DIFF
--- a/modules/effectie-cats-effect2/jvm/src/test/scala/effectie/resource/Ce2UseResourceSpec.scala
+++ b/modules/effectie-cats-effect2/jvm/src/test/scala/effectie/resource/Ce2UseResourceSpec.scala
@@ -1,8 +1,10 @@
 package effectie.resource
 
 import cats.effect._
+import effectie.instances.ce2.fx.ioFx
 import effectie.instances.ce2.resource.ioUseResource
 import effectie.resource.data.TestErrors.TestException
+import effectie.resource.data.{TestResource, TestableResource}
 import hedgehog._
 import hedgehog.runner._
 
@@ -17,8 +19,100 @@ object Ce2UseResourceSpec extends Properties {
     example(
       "test UseResource[IO] flatMap chain: LIFO release order and ExitCase through translation",
       testFlatMapChainLifoReleaseAndExitCase,
-    )
+    ),
+    example(
+      "test ReleasableResource.fromAutoCloseable[IO, A]: close() is called on success and on failure",
+      testFromAutoCloseableClosesTheResource,
+    ),
+    example(
+      "test Ce2UseResource interop with cats.effect.Resource: an AutoCloseable is closed in both directions",
+      testCatsEffectResourceInteropClosesTheResource,
+    ),
   )
+
+  def testFromAutoCloseableClosesTheResource: Result = {
+    val successResource = TestResource()
+    val failureResource = TestResource()
+
+    val beforeUse = (successResource.closeStatus ==== TestableResource.CloseStatus.notClosed)
+      .log("the resource should not be closed before use")
+
+    val successResult =
+      ReleasableResource
+        .fromAutoCloseable[IO, TestResource](IO(successResource))
+        .use(resource =>
+          IO {
+            resource.write("written")
+            resource.closeStatus
+          }
+        )
+        .unsafeRunSync()
+
+    val failureResult =
+      ReleasableResource
+        .fromAutoCloseable[IO, TestResource](IO(failureResource))
+        .use(_ => IO.raiseError[Unit](TestException(1)))
+        .attempt
+        .unsafeRunSync()
+
+    Result.all(
+      List(
+        beforeUse,
+        (successResult ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should still be open while the use function runs"),
+        (successResource.content ==== Vector("written")).log("content written during use"),
+        (successResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function succeeds"),
+        (failureResult ==== Left(TestException(1))).log("the use error should propagate"),
+        (failureResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function fails"),
+      )
+    )
+  }
+
+  def testCatsEffectResourceInteropClosesTheResource: Result = {
+    val toCatsResource   = TestResource()
+    val fromCatsResource = TestResource()
+
+    // a ReleasableResource run by cats-effect's own Resource.use
+    val toCatsResult =
+      Ce2UseResource
+        .toCatsEffectResource(ReleasableResource.fromAutoCloseable[IO, TestResource](IO(toCatsResource)))
+        .use(resource =>
+          IO {
+            resource.write("to-cats")
+            resource.closeStatus
+          }
+        )
+        .unsafeRunSync()
+
+    // a cats-effect Resource run by the effectie UseResource interpreter
+    val fromCatsResult =
+      Ce2UseResource
+        .fromCatsEffectResource(Resource.fromAutoCloseable[IO, TestResource](IO(fromCatsResource)))
+        .use(resource =>
+          IO {
+            resource.write("from-cats")
+            resource.closeStatus
+          }
+        )
+        .unsafeRunSync()
+
+    Result.all(
+      List(
+        (toCatsResult ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should still be open while cats-effect Resource.use runs"),
+        (toCatsResource.content ==== Vector("to-cats")).log("toCatsEffectResource content"),
+        (toCatsResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("cats-effect Resource.use should close the underlying AutoCloseable"),
+        (fromCatsResult ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should still be open while the interpreter runs the use function"),
+        (fromCatsResource.content ==== Vector("from-cats")).log("fromCatsEffectResource content"),
+        (fromCatsResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("the UseResource interpreter should close a cats-effect Resource's AutoCloseable"),
+      )
+    )
+  }
 
   private def exitCaseName(exitCase: ReleasableResource.ExitCase): String =
     exitCase match {

--- a/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/resource/Ce3UseResourceSpec.scala
+++ b/modules/effectie-cats-effect3/jvm/src/test/scala/effectie/instances/resource/Ce3UseResourceSpec.scala
@@ -4,8 +4,10 @@ import cats.MonadError
 import cats.effect._
 import cats.effect.kernel.Outcome
 import cats.syntax.all._
+import effectie.instances.ce3.fx.ioFx
 import effectie.instances.ce3.resource.ioUseResource
 import effectie.resource.data.TestErrors.TestException
+import effectie.resource.data.{TestResource, TestableResource}
 import hedgehog._
 import hedgehog.runner._
 
@@ -38,6 +40,14 @@ object Ce3UseResourceSpec extends Properties {
     example(
       "test UseResource[IO] flatMap chain: LIFO release order and ExitCase through translation",
       testFlatMapChainLifoReleaseAndExitCase,
+    ),
+    example(
+      "test ReleasableResource.fromAutoCloseable[IO, A]: close() is called on success, on failure and on cancellation",
+      testFromAutoCloseableClosesTheResource,
+    ),
+    example(
+      "test Ce3UseResource interop with cats.effect.Resource: an AutoCloseable is closed in both directions",
+      testCatsEffectResourceInteropClosesTheResource,
     ),
   )
 
@@ -148,6 +158,108 @@ object Ce3UseResourceSpec extends Properties {
       }
 
     (chained.use(n => IO.pure(n)).unsafeRunSync() ==== depth).log(s"${depth.toString} deep flatMap chain")
+  }
+
+  def testFromAutoCloseableClosesTheResource: Result = {
+    val successResource  = TestResource()
+    val failureResource  = TestResource()
+    val canceledResource = TestResource()
+
+    val beforeUse = (successResource.closeStatus ==== TestableResource.CloseStatus.notClosed)
+      .log("the resource should not be closed before use")
+
+    val successResult =
+      ReleasableResource
+        .fromAutoCloseable[IO, TestResource](IO(successResource))
+        .use(resource =>
+          IO {
+            resource.write("written")
+            resource.closeStatus
+          }
+        )
+        .unsafeRunSync()
+
+    val failureResult =
+      ReleasableResource
+        .fromAutoCloseable[IO, TestResource](IO(failureResource))
+        .use(_ => IO.raiseError[Unit](TestException(1)))
+        .attempt
+        .unsafeRunSync()
+
+    val canceledOutcome =
+      ReleasableResource
+        .fromAutoCloseable[IO, TestResource](IO(canceledResource))
+        .use(_ => IO.canceled *> IO.unit)
+        .start
+        .flatMap(_.join)
+        .unsafeRunSync()
+
+    val canceledResult = canceledOutcome match {
+      case Outcome.Canceled() => Result.success
+      case Outcome.Succeeded(_) => Result.failure.log("Expected Canceled outcome but got Succeeded")
+      case Outcome.Errored(err) => Result.failure.log(s"Expected Canceled outcome but got Errored(${err.toString})")
+    }
+
+    Result.all(
+      List(
+        beforeUse,
+        (successResult ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should still be open while the use function runs"),
+        (successResource.content ==== Vector("written")).log("content written during use"),
+        (successResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function succeeds"),
+        (failureResult ==== Left(TestException(1))).log("the use error should propagate"),
+        (failureResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function fails"),
+        canceledResult,
+        (canceledResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use is canceled"),
+      )
+    )
+  }
+
+  def testCatsEffectResourceInteropClosesTheResource: Result = {
+    val toCatsResource   = TestResource()
+    val fromCatsResource = TestResource()
+
+    // a ReleasableResource run by cats-effect's own Resource.use
+    val toCatsResult =
+      Ce3UseResource
+        .toCatsEffectResource(ReleasableResource.fromAutoCloseable[IO, TestResource](IO(toCatsResource)))
+        .use(resource =>
+          IO {
+            resource.write("to-cats")
+            resource.closeStatus
+          }
+        )
+        .unsafeRunSync()
+
+    // a cats-effect Resource run by the effectie UseResource interpreter
+    val fromCatsResult =
+      Ce3UseResource
+        .fromCatsEffectResource(Resource.fromAutoCloseable[IO, TestResource](IO(fromCatsResource)))
+        .use(resource =>
+          IO {
+            resource.write("from-cats")
+            resource.closeStatus
+          }
+        )
+        .unsafeRunSync()
+
+    Result.all(
+      List(
+        (toCatsResult ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should still be open while cats-effect Resource.use runs"),
+        (toCatsResource.content ==== Vector("to-cats")).log("toCatsEffectResource content"),
+        (toCatsResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("cats-effect Resource.use should close the underlying AutoCloseable"),
+        (fromCatsResult ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should still be open while the interpreter runs the use function"),
+        (fromCatsResource.content ==== Vector("from-cats")).log("fromCatsEffectResource content"),
+        (fromCatsResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("the UseResource interpreter should close a cats-effect Resource's AutoCloseable"),
+      )
+    )
   }
 
   def testFlatMapChainLifoReleaseAndExitCase: Result = {

--- a/modules/effectie-cats-effect3/native/src/test/scala/effectie/instances/resource/Ce3UseResourceSpec.scala
+++ b/modules/effectie-cats-effect3/native/src/test/scala/effectie/instances/resource/Ce3UseResourceSpec.scala
@@ -4,8 +4,10 @@ import cats.MonadError
 import cats.effect._
 import cats.effect.kernel.Outcome
 import cats.syntax.all._
+import effectie.instances.ce3.fx.ioFx
 import effectie.instances.ce3.resource.ioUseResource
 import effectie.resource.data.TestErrors.TestException
+import effectie.resource.data.{TestResource, TestableResource}
 import hedgehog._
 import hedgehog.runner._
 
@@ -38,6 +40,14 @@ object Ce3UseResourceSpec extends Properties {
     example(
       "test UseResource[IO] flatMap chain: LIFO release order and ExitCase through translation",
       testFlatMapChainLifoReleaseAndExitCase,
+    ),
+    example(
+      "test ReleasableResource.fromAutoCloseable[IO, A]: close() is called on success, on failure and on cancellation",
+      testFromAutoCloseableClosesTheResource,
+    ),
+    example(
+      "test Ce3UseResource interop with cats.effect.Resource: an AutoCloseable is closed in both directions",
+      testCatsEffectResourceInteropClosesTheResource,
     ),
   )
 
@@ -148,6 +158,108 @@ object Ce3UseResourceSpec extends Properties {
       }
 
     (chained.use(n => IO.pure(n)).unsafeRunSync() ==== depth).log(s"${depth.toString} deep flatMap chain")
+  }
+
+  def testFromAutoCloseableClosesTheResource: Result = {
+    val successResource  = TestResource()
+    val failureResource  = TestResource()
+    val canceledResource = TestResource()
+
+    val beforeUse = (successResource.closeStatus ==== TestableResource.CloseStatus.notClosed)
+      .log("the resource should not be closed before use")
+
+    val successResult =
+      ReleasableResource
+        .fromAutoCloseable[IO, TestResource](IO(successResource))
+        .use(resource =>
+          IO {
+            resource.write("written")
+            resource.closeStatus
+          }
+        )
+        .unsafeRunSync()
+
+    val failureResult =
+      ReleasableResource
+        .fromAutoCloseable[IO, TestResource](IO(failureResource))
+        .use(_ => IO.raiseError[Unit](TestException(1)))
+        .attempt
+        .unsafeRunSync()
+
+    val canceledOutcome =
+      ReleasableResource
+        .fromAutoCloseable[IO, TestResource](IO(canceledResource))
+        .use(_ => IO.canceled *> IO.unit)
+        .start
+        .flatMap(_.join)
+        .unsafeRunSync()
+
+    val canceledResult = canceledOutcome match {
+      case Outcome.Canceled() => Result.success
+      case Outcome.Succeeded(_) => Result.failure.log("Expected Canceled outcome but got Succeeded")
+      case Outcome.Errored(err) => Result.failure.log(s"Expected Canceled outcome but got Errored(${err.toString})")
+    }
+
+    Result.all(
+      List(
+        beforeUse,
+        (successResult ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should still be open while the use function runs"),
+        (successResource.content ==== Vector("written")).log("content written during use"),
+        (successResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function succeeds"),
+        (failureResult ==== Left(TestException(1))).log("the use error should propagate"),
+        (failureResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function fails"),
+        canceledResult,
+        (canceledResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use is canceled"),
+      )
+    )
+  }
+
+  def testCatsEffectResourceInteropClosesTheResource: Result = {
+    val toCatsResource   = TestResource()
+    val fromCatsResource = TestResource()
+
+    // a ReleasableResource run by cats-effect's own Resource.use
+    val toCatsResult =
+      Ce3UseResource
+        .toCatsEffectResource(ReleasableResource.fromAutoCloseable[IO, TestResource](IO(toCatsResource)))
+        .use(resource =>
+          IO {
+            resource.write("to-cats")
+            resource.closeStatus
+          }
+        )
+        .unsafeRunSync()
+
+    // a cats-effect Resource run by the effectie UseResource interpreter
+    val fromCatsResult =
+      Ce3UseResource
+        .fromCatsEffectResource(Resource.fromAutoCloseable[IO, TestResource](IO(fromCatsResource)))
+        .use(resource =>
+          IO {
+            resource.write("from-cats")
+            resource.closeStatus
+          }
+        )
+        .unsafeRunSync()
+
+    Result.all(
+      List(
+        (toCatsResult ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should still be open while cats-effect Resource.use runs"),
+        (toCatsResource.content ==== Vector("to-cats")).log("toCatsEffectResource content"),
+        (toCatsResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("cats-effect Resource.use should close the underlying AutoCloseable"),
+        (fromCatsResult ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should still be open while the interpreter runs the use function"),
+        (fromCatsResource.content ==== Vector("from-cats")).log("fromCatsEffectResource content"),
+        (fromCatsResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("the UseResource interpreter should close a cats-effect Resource's AutoCloseable"),
+      )
+    )
   }
 
   def testFlatMapChainLifoReleaseAndExitCase: Result = {

--- a/modules/effectie-cats/js/src/test/scala/effectie/resource/ReleasableResourceFutureSpec.scala
+++ b/modules/effectie-cats/js/src/test/scala/effectie/resource/ReleasableResourceFutureSpec.scala
@@ -1,7 +1,7 @@
 package effectie.resource
 
 import effectie.resource.data.TestErrors.TestException
-import effectie.resource.data.{TestResourceNoAutoClose, TestableResource}
+import effectie.resource.data.{TestResource, TestResourceNoAutoClose, TestableResource}
 import effectie.testing.FutureTools
 import munit.Assertions
 
@@ -91,6 +91,59 @@ class ReleasableResourceFutureSpec extends munit.FunSuite with FutureTools {
       case ReleasableResource.ExitCase.Errored(err) => s"Errored(${err.toString})"
       case ReleasableResource.ExitCase.Canceled => "Canceled"
     }
+
+  test("test ReleasableResource.fromAutoCloseable[Future, A]: close() is called on success and on failure") {
+    import effectie.instances.future.fxCtor._
+
+    val successResource = TestResource()
+    val failureResource = TestResource()
+    val throwResource   = TestResource()
+
+    Assertions.assertEquals(
+      successResource.closeStatus,
+      TestableResource.CloseStatus.notClosed,
+      "the resource should not be closed before use",
+    )
+
+    for {
+      _ <- ReleasableResource
+             .fromAutoCloseable[Future, TestResource](Future(successResource))
+             .use(resource => Future(resource.write("written")))
+      _ <- ReleasableResource
+             .fromAutoCloseable[Future, TestResource](Future(failureResource))
+             .use(_ => Future.failed[Unit](TestException(1)))
+             .map(_ => Assertions.fail("An error was expected but the use succeeded"))
+             .recover {
+               case TestException(1) => ()
+               case ex: Throwable => Assertions.fail(s"TestException(1) was expected but got ${ex.toString}")
+             }
+      _ <- ReleasableResource
+             .fromAutoCloseable[Future, TestResource](Future(throwResource))
+             .use[Unit](_ => throw TestException(2)) // scalafix:ok DisableSyntax.throw
+             .map(_ => Assertions.fail("An error was expected but the use succeeded"))
+             .recover {
+               case TestException(2) => ()
+               case ex: Throwable => Assertions.fail(s"TestException(2) was expected but got ${ex.toString}")
+             }
+    } yield {
+      Assertions.assertEquals(successResource.content, Vector("written"), "content written during use")
+      Assertions.assertEquals(
+        successResource.closeStatus,
+        TestableResource.CloseStatus.closed,
+        "close() should be called when the use function succeeds",
+      )
+      Assertions.assertEquals(
+        failureResource.closeStatus,
+        TestableResource.CloseStatus.closed,
+        "close() should be called when the use function returns a failed Future",
+      )
+      Assertions.assertEquals(
+        throwResource.closeStatus,
+        TestableResource.CloseStatus.closed,
+        "close() should be called when the use function throws synchronously",
+      )
+    }
+  }
 
   test("test ReleasableResource[Future] ExitCase: Completed on success, Errored on use failure") {
     var exitCases = Vector.empty[String] // scalafix:ok DisableSyntax.var

--- a/modules/effectie-cats/jvm/src/test/scala/effectie/resource/ReleasableResourceFutureSpec.scala
+++ b/modules/effectie-cats/jvm/src/test/scala/effectie/resource/ReleasableResourceFutureSpec.scala
@@ -1,7 +1,7 @@
 package effectie.resource
 
 import effectie.resource.data.TestErrors.TestException
-import effectie.resource.data.{TestResourceNoAutoClose, TestableResource}
+import effectie.resource.data.{TestResource, TestResourceNoAutoClose, TestableResource}
 import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
 import hedgehog._
@@ -38,6 +38,10 @@ object ReleasableResourceFutureSpec extends Properties {
     example(
       "test ReleasableResource[Future] flatMap chain: acquisition order and LIFO release with ExitCase.Completed",
       testFlatMapChainLifoRelease,
+    ),
+    example(
+      "test ReleasableResource.fromAutoCloseable[Future, A]: close() is called on success and on failure",
+      testFromAutoCloseableClosesTheResource,
     ),
   )
 
@@ -205,6 +209,75 @@ object ReleasableResourceFutureSpec extends Properties {
           )
         )
     }
+  }
+
+  def testFromAutoCloseableClosesTheResource: Result = {
+    import effectie.instances.future.fxCtor._
+
+    implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+    val waitFor                                   = WaitFor(400.milliseconds)
+    implicit val executorService: ExecutorService = Executors.newFixedThreadPool(3)
+    implicit val ec: ExecutionContext             =
+      ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+    val successResource = TestResource()
+    val failureResource = TestResource()
+    val throwResource   = TestResource()
+
+    val beforeUse = Result.all(
+      List(
+        (successResource.closeStatus ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should not be closed before use"),
+        (failureResource.closeStatus ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should not be closed before use"),
+      )
+    )
+
+    val results =
+      ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(
+        for {
+          successResult <- ReleasableResource
+                             .fromAutoCloseable[Future, TestResource](Future(successResource))
+                             .use(resource => Future(resource.write("written")))
+                             .map(_ => Result.success)
+          failureResult <- ReleasableResource
+                             .fromAutoCloseable[Future, TestResource](Future(failureResource))
+                             .use(_ => Future.failed[Unit](TestException(1)))
+                             .map(_ => Result.failure.log("An error was expected but the use succeeded"))
+                             .recover {
+                               case TestException(1) => Result.success
+                               case ex: Throwable =>
+                                 Result.failure.log(s"TestException(1) was expected but got ${ex.toString}")
+                             }
+          throwResult   <- ReleasableResource
+                             .fromAutoCloseable[Future, TestResource](Future(throwResource))
+                             .use[Unit](_ => throw TestException(2)) // scalafix:ok DisableSyntax.throw
+                             .map(_ => Result.failure.log("An error was expected but the use succeeded"))
+                             .recover {
+                               case TestException(2) => Result.success
+                               case ex: Throwable =>
+                                 Result.failure.log(s"TestException(2) was expected but got ${ex.toString}")
+                             }
+        } yield Result.all(List(successResult, failureResult, throwResult))
+      )
+
+    Result.all(
+      List(
+        beforeUse,
+        results,
+        (successResource.content ==== Vector("written")).log("content written during use"),
+        (successResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function succeeds"),
+        (failureResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function returns a failed Future"),
+        (throwResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function throws synchronously"),
+      )
+    )
   }
 
   def testFlatMapChainLifoRelease: Result = {

--- a/modules/effectie-cats/native/src/test/scala/effectie/resource/ReleasableResourceFutureSpec.scala
+++ b/modules/effectie-cats/native/src/test/scala/effectie/resource/ReleasableResourceFutureSpec.scala
@@ -1,7 +1,7 @@
 package effectie.resource
 
 import effectie.resource.data.TestErrors.TestException
-import effectie.resource.data.{TestResourceNoAutoClose, TestableResource}
+import effectie.resource.data.{TestResource, TestResourceNoAutoClose, TestableResource}
 import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
 import hedgehog._
@@ -38,6 +38,10 @@ object ReleasableResourceFutureSpec extends Properties {
     example(
       "test ReleasableResource[Future] flatMap chain: acquisition order and LIFO release with ExitCase.Completed",
       testFlatMapChainLifoRelease,
+    ),
+    example(
+      "test ReleasableResource.fromAutoCloseable[Future, A]: close() is called on success and on failure",
+      testFromAutoCloseableClosesTheResource,
     ),
   )
 
@@ -205,6 +209,75 @@ object ReleasableResourceFutureSpec extends Properties {
           )
         )
     }
+  }
+
+  def testFromAutoCloseableClosesTheResource: Result = {
+    import effectie.instances.future.fxCtor._
+
+    implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
+
+    val waitFor                                   = WaitFor(400.milliseconds)
+    implicit val executorService: ExecutorService = Executors.newFixedThreadPool(3)
+    implicit val ec: ExecutionContext             =
+      ConcurrentSupport.newExecutionContext(executorService, ErrorLogger.printlnExecutionContextErrorLogger)
+
+    val successResource = TestResource()
+    val failureResource = TestResource()
+    val throwResource   = TestResource()
+
+    val beforeUse = Result.all(
+      List(
+        (successResource.closeStatus ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should not be closed before use"),
+        (failureResource.closeStatus ==== TestableResource.CloseStatus.notClosed)
+          .log("the resource should not be closed before use"),
+      )
+    )
+
+    val results =
+      ConcurrentSupport.futureToValueAndTerminate(
+        executorService,
+        waitFor,
+      )(
+        for {
+          successResult <- ReleasableResource
+                             .fromAutoCloseable[Future, TestResource](Future(successResource))
+                             .use(resource => Future(resource.write("written")))
+                             .map(_ => Result.success)
+          failureResult <- ReleasableResource
+                             .fromAutoCloseable[Future, TestResource](Future(failureResource))
+                             .use(_ => Future.failed[Unit](TestException(1)))
+                             .map(_ => Result.failure.log("An error was expected but the use succeeded"))
+                             .recover {
+                               case TestException(1) => Result.success
+                               case ex: Throwable =>
+                                 Result.failure.log(s"TestException(1) was expected but got ${ex.toString}")
+                             }
+          throwResult   <- ReleasableResource
+                             .fromAutoCloseable[Future, TestResource](Future(throwResource))
+                             .use[Unit](_ => throw TestException(2)) // scalafix:ok DisableSyntax.throw
+                             .map(_ => Result.failure.log("An error was expected but the use succeeded"))
+                             .recover {
+                               case TestException(2) => Result.success
+                               case ex: Throwable =>
+                                 Result.failure.log(s"TestException(2) was expected but got ${ex.toString}")
+                             }
+        } yield Result.all(List(successResult, failureResult, throwResult))
+      )
+
+    Result.all(
+      List(
+        beforeUse,
+        results,
+        (successResource.content ==== Vector("written")).log("content written during use"),
+        (successResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function succeeds"),
+        (failureResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function returns a failed Future"),
+        (throwResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function throws synchronously"),
+      )
+    )
   }
 
   def testFlatMapChainLifoRelease: Result = {

--- a/modules/effectie-cats/shared/src/test/scala/effectie/resource/UseResourceTryInterpreterSpec.scala
+++ b/modules/effectie-cats/shared/src/test/scala/effectie/resource/UseResourceTryInterpreterSpec.scala
@@ -98,6 +98,10 @@ object UseResourceTryInterpreterSpec extends Properties {
       "test ReleasableResource.ExitCase smart constructors",
       testExitCaseSmartConstructors,
     ),
+    example(
+      "test ReleasableResource.fromAutoCloseable[Try, A]: close() is called when the use function fails or throws",
+      testFromAutoCloseableClosesOnUseFailure,
+    ),
     property(
       "test deprecated ReleasableResource Try shims: usingResource / usingResourceFromTry / makeTry / pureTry",
       testDeprecatedTryShims,
@@ -712,6 +716,39 @@ object UseResourceTryInterpreterSpec extends Properties {
     )
   }
 
+  def testFromAutoCloseableClosesOnUseFailure: Result = {
+    import effectie.instances.tries.fxCtor._
+
+    val failedResource = TestResource()
+
+    val beforeUse = (failedResource.closeStatus ==== TestableResource.CloseStatus.notClosed)
+      .log("the resource should not be closed before use")
+
+    val failedResult =
+      ReleasableResource
+        .fromAutoCloseable[Try, TestResource](Try(failedResource))
+        .use(_ => Failure[Unit](TestException(1)))
+
+    val thrownResource = TestResource()
+
+    val thrownResult =
+      ReleasableResource
+        .fromAutoCloseable[Try, TestResource](Try(thrownResource))
+        .use[Unit](_ => throw TestException(2)) // scalafix:ok DisableSyntax.throw
+
+    Result.all(
+      List(
+        beforeUse,
+        (failedResult ==== Failure(TestException(1))).log("the use error should propagate"),
+        (failedResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function returns a Failure"),
+        (thrownResult ==== Failure(TestException(2))).log("the thrown error should propagate"),
+        (thrownResource.closeStatus ==== TestableResource.CloseStatus.closed)
+          .log("close() should be called when the use function throws synchronously"),
+      )
+    )
+  }
+
   @nowarn("cat=deprecation")
   def testDeprecatedTryShims: Property =
     for {
@@ -721,11 +758,14 @@ object UseResourceTryInterpreterSpec extends Properties {
                    .map(_.toVector)
                    .log("content")
     } yield {
-      var acquireCount = 0 // scalafix:ok DisableSyntax.var
+      var acquireCount                                = 0 // scalafix:ok DisableSyntax.var
+      var usingResourceInstance: Option[TestResource] = None // scalafix:ok DisableSyntax.var
 
       val usingResourceResource = ReleasableResource.usingResource {
         acquireCount += 1
-        TestResource()
+        val acquired = TestResource()
+        usingResourceInstance = Some(acquired)
+        acquired
       }
 
       val usingResourceBeforeUse = (acquireCount ==== 0).log("usingResource should not acquire at construction")
@@ -749,6 +789,9 @@ object UseResourceTryInterpreterSpec extends Properties {
           usingResourceBeforeUse,
           (usingResourceResult ==== Success(())).log("usingResource use result"),
           (acquireCount ==== 1).log("usingResource should acquire once on use"),
+          (usingResourceInstance.map(_.content) ==== Some(content)).log("usingResource content"),
+          (usingResourceInstance.map(_.closeStatus) ==== Some(TestableResource.CloseStatus.closed))
+            .log("usingResource should close the acquired resource"),
           (fromTryResult ==== Success(())).log("usingResourceFromTry use result"),
           (fromTryResource.content ==== content).log("usingResourceFromTry content"),
           (fromTryResource.closeStatus ==== TestableResource.CloseStatus.closed)


### PR DESCRIPTION
# Verify resources are actually closed across `Try`, `Future` and cats-effect

The resource specs asserted release through event logs and counters, but `close()` on a real `AutoCloseable` was only checked via the shared `ReleasableResourceSpec` helper, which `Try` does not go through and which the `UseResource` specs bypass entirely. That left the question "does the resource actually get closed?" unverified for the interpreter and for the `cats.effect.Resource` interop, which is exactly the property these types exist to guarantee.

All new tests use the real `TestResource` (an `AutoCloseable`) and assert `NotClosed` before use, so none of them can pass vacuously.

- `Try`: `fromAutoCloseable` closes when the use function returns a `Failure` and when it throws synchronously. Also capture the instance that `usingResource` acquires inside its by-name block, which previously could not be asserted on at all, and check its content and closeStatus.

- `Future`: `fromAutoCloseable` closes on success, on a failed `Future` and on a synchronous throw, on the JVM, Scala.js and Scala Native.

- cats-effect 3: `fromAutoCloseable` closes on success, on raiseError and on cancellation, the last one deterministically via `IO.canceled`. `Ce3UseResource` interop is covered in both directions with a real `AutoCloseable`, so `toCatsEffectResource` is driven by cats-effect's own `Resource.use` and `fromCatsEffectResource` wraps `Resource.fromAutoCloseable`.

- cats-effect 2: the same, minus cancellation, since there is no deterministic equivalent of `IO.canceled` and a `fiber.cancel` handshake would be timing dependent.

The use function now returns the resource's closeStatus rather than `Unit`, so each test also asserts the resource is still open while use runs. The previous `Unit` comparison was vacuous and did not compile on Scala 2.12, where `==== ()` parses as an empty argument list.

No production code is changed.