### PR TITLE
effectie v2.5.0

### DIFF
--- a/changelogs/2.5.0.md
+++ b/changelogs/2.5.0.md
@@ -1,0 +1,47 @@
+## [2.5.0](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m7) - 2026-08-04
+
+## New Features
+
+### Redesign `ReleasableResource` as a pure description ADT with the `UseResource` interpreter (#705)
+
+`ReleasableResource[F[*], +A]` is now a `sealed`, covariant, constraint-free data type describing acquisition and release. It follows effectie's own `Fx` pattern: one shared contract with per-effect-system instances, so the same code behaves identically for `Try`, `Future`, cats-effect 2/3 `IO`, and Monix `Task`.
+
+- **Constructors** (no typeclass needed): `ReleasableResource.pure` / `eval` / `make` / `makeCase` / `fromAutoCloseable` (requires `FxCtor[F]`) / `raiseError` / `unit`
+- **Combinators**: `map`, `flatMap`, `evalMap`, `evalTap`, `flatTap`, `onFinalize`, `onFinalizeCase`, `attempt`, `handleErrorWith`, `surround`, `use_`
+- **`ReleasableResource.ExitCase`** (`Completed` / `Errored` / `Canceled`): release actions registered with `makeCase` / `onFinalizeCase` observe how the scope ended. `Canceled` only occurs for cancellable effect systems (cats-effect, Monix).
+- **Constraint-free `MonadError[ReleasableResource[F, *], Throwable]`** in the companion object — no `ResourceMaker` required, with a stack-safe `tailRecM` (replaces the previous `ResourceMaker`-gated `Applicative` instance).
+
+### New `UseResource[F]` typeclass — the capability of running a `ReleasableResource`
+
+Running `.use(...)` now requires an implicit `effectie.resource.UseResource[F]`:
+
+- `Try` / `Future`: provided automatically (companion object instances; `Future` needs an implicit `ExecutionContext`)
+- cats-effect 3: `import effectie.instances.ce3.resource._` (`IO`) or `import effectie.instances.ce3.f.resource._` (any `F[_]: MonadCancelThrow`)
+- cats-effect 2: `import effectie.instances.ce2.resource._` (`IO`) or `import effectie.instances.ce2.f.resource._` (any `F[_]: BracketThrow`)
+- Monix 3: `import effectie.instances.monix3.resource._` (`Task`)
+- Scala 3: use `.given` instead of `._` (e.g. `import effectie.instances.ce3.resource.given`), or import the instance by name (e.g. `ioUseResource`, `taskUseResource`) which works in both Scala 2 and Scala 3
+
+The cats-effect and Monix instances interpret the description through a real `cats.effect.Resource`, so bracketing and cancellation safety are exactly cats-effect's. There is deliberately no generic fallback instance, so cancellable effect types can never silently lose cancellation safety.
+
+### cats-effect interop
+
+- `Ce3UseResource.toCatsEffectResource` / `Ce3UseResource.fromCatsEffectResource` — two-way conversion with `cats.effect.Resource` (cats-effect 3)
+- `Ce2UseResource.toCatsEffectResource` / `Ce2UseResource.fromCatsEffectResource` — the same for cats-effect 2 (note: CE2's `allocated` exposes no exit case, so a wrapped foreign finalizer cannot observe it)
+
+## Behavior Fixes
+
+- **Lazy acquisition**: constructing a `ReleasableResource` no longer performs any effects for `Try` / `Future` (previously the resource was acquired eagerly at construction, leaking when never used). Acquisition now happens on each `use`, and a second `use` acquires a fresh resource instead of reusing a closed one.
+- **Release errors are no longer swallowed**: previously `Try` discarded them silently and `Future` printed to stdout. Now, when `use` succeeded but release fails, the release error is raised; when both fail, the `use` error is raised with the release error attached via `addSuppressed` (cats-effect parity).
+- **`Future` resource leak fixed**: a synchronous throw inside the `use` function now still releases the resource.
+- **`ResourceMaker[F].eval` for cats-effect** now maps to `Resource.eval` semantics (previously it created an uncancelable no-op-release acquisition).
+
+## Deprecations
+
+`ResourceMaker` and its instances (`ResourceMaker.tryResourceMaker`, `ResourceMaker.futureResourceMaker`, `Ce2ResourceMaker.maker`, `Ce3ResourceMaker.maker`), the old `ReleasableResource` companion constructors (`usingResource`, `usingResourceFromTry`, `futureResource`, `makeTry`, `pureTry`, `makeFuture`, `pureFuture`), and the `Ce2Resource` / `Ce3Resource` constructor objects are deprecated but keep working as thin shims over the new API. Each deprecation message contains the exact replacement and the `UseResource` import to add.
+
+## Breaking Changes
+
+- `ReleasableResource` is now `sealed`; the public traits `Ce2Resource` and `Ce3Resource` are removed (their companion `object`s remain as deprecated constructors).
+- `.use(...)` requires an implicit `UseResource[F]`: `Try` / `Future` users need no change; cats-effect / Monix users add one import (a descriptive `implicitNotFound` message shows exactly which).
+- The `Applicative[ReleasableResource[F, *]]` instance requiring `ResourceMaker[F]` is replaced by the constraint-free `MonadError` instance.
+- `Try` / `Future` resource semantics intentionally changed as listed under Behavior Fixes.


### PR DESCRIPTION
# effectie v2.5.0
## [2.5.0](https://github.com/kevin-lee/effectie/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m7) - 2026-08-04

## New Features

### Redesign `ReleasableResource` as a pure description ADT with the `UseResource` interpreter (#705)

`ReleasableResource[F[*], +A]` is now a `sealed`, covariant, constraint-free data type describing acquisition and release. It follows effectie's own `Fx` pattern: one shared contract with per-effect-system instances, so the same code behaves identically for `Try`, `Future`, cats-effect 2/3 `IO`, and Monix `Task`.

- **Constructors** (no typeclass needed): `ReleasableResource.pure` / `eval` / `make` / `makeCase` / `fromAutoCloseable` (requires `FxCtor[F]`) / `raiseError` / `unit`
- **Combinators**: `map`, `flatMap`, `evalMap`, `evalTap`, `flatTap`, `onFinalize`, `onFinalizeCase`, `attempt`, `handleErrorWith`, `surround`, `use_`
- **`ReleasableResource.ExitCase`** (`Completed` / `Errored` / `Canceled`): release actions registered with `makeCase` / `onFinalizeCase` observe how the scope ended. `Canceled` only occurs for cancellable effect systems (cats-effect, Monix).
- **Constraint-free `MonadError[ReleasableResource[F, *], Throwable]`** in the companion object — no `ResourceMaker` required, with a stack-safe `tailRecM` (replaces the previous `ResourceMaker`-gated `Applicative` instance).

### New `UseResource[F]` typeclass — the capability of running a `ReleasableResource`

Running `.use(...)` now requires an implicit `effectie.resource.UseResource[F]`:

- `Try` / `Future`: provided automatically (companion object instances; `Future` needs an implicit `ExecutionContext`)
- cats-effect 3: `import effectie.instances.ce3.resource._` (`IO`) or `import effectie.instances.ce3.f.resource._` (any `F[_]: MonadCancelThrow`)
- cats-effect 2: `import effectie.instances.ce2.resource._` (`IO`) or `import effectie.instances.ce2.f.resource._` (any `F[_]: BracketThrow`)
- Monix 3: `import effectie.instances.monix3.resource._` (`Task`)
- Scala 3: use `.given` instead of `._` (e.g. `import effectie.instances.ce3.resource.given`), or import the instance by name (e.g. `ioUseResource`, `taskUseResource`) which works in both Scala 2 and Scala 3

The cats-effect and Monix instances interpret the description through a real `cats.effect.Resource`, so bracketing and cancellation safety are exactly cats-effect's. There is deliberately no generic fallback instance, so cancellable effect types can never silently lose cancellation safety.

### cats-effect interop

- `Ce3UseResource.toCatsEffectResource` / `Ce3UseResource.fromCatsEffectResource` — two-way conversion with `cats.effect.Resource` (cats-effect 3)
- `Ce2UseResource.toCatsEffectResource` / `Ce2UseResource.fromCatsEffectResource` — the same for cats-effect 2 (note: CE2's `allocated` exposes no exit case, so a wrapped foreign finalizer cannot observe it)

## Behavior Fixes

- **Lazy acquisition**: constructing a `ReleasableResource` no longer performs any effects for `Try` / `Future` (previously the resource was acquired eagerly at construction, leaking when never used). Acquisition now happens on each `use`, and a second `use` acquires a fresh resource instead of reusing a closed one.
- **Release errors are no longer swallowed**: previously `Try` discarded them silently and `Future` printed to stdout. Now, when `use` succeeded but release fails, the release error is raised; when both fail, the `use` error is raised with the release error attached via `addSuppressed` (cats-effect parity).
- **`Future` resource leak fixed**: a synchronous throw inside the `use` function now still releases the resource.
- **`ResourceMaker[F].eval` for cats-effect** now maps to `Resource.eval` semantics (previously it created an uncancelable no-op-release acquisition).

## Deprecations

`ResourceMaker` and its instances (`ResourceMaker.tryResourceMaker`, `ResourceMaker.futureResourceMaker`, `Ce2ResourceMaker.maker`, `Ce3ResourceMaker.maker`), the old `ReleasableResource` companion constructors (`usingResource`, `usingResourceFromTry`, `futureResource`, `makeTry`, `pureTry`, `makeFuture`, `pureFuture`), and the `Ce2Resource` / `Ce3Resource` constructor objects are deprecated but keep working as thin shims over the new API. Each deprecation message contains the exact replacement and the `UseResource` import to add.

## Breaking Changes

- `ReleasableResource` is now `sealed`; the public traits `Ce2Resource` and `Ce3Resource` are removed (their companion `object`s remain as deprecated constructors).
- `.use(...)` requires an implicit `UseResource[F]`: `Try` / `Future` users need no change; cats-effect / Monix users add one import (a descriptive `implicitNotFound` message shows exactly which).
- The `Applicative[ReleasableResource[F, *]]` instance requiring `ResourceMaker[F]` is replaced by the constraint-free `MonadError` instance.
- `Try` / `Future` resource semantics intentionally changed as listed under Behavior Fixes.
